### PR TITLE
Simplify the first-run computer choice copy

### DIFF
--- a/apps/web/e2e/host-computer-prompt.spec.ts
+++ b/apps/web/e2e/host-computer-prompt.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+for (const platform of ["darwin", "win32"]) {
+  test(`host computer choice explains file access on ${platform}`, async ({ page }, testInfo) => {
+    await signup(
+      page,
+      `host-choice-${platform}-${Date.now()}@rakazo.test`,
+      "password12",
+      "Host Tester",
+    );
+    await completeOnboarding(page);
+    await page.addInitScript((platform) => {
+      Object.defineProperty(window, "rakazoDesktop", {
+        value: {
+          platform,
+          window: {
+            close: async () => {},
+            minimize: async () => {},
+            toggleMaximize: async () => {},
+            state: async () => ({ minimized: false, maximized: false, fullScreen: false }),
+          },
+          oauth: { onCallback: () => () => {} },
+          update: {
+            state: async () => ({ phase: "idle", currentVersion: "0.1.0" }),
+          },
+        },
+      });
+    }, platform);
+    await page.route(/\/rpc\/(me|bootstrap)$/, async (route) => {
+      const response = await route.fetch();
+      const body = await response.json();
+      const me = route.request().url().endsWith("/me") ? body.json : body.json.me;
+      me.canChooseHostComputer = true;
+      me.computerHost = null;
+      await route.fulfill({ response, json: body });
+    });
+    await page.reload();
+    const dialog = page.getByRole("dialog", { name: "Where should bots run?" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Docker gives bots a separate workspace.")).toBeVisible();
+    const host = platform === "darwin" ? "this Mac" : "this computer";
+    await expect(
+      dialog.getByText(
+        `On ${host}, bots can access your files and run commands without asking. Avoid this on shared or public servers.`,
+      ),
+    ).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Docker (recommended)" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: `Use ${host}` })).toBeVisible();
+    await captureScreenshot(page, testInfo, `host-computer-choice-${platform}`);
+  });
+}

--- a/apps/web/scripts/translations-de.json
+++ b/apps/web/scripts/translations-de.json
@@ -579,5 +579,7 @@
   "Message from": "Nachricht von",
   "This chat is view-only": "Dieser Chat ist schreibgeschützt",
   "Could not load this chat.": "Dieser Chat konnte nicht geladen werden.",
-  "No messages with {peerBotName} yet.": "Noch keine Nachrichten mit {peerBotName}."
+  "No messages with {peerBotName} yet.": "Noch keine Nachrichten mit {peerBotName}.",
+  "Docker gives bots a separate workspace.": "Docker gibt Bots einen separaten Arbeitsbereich.",
+  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "Wenn {hostLabel} verwendet wird, können Bots ohne Rückfrage auf deine Dateien zugreifen und Befehle ausführen. Vermeide dies auf gemeinsam genutzten oder öffentlichen Servern."
 }

--- a/apps/web/scripts/translations-es.json
+++ b/apps/web/scripts/translations-es.json
@@ -722,5 +722,7 @@
   "Apps": "Apps",
   "Asleep": "En reposo",
   "at <0/>": "a las <0/>",
-  "Authorization expired — reconnect required": "Autorización expirada: se requiere reconectar"
+  "Authorization expired — reconnect required": "Autorización expirada: se requiere reconectar",
+  "Docker gives bots a separate workspace.": "Docker les da a los bots un espacio de trabajo separado.",
+  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "En {hostLabel}, los bots pueden acceder a tus archivos y ejecutar comandos sin preguntar. Evita esta opción en servidores compartidos o públicos."
 }

--- a/apps/web/scripts/translations-hi.json
+++ b/apps/web/scripts/translations-hi.json
@@ -582,5 +582,7 @@
   "Message from": "संदेश भेजने वाला",
   "This chat is view-only": "यह चैट केवल देखने के लिए है",
   "Could not load this chat.": "यह चैट लोड नहीं हो सकी.",
-  "No messages with {peerBotName} yet.": "{peerBotName} के साथ अभी कोई संदेश नहीं."
+  "No messages with {peerBotName} yet.": "{peerBotName} के साथ अभी कोई संदेश नहीं.",
+  "Docker gives bots a separate workspace.": "Docker बॉट्स को अलग कार्यक्षेत्र देता है।",
+  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "{hostLabel} चुनने पर बॉट्स बिना पूछे आपकी फ़ाइलें खोल सकते हैं और कमांड चला सकते हैं। साझा या सार्वजनिक सर्वर पर इस विकल्प से बचें।"
 }

--- a/apps/web/scripts/translations-ko.json
+++ b/apps/web/scripts/translations-ko.json
@@ -579,5 +579,7 @@
   "Message from": "메시지 보낸 봇",
   "This chat is view-only": "이 채팅은 읽기 전용입니다",
   "Could not load this chat.": "이 채팅을 불러오지 못했습니다.",
-  "No messages with {peerBotName} yet.": "{peerBotName}와의 메시지가 아직 없습니다."
+  "No messages with {peerBotName} yet.": "{peerBotName}와의 메시지가 아직 없습니다.",
+  "Docker gives bots a separate workspace.": "Docker는 Bot에게 별도의 작업 공간을 제공합니다.",
+  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "{hostLabel}에서는 Bot이 묻지 않고 파일에 접근하고 명령을 실행할 수 있습니다. 공유 서버나 공개 서버에서는 이 옵션을 사용하지 마세요."
 }

--- a/apps/web/scripts/translations-pt-BR.json
+++ b/apps/web/scripts/translations-pt-BR.json
@@ -581,5 +581,7 @@
   "Message from": "Mensagem de",
   "This chat is view-only": "Este chat é somente leitura",
   "Could not load this chat.": "Não foi possível carregar este chat.",
-  "No messages with {peerBotName} yet.": "Ainda sem mensagens com {peerBotName}."
+  "No messages with {peerBotName} yet.": "Ainda sem mensagens com {peerBotName}.",
+  "Docker gives bots a separate workspace.": "O Docker dá aos bots um espaço de trabalho separado.",
+  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "Ao usar {hostLabel}, os bots podem acessar seus arquivos e executar comandos sem perguntar. Evite esta opção em servidores compartilhados ou públicos."
 }

--- a/apps/web/scripts/translations-tr.json
+++ b/apps/web/scripts/translations-tr.json
@@ -576,5 +576,7 @@
   "Message from": "Mesaj gönderen",
   "This chat is view-only": "Bu sohbet yalnızca görüntülenebilir",
   "Could not load this chat.": "Bu sohbet yüklenemedi.",
-  "No messages with {peerBotName} yet.": "{peerBotName} ile henüz mesaj yok."
+  "No messages with {peerBotName} yet.": "{peerBotName} ile henüz mesaj yok.",
+  "Docker gives bots a separate workspace.": "Docker, botlara ayrı bir çalışma alanı sağlar.",
+  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "{hostLabel} kullanıldığında botlar sormadan dosyalarına erişebilir ve komut çalıştırabilir. Paylaşılan veya herkese açık sunucularda bu seçeneği kullanma."
 }

--- a/apps/web/scripts/translations-zh-CN.json
+++ b/apps/web/scripts/translations-zh-CN.json
@@ -728,5 +728,7 @@
   "Waiting for the API to come back…": "正在等待 API 恢复…",
   "Webhook": "Webhook",
   "What should this routine do each time it runs?": "每次运行时，这个例行任务应做什么？",
-  "When a webhook fires": "当 Webhook 触发时"
+  "When a webhook fires": "当 Webhook 触发时",
+  "Docker gives bots a separate workspace.": "Docker 为 Bot 提供独立的工作空间。",
+  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "使用{hostLabel}时，Bot 可以直接访问你的文件并执行命令，无需询问。请勿在共享或公开服务器上使用此选项。"
 }

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3315,8 +3315,8 @@ msgstr "Executor-Token"
 
 #: src/pages/HostComputerPrompt.tsx:62
 msgid "Docker gives bots a separate workspace."
-msgstr ""
+msgstr "Docker gibt Bots einen separaten Arbeitsbereich."
 
 #: src/pages/HostComputerPrompt.tsx:80
 msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr ""
+msgstr "Wenn {hostLabel} verwendet wird, können Bots ohne Rückfrage auf deine Dateien zugreifen und Befehle ausführen. Vermeide dies auf gemeinsam genutzten oder öffentlichen Servern."

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -1391,13 +1391,9 @@ msgstr "Anzeigename"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "Gib keine Passwörter in die Demo ein. Verwende „Kontrolle übernehmen“ für Zugangsdaten."
 
-#: src/pages/HostComputerPrompt.tsx:79
+#: src/pages/HostComputerPrompt.tsx:68
 msgid "Docker (recommended)"
 msgstr "Docker (empfohlen)"
-
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker is the default: bots use a shared Team Computer."
-msgstr "Docker ist der Standard: Bots verwenden einen gemeinsamen Team-Computer."
 
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
@@ -1812,10 +1808,6 @@ msgstr "Abmelden"
 #: src/pages/shell/bot-panel.tsx:492
 msgid "Low"
 msgstr "Niedrig"
-
-#: src/pages/HostComputerPrompt.tsx:64
-msgid "macOS will not ask for extra permission if you let bots run on this Mac. They run as you."
-msgstr "Auf diesem Mac fragt macOS nicht nach zusätzlichen Berechtigungen, wenn Bots dort ausgeführt werden. Sie handeln mit deinen Rechten."
 
 #: src/pages/AccountSettingsOverlay.tsx:143
 msgid "Manage messaging settings"
@@ -2953,10 +2945,6 @@ msgstr "Dieser Chat ist schreibgeschützt"
 msgid "this computer"
 msgstr "dieser Computer"
 
-#: src/pages/HostComputerPrompt.tsx:97
-msgid "This computer runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "Dieser Computer führt Shell-Befehle mit deinem Konto aus und kann auf Dateien in deinem persönlichen Ordner zugreifen. Aktiviere dies nicht auf einem gemeinsam genutzten oder öffentlichen Server."
-
 #: src/components/ArtifactFileCard.tsx:133
 msgid "This file is not valid UTF-8 Markdown."
 msgstr "Diese Datei ist kein gültiges UTF-8-Markdown."
@@ -2964,10 +2952,6 @@ msgstr "Diese Datei ist kein gültiges UTF-8-Markdown."
 #: src/pages/HostComputerPrompt.tsx:22
 msgid "this Mac"
 msgstr "dieser Mac"
-
-#: src/pages/HostComputerPrompt.tsx:92
-msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "Dieser Mac führt Shell-Befehle mit deinem Konto aus und kann auf Dateien in deinem persönlichen Ordner zugreifen. Aktiviere dies nicht auf einem gemeinsam genutzten oder öffentlichen Server."
 
 #: src/pages/shell/dialogs.tsx:185
 msgid "This permanently removes every message and stops current work. The chat remains available."
@@ -3092,7 +3076,7 @@ msgstr ""
 msgid "Usage"
 msgstr "Nutzung"
 
-#: src/pages/HostComputerPrompt.tsx:87
+#: src/pages/HostComputerPrompt.tsx:76
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} verwenden"
 
@@ -3218,10 +3202,6 @@ msgstr "Sicher gespeichert. Hier nie angezeigt."
 msgid "Your name"
 msgstr "Dein Name"
 
-#: src/pages/HostComputerPrompt.tsx:69
-msgid "Your OS will not ask for extra permission if you let bots run on {hostLabel}. They run as you."
-msgstr "Auf {hostLabel} fragt dein Betriebssystem nicht nach zusätzlichen Berechtigungen, wenn Bots dort ausgeführt werden. Sie handeln mit deinen Rechten."
-
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Dein Team aus jederzeit verfügbaren Agents<0/>für echte Aufgaben."
@@ -3333,3 +3313,10 @@ msgstr "Executor verbinden"
 msgid "Executor token"
 msgstr "Executor-Token"
 
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker gives bots a separate workspace."
+msgstr ""
+
+#: src/pages/HostComputerPrompt.tsx:80
+msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
+msgstr ""

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -1391,13 +1391,9 @@ msgstr "Display name"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "Do not type passwords into the demo. Use Take control for credentials."
 
-#: src/pages/HostComputerPrompt.tsx:79
+#: src/pages/HostComputerPrompt.tsx:68
 msgid "Docker (recommended)"
 msgstr "Docker (recommended)"
-
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker is the default: bots use a shared Team Computer."
-msgstr "Docker is the default: bots use a shared Team Computer."
 
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
@@ -1812,10 +1808,6 @@ msgstr "Log out"
 #: src/pages/shell/bot-panel.tsx:492
 msgid "Low"
 msgstr "Low"
-
-#: src/pages/HostComputerPrompt.tsx:64
-msgid "macOS will not ask for extra permission if you let bots run on this Mac. They run as you."
-msgstr "macOS will not ask for extra permission if you let bots run on this Mac. They run as you."
 
 #: src/pages/AccountSettingsOverlay.tsx:143
 msgid "Manage messaging settings"
@@ -2953,10 +2945,6 @@ msgstr "This chat is view-only"
 msgid "this computer"
 msgstr "this computer"
 
-#: src/pages/HostComputerPrompt.tsx:97
-msgid "This computer runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "This computer runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-
 #: src/components/ArtifactFileCard.tsx:133
 msgid "This file is not valid UTF-8 Markdown."
 msgstr "This file is not valid UTF-8 Markdown."
@@ -2964,10 +2952,6 @@ msgstr "This file is not valid UTF-8 Markdown."
 #: src/pages/HostComputerPrompt.tsx:22
 msgid "this Mac"
 msgstr "this Mac"
-
-#: src/pages/HostComputerPrompt.tsx:92
-msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 
 #: src/pages/shell/dialogs.tsx:185
 msgid "This permanently removes every message and stops current work. The chat remains available."
@@ -3092,7 +3076,7 @@ msgstr "Updating…"
 msgid "Usage"
 msgstr "Usage"
 
-#: src/pages/HostComputerPrompt.tsx:87
+#: src/pages/HostComputerPrompt.tsx:76
 msgid "Use {hostLabel}"
 msgstr "Use {hostLabel}"
 
@@ -3218,10 +3202,6 @@ msgstr "Stored securely. Never shown here."
 msgid "Your name"
 msgstr "Your name"
 
-#: src/pages/HostComputerPrompt.tsx:69
-msgid "Your OS will not ask for extra permission if you let bots run on {hostLabel}. They run as you."
-msgstr "Your OS will not ask for extra permission if you let bots run on {hostLabel}. They run as you."
-
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Your team of always-on agents<0/>that you can give real work to."
@@ -3333,3 +3313,10 @@ msgstr "Connect Executor"
 msgid "Executor token"
 msgstr "Executor token"
 
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker gives bots a separate workspace."
+msgstr "Docker gives bots a separate workspace."
+
+#: src/pages/HostComputerPrompt.tsx:80
+msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
+msgstr "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -3275,8 +3275,8 @@ msgstr "Token de Executor"
 
 #: src/pages/HostComputerPrompt.tsx:62
 msgid "Docker gives bots a separate workspace."
-msgstr ""
+msgstr "Docker les da a los bots un espacio de trabajo separado."
 
 #: src/pages/HostComputerPrompt.tsx:80
 msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr ""
+msgstr "En {hostLabel}, los bots pueden acceder a tus archivos y ejecutar comandos sin preguntar. Evita esta opción en servidores compartidos o públicos."

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -1365,13 +1365,9 @@ msgstr "Nombre para mostrar"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "No escribas contraseñas en la demo. Usa Tomar control para las credenciales."
 
-#: src/pages/HostComputerPrompt.tsx:79
+#: src/pages/HostComputerPrompt.tsx:68
 msgid "Docker (recommended)"
 msgstr "Docker (recomendado)"
-
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker is the default: bots use a shared Team Computer."
-msgstr "Docker es el valor predeterminado: los bots usan una Team Computer compartida."
 
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
@@ -1782,10 +1778,6 @@ msgstr "Cerrar sesión"
 #: src/pages/shell/bot-panel.tsx:492
 msgid "Low"
 msgstr "Bajo"
-
-#: src/pages/HostComputerPrompt.tsx:64
-msgid "macOS will not ask for extra permission if you let bots run on this Mac. They run as you."
-msgstr "MacOS no pedirá permisos extra si dejas que los bots se ejecuten en esta Mac: se ejecutan como tú."
 
 #: src/pages/AccountSettingsOverlay.tsx:143
 msgid "Manage messaging settings"
@@ -2921,10 +2913,6 @@ msgstr "Este chat es de solo lectura"
 msgid "this computer"
 msgstr "esta computadora"
 
-#: src/pages/HostComputerPrompt.tsx:97
-msgid "This computer runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "Esta computadora ejecuta comandos de shell con tu cuenta, incluidos archivos de tu carpeta de inicio. No la actives en un servidor compartido o público."
-
 #: src/components/ArtifactFileCard.tsx:133
 msgid "This file is not valid UTF-8 Markdown."
 msgstr "Este archivo no es Markdown UTF-8 válido."
@@ -2932,10 +2920,6 @@ msgstr "Este archivo no es Markdown UTF-8 válido."
 #: src/pages/HostComputerPrompt.tsx:22
 msgid "this Mac"
 msgstr "esta Mac"
-
-#: src/pages/HostComputerPrompt.tsx:92
-msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "Esta Mac ejecuta comandos de shell con tu cuenta, incluidos archivos de tu carpeta de inicio. No la actives en un servidor compartido o público."
 
 #: src/pages/shell/dialogs.tsx:185
 msgid "This permanently removes every message and stops current work. The chat remains available."
@@ -3052,7 +3036,7 @@ msgstr "Actualizando…"
 msgid "Usage"
 msgstr "Uso"
 
-#: src/pages/HostComputerPrompt.tsx:87
+#: src/pages/HostComputerPrompt.tsx:76
 msgid "Use {hostLabel}"
 msgstr "Usar {hostLabel}"
 
@@ -3178,10 +3162,6 @@ msgstr "Almacenado de forma segura. Nunca se muestra aquí."
 msgid "Your name"
 msgstr "Tu nombre"
 
-#: src/pages/HostComputerPrompt.tsx:69
-msgid "Your OS will not ask for extra permission if you let bots run on {hostLabel}. They run as you."
-msgstr "Tu sistema operativo no pedirá permisos extra si dejas que los bots se ejecuten en {hostLabel}: se ejecutan como tú."
-
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Tu equipo de agentes siempre activos<0/>a los que puedes dar trabajo real."
@@ -3293,3 +3273,10 @@ msgstr "Conectar Executor"
 msgid "Executor token"
 msgstr "Token de Executor"
 
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker gives bots a separate workspace."
+msgstr ""
+
+#: src/pages/HostComputerPrompt.tsx:80
+msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
+msgstr ""

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -1391,13 +1391,9 @@ msgstr "प्रदर्शित नाम"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "डेमो में पासवर्ड टाइप न करें। क्रेडेंशियल्स के लिए 'टेक कंट्रोल' (Take control) का इस्तेमाल करें।"
 
-#: src/pages/HostComputerPrompt.tsx:79
+#: src/pages/HostComputerPrompt.tsx:68
 msgid "Docker (recommended)"
 msgstr "Docker (अनुशंसित)"
-
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker is the default: bots use a shared Team Computer."
-msgstr "Docker डिफ़ॉल्ट है: बॉट एक साझा टीम कंप्यूटर का उपयोग करते हैं।"
 
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
@@ -1812,10 +1808,6 @@ msgstr "लॉग आउट"
 #: src/pages/shell/bot-panel.tsx:492
 msgid "Low"
 msgstr "निम्न"
-
-#: src/pages/HostComputerPrompt.tsx:64
-msgid "macOS will not ask for extra permission if you let bots run on this Mac. They run as you."
-msgstr "यदि आप बॉट्स को इस Mac पर चलने देते हैं तो macOS अतिरिक्त अनुमति नहीं मांगेगा। वे आपके रूप में ही चलते हैं।"
 
 #: src/pages/AccountSettingsOverlay.tsx:143
 msgid "Manage messaging settings"
@@ -2953,10 +2945,6 @@ msgstr "यह चैट केवल देखने के लिए है"
 msgid "this computer"
 msgstr "यह कंप्यूटर"
 
-#: src/pages/HostComputerPrompt.tsx:97
-msgid "This computer runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "यह कंप्यूटर आपके खाते से शेल कमांड चलाता है, जिसमें आपके होम फ़ोल्डर की फ़ाइलें भी शामिल हैं। इसे किसी साझा या सार्वजनिक सर्वर पर चालू न करें।"
-
 #: src/components/ArtifactFileCard.tsx:133
 msgid "This file is not valid UTF-8 Markdown."
 msgstr "यह फ़ाइल मान्य UTF-8 Markdown नहीं है।"
@@ -2964,10 +2952,6 @@ msgstr "यह फ़ाइल मान्य UTF-8 Markdown नहीं ह�
 #: src/pages/HostComputerPrompt.tsx:22
 msgid "this Mac"
 msgstr "यह Mac"
-
-#: src/pages/HostComputerPrompt.tsx:92
-msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "यह Mac आपके खाते से शेल कमांड चलाता है, जिसमें आपके होम फ़ोल्डर की फ़ाइलें भी शामिल हैं। इसे किसी साझा या सार्वजनिक सर्वर पर चालू न करें।"
 
 #: src/pages/shell/dialogs.tsx:185
 msgid "This permanently removes every message and stops current work. The chat remains available."
@@ -3092,7 +3076,7 @@ msgstr "अपडेट हो रहा है…"
 msgid "Usage"
 msgstr "उपयोग"
 
-#: src/pages/HostComputerPrompt.tsx:87
+#: src/pages/HostComputerPrompt.tsx:76
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} का उपयोग करें"
 
@@ -3218,10 +3202,6 @@ msgstr "सुरक्षित रूप से संग्रहीत। �
 msgid "Your name"
 msgstr "आपका नाम"
 
-#: src/pages/HostComputerPrompt.tsx:69
-msgid "Your OS will not ask for extra permission if you let bots run on {hostLabel}. They run as you."
-msgstr "यदि आप बॉट्स को {hostLabel} पर चलने देते हैं तो आपका OS अतिरिक्त अनुमति नहीं मांगेगा। वे आपके रूप में ही चलते हैं।"
-
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "हमेशा चालू रहने वाले एजेंटों की आपकी टीम<0/>जिन्हें आप असली काम सौंप सकते हैं।"
@@ -3333,3 +3313,10 @@ msgstr "Executor कनेक्ट करें"
 msgid "Executor token"
 msgstr "Executor टोकन"
 
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker gives bots a separate workspace."
+msgstr ""
+
+#: src/pages/HostComputerPrompt.tsx:80
+msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
+msgstr ""

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3315,8 +3315,8 @@ msgstr "Executor टोकन"
 
 #: src/pages/HostComputerPrompt.tsx:62
 msgid "Docker gives bots a separate workspace."
-msgstr ""
+msgstr "Docker बॉट्स को अलग कार्यक्षेत्र देता है।"
 
 #: src/pages/HostComputerPrompt.tsx:80
 msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr ""
+msgstr "{hostLabel} चुनने पर बॉट्स बिना पूछे आपकी फ़ाइलें खोल सकते हैं और कमांड चला सकते हैं। साझा या सार्वजनिक सर्वर पर इस विकल्प से बचें।"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -1391,13 +1391,9 @@ msgstr "표시 이름"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "시연 중에는 비밀번호를 입력하지 마세요. 인증이 필요하면 직접 조작을 사용하세요."
 
-#: src/pages/HostComputerPrompt.tsx:79
+#: src/pages/HostComputerPrompt.tsx:68
 msgid "Docker (recommended)"
 msgstr "Docker에서 실행(권장)"
-
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker is the default: bots use a shared Team Computer."
-msgstr "기본 설정은 Docker이며, Bot들이 격리된 팀 컴퓨터를 함께 사용합니다."
 
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
@@ -1812,10 +1808,6 @@ msgstr "로그아웃"
 #: src/pages/shell/bot-panel.tsx:492
 msgid "Low"
 msgstr "낮음"
-
-#: src/pages/HostComputerPrompt.tsx:64
-msgid "macOS will not ask for extra permission if you let bots run on this Mac. They run as you."
-msgstr "이 Mac에서 실행하면 Bot이 내 계정 권한으로 동작하며 macOS가 작업마다 별도 승인을 묻지 않습니다."
 
 #: src/pages/AccountSettingsOverlay.tsx:143
 msgid "Manage messaging settings"
@@ -2953,10 +2945,6 @@ msgstr "이 채팅은 읽기 전용입니다"
 msgid "this computer"
 msgstr "이 컴퓨터"
 
-#: src/pages/HostComputerPrompt.tsx:97
-msgid "This computer runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "이 컴퓨터에서는 홈 폴더의 파일을 포함해 내 계정 권한으로 터미널 명령을 실행합니다. 여러 사람이 쓰거나 공개된 서버에서는 사용하지 마세요."
-
 #: src/components/ArtifactFileCard.tsx:133
 msgid "This file is not valid UTF-8 Markdown."
 msgstr "이 파일은 올바른 UTF-8 Markdown 형식이 아닙니다."
@@ -2964,10 +2952,6 @@ msgstr "이 파일은 올바른 UTF-8 Markdown 형식이 아닙니다."
 #: src/pages/HostComputerPrompt.tsx:22
 msgid "this Mac"
 msgstr "이 Mac"
-
-#: src/pages/HostComputerPrompt.tsx:92
-msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "이 Mac에서는 홈 폴더의 파일을 포함해 내 계정 권한으로 터미널 명령을 실행합니다. 여러 사람이 쓰거나 공개된 서버에서는 사용하지 마세요."
 
 #: src/pages/shell/dialogs.tsx:185
 msgid "This permanently removes every message and stops current work. The chat remains available."
@@ -3092,7 +3076,7 @@ msgstr "업데이트 중…"
 msgid "Usage"
 msgstr "사용량"
 
-#: src/pages/HostComputerPrompt.tsx:87
+#: src/pages/HostComputerPrompt.tsx:76
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} 사용"
 
@@ -3218,10 +3202,6 @@ msgstr "안전하게 저장됩니다. 이 화면에 표시되지 않습니다."
 msgid "Your name"
 msgstr "이름"
 
-#: src/pages/HostComputerPrompt.tsx:69
-msgid "Your OS will not ask for extra permission if you let bots run on {hostLabel}. They run as you."
-msgstr "{hostLabel}에서 실행하면 Bot이 내 계정 권한으로 동작하며 운영체제가 작업마다 별도 승인을 묻지 않습니다."
-
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "언제든 실제 작업을 맡길 수 있는<0/>나만의 Agent 팀"
@@ -3333,3 +3313,10 @@ msgstr "Executor 연결"
 msgid "Executor token"
 msgstr "Executor 토큰"
 
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker gives bots a separate workspace."
+msgstr ""
+
+#: src/pages/HostComputerPrompt.tsx:80
+msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
+msgstr ""

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3315,8 +3315,8 @@ msgstr "Executor 토큰"
 
 #: src/pages/HostComputerPrompt.tsx:62
 msgid "Docker gives bots a separate workspace."
-msgstr ""
+msgstr "Docker는 Bot에게 별도의 작업 공간을 제공합니다."
 
 #: src/pages/HostComputerPrompt.tsx:80
 msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr ""
+msgstr "{hostLabel}에서는 Bot이 묻지 않고 파일에 접근하고 명령을 실행할 수 있습니다. 공유 서버나 공개 서버에서는 이 옵션을 사용하지 마세요."

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3315,8 +3315,8 @@ msgstr "Token do Executor"
 
 #: src/pages/HostComputerPrompt.tsx:62
 msgid "Docker gives bots a separate workspace."
-msgstr ""
+msgstr "O Docker dá aos bots um espaço de trabalho separado."
 
 #: src/pages/HostComputerPrompt.tsx:80
 msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr ""
+msgstr "Ao usar {hostLabel}, os bots podem acessar seus arquivos e executar comandos sem perguntar. Evite esta opção em servidores compartilhados ou públicos."

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -1391,13 +1391,9 @@ msgstr "Nome de exibição"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "Não digite senhas na demonstração. Use Assuma o controle das credenciais."
 
-#: src/pages/HostComputerPrompt.tsx:79
+#: src/pages/HostComputerPrompt.tsx:68
 msgid "Docker (recommended)"
 msgstr "Docker (recomendado)"
-
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker is the default: bots use a shared Team Computer."
-msgstr "O Docker é o padrão: os bots usam um Computador de Equipe compartilhado."
 
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
@@ -1812,10 +1808,6 @@ msgstr "Sair"
 #: src/pages/shell/bot-panel.tsx:492
 msgid "Low"
 msgstr "Baixo"
-
-#: src/pages/HostComputerPrompt.tsx:64
-msgid "macOS will not ask for extra permission if you let bots run on this Mac. They run as you."
-msgstr "O macOS não pedirá permissão extra se você permitir que os bots sejam executados neste Mac. Eles são executados como você."
 
 #: src/pages/AccountSettingsOverlay.tsx:143
 msgid "Manage messaging settings"
@@ -2953,10 +2945,6 @@ msgstr "Este chat é somente leitura"
 msgid "this computer"
 msgstr "Este computador"
 
-#: src/pages/HostComputerPrompt.tsx:97
-msgid "This computer runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "Este computador executa comandos shell com sua conta, incluindo arquivos em sua pasta inicial. Não o ligue para um servidor compartilhado ou público."
-
 #: src/components/ArtifactFileCard.tsx:133
 msgid "This file is not valid UTF-8 Markdown."
 msgstr "Este arquivo não é válido UTF-8 Markdown."
@@ -2964,10 +2952,6 @@ msgstr "Este arquivo não é válido UTF-8 Markdown."
 #: src/pages/HostComputerPrompt.tsx:22
 msgid "this Mac"
 msgstr "esse Mac"
-
-#: src/pages/HostComputerPrompt.tsx:92
-msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "Este Mac executa comandos do shell com sua conta, incluindo arquivos em sua pasta inicial. Não o ligue para um servidor compartilhado ou público."
 
 #: src/pages/shell/dialogs.tsx:185
 msgid "This permanently removes every message and stops current work. The chat remains available."
@@ -3092,7 +3076,7 @@ msgstr "Atualizando…"
 msgid "Usage"
 msgstr "Uso"
 
-#: src/pages/HostComputerPrompt.tsx:87
+#: src/pages/HostComputerPrompt.tsx:76
 msgid "Use {hostLabel}"
 msgstr "Usar {hostLabel}"
 
@@ -3218,10 +3202,6 @@ msgstr "Armazenado com segurança. Nunca mostrado aqui."
 msgid "Your name"
 msgstr "O seu nome"
 
-#: src/pages/HostComputerPrompt.tsx:69
-msgid "Your OS will not ask for extra permission if you let bots run on {hostLabel}. They run as you."
-msgstr "Seu sistema operacional não pedirá permissão extra se você permitir que os bots sejam executados no {hostLabel}. Eles são executados como você."
-
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Sua equipe de agentes sempre ativos<0/>, a quem você pode dar trabalho de verdade."
@@ -3333,3 +3313,10 @@ msgstr "Conectar Executor"
 msgid "Executor token"
 msgstr "Token do Executor"
 
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker gives bots a separate workspace."
+msgstr ""
+
+#: src/pages/HostComputerPrompt.tsx:80
+msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
+msgstr ""

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3315,8 +3315,8 @@ msgstr "Executor belirteci"
 
 #: src/pages/HostComputerPrompt.tsx:62
 msgid "Docker gives bots a separate workspace."
-msgstr ""
+msgstr "Docker, botlara ayrı bir çalışma alanı sağlar."
 
 #: src/pages/HostComputerPrompt.tsx:80
 msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr ""
+msgstr "{hostLabel} kullanıldığında botlar sormadan dosyalarına erişebilir ve komut çalıştırabilir. Paylaşılan veya herkese açık sunucularda bu seçeneği kullanma."

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -1391,13 +1391,9 @@ msgstr "Görünen ad"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "Demoya parola yazma. Kimlik bilgileri için Kontrolü al'ı kullan."
 
-#: src/pages/HostComputerPrompt.tsx:79
+#: src/pages/HostComputerPrompt.tsx:68
 msgid "Docker (recommended)"
 msgstr "Docker (önerilen)"
-
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker is the default: bots use a shared Team Computer."
-msgstr "Varsayılan Docker'dır: botlar ortak bir Takım Bilgisayarı kullanır."
 
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
@@ -1812,10 +1808,6 @@ msgstr "Çıkış yap"
 #: src/pages/shell/bot-panel.tsx:492
 msgid "Low"
 msgstr "Düşük"
-
-#: src/pages/HostComputerPrompt.tsx:64
-msgid "macOS will not ask for extra permission if you let bots run on this Mac. They run as you."
-msgstr "Botların bu Mac'te çalışmasına izin verirsen macOS ek izin istemez. Botlar senin adına çalışır."
 
 #: src/pages/AccountSettingsOverlay.tsx:143
 msgid "Manage messaging settings"
@@ -2953,10 +2945,6 @@ msgstr "Bu sohbet yalnızca görüntülenebilir"
 msgid "this computer"
 msgstr "bu bilgisayar"
 
-#: src/pages/HostComputerPrompt.tsx:97
-msgid "This computer runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "Bu bilgisayar kabuk komutlarını senin hesabınla çalıştırır; kullanıcı klasöründeki dosyalar buna dahildir. Ortak veya herkese açık bir sunucuda etkinleştirme."
-
 #: src/components/ArtifactFileCard.tsx:133
 msgid "This file is not valid UTF-8 Markdown."
 msgstr "Bu dosya geçerli bir UTF-8 Markdown değil."
@@ -2964,10 +2952,6 @@ msgstr "Bu dosya geçerli bir UTF-8 Markdown değil."
 #: src/pages/HostComputerPrompt.tsx:22
 msgid "this Mac"
 msgstr "bu Mac"
-
-#: src/pages/HostComputerPrompt.tsx:92
-msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "Bu Mac kabuk komutlarını senin hesabınla çalıştırır; kullanıcı klasöründeki dosyalar buna dahildir. Ortak veya herkese açık bir sunucuda etkinleştirme."
 
 #: src/pages/shell/dialogs.tsx:185
 msgid "This permanently removes every message and stops current work. The chat remains available."
@@ -3092,7 +3076,7 @@ msgstr ""
 msgid "Usage"
 msgstr "Kullanım"
 
-#: src/pages/HostComputerPrompt.tsx:87
+#: src/pages/HostComputerPrompt.tsx:76
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} kullan"
 
@@ -3218,10 +3202,6 @@ msgstr "Güvenle saklanır. Burada gösterilmez."
 msgid "Your name"
 msgstr "Adın"
 
-#: src/pages/HostComputerPrompt.tsx:69
-msgid "Your OS will not ask for extra permission if you let bots run on {hostLabel}. They run as you."
-msgstr "Botların {hostLabel} üzerinde çalışmasına izin verirsen işletim sistemin ek izin istemez. Botlar senin adına çalışır."
-
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Gerçek işler verebileceğin,<0/>her zaman açık agent takımın."
@@ -3333,3 +3313,10 @@ msgstr "Executor'a bağlan"
 msgid "Executor token"
 msgstr "Executor belirteci"
 
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker gives bots a separate workspace."
+msgstr ""
+
+#: src/pages/HostComputerPrompt.tsx:80
+msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
+msgstr ""

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -1391,13 +1391,9 @@ msgstr "显示名称"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "不要在示范中输入密码。凭据请用「接管」。"
 
-#: src/pages/HostComputerPrompt.tsx:79
+#: src/pages/HostComputerPrompt.tsx:68
 msgid "Docker (recommended)"
 msgstr "Docker（推荐）"
-
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker is the default: bots use a shared Team Computer."
-msgstr "默认使用 Docker：Bot 共用一台团队电脑。"
 
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
@@ -1812,10 +1808,6 @@ msgstr "退出登录"
 #: src/pages/shell/bot-panel.tsx:492
 msgid "Low"
 msgstr "低"
-
-#: src/pages/HostComputerPrompt.tsx:64
-msgid "macOS will not ask for extra permission if you let bots run on this Mac. They run as you."
-msgstr "若让 Bot 在这台 Mac 上运行，它们会使用你的账户权限，macOS 不会再逐项询问。"
 
 #: src/pages/AccountSettingsOverlay.tsx:143
 msgid "Manage messaging settings"
@@ -2953,10 +2945,6 @@ msgstr "此对话为只读"
 msgid "this computer"
 msgstr "这台电脑"
 
-#: src/pages/HostComputerPrompt.tsx:97
-msgid "This computer runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "这台电脑会用你的账户运行 shell，包括主目录中的文件。不要在共享或公开服务器上开启。"
-
 #: src/components/ArtifactFileCard.tsx:133
 msgid "This file is not valid UTF-8 Markdown."
 msgstr "此文件不是有效的 UTF-8 Markdown。"
@@ -2964,10 +2952,6 @@ msgstr "此文件不是有效的 UTF-8 Markdown。"
 #: src/pages/HostComputerPrompt.tsx:22
 msgid "this Mac"
 msgstr "这台 Mac"
-
-#: src/pages/HostComputerPrompt.tsx:92
-msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
-msgstr "这台 Mac 会用你的账户运行 shell，包括主目录中的文件。不要在共享或公开服务器上开启。"
 
 #: src/pages/shell/dialogs.tsx:185
 msgid "This permanently removes every message and stops current work. The chat remains available."
@@ -3092,7 +3076,7 @@ msgstr "正在更新…"
 msgid "Usage"
 msgstr "用量"
 
-#: src/pages/HostComputerPrompt.tsx:87
+#: src/pages/HostComputerPrompt.tsx:76
 msgid "Use {hostLabel}"
 msgstr "使用 {hostLabel}"
 
@@ -3218,10 +3202,6 @@ msgstr "已安全存储。不会显示在这里。"
 msgid "Your name"
 msgstr "你的名字"
 
-#: src/pages/HostComputerPrompt.tsx:69
-msgid "Your OS will not ask for extra permission if you let bots run on {hostLabel}. They run as you."
-msgstr "若让 Bot 在 {hostLabel} 上运行，它们会使用你的账户权限，系统不会再逐项询问。"
-
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "你的一支随时在线的 Agent 团队<0/>可以交给它们真正的工作。"
@@ -3333,3 +3313,10 @@ msgstr "连接 Executor"
 msgid "Executor token"
 msgstr "Executor 令牌"
 
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker gives bots a separate workspace."
+msgstr ""
+
+#: src/pages/HostComputerPrompt.tsx:80
+msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
+msgstr ""

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -3315,8 +3315,8 @@ msgstr "Executor 令牌"
 
 #: src/pages/HostComputerPrompt.tsx:62
 msgid "Docker gives bots a separate workspace."
-msgstr ""
+msgstr "Docker 为 Bot 提供独立的工作空间。"
 
 #: src/pages/HostComputerPrompt.tsx:80
 msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr ""
+msgstr "使用{hostLabel}时，Bot 可以直接访问你的文件并执行命令，无需询问。请勿在共享或公开服务器上使用此选项。"

--- a/apps/web/src/pages/HostComputerPrompt.tsx
+++ b/apps/web/src/pages/HostComputerPrompt.tsx
@@ -59,18 +59,7 @@ export function HostComputerPrompt({ initialMe }: { initialMe?: Me }) {
             <Trans>Where should bots run?</Trans>
           </DialogTitle>
           <DialogDescription className="leading-relaxed">
-            <Trans>Docker is the default: bots use a shared Team Computer.</Trans>{" "}
-            {mac ? (
-              <Trans>
-                macOS will not ask for extra permission if you let bots run on this Mac. They run as
-                you.
-              </Trans>
-            ) : (
-              <Trans>
-                Your OS will not ask for extra permission if you let bots run on {hostLabel}. They
-                run as you.
-              </Trans>
-            )}
+            <Trans>Docker gives bots a separate workspace.</Trans>
           </DialogDescription>
         </DialogHeader>
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
@@ -88,17 +77,10 @@ export function HostComputerPrompt({ initialMe }: { initialMe?: Me }) {
           </Button>
         </div>
         <p className="text-xs leading-relaxed text-muted-foreground/80">
-          {mac ? (
-            <Trans>
-              This Mac runs shell commands with your account, including files in your home folder.
-              Do not turn it on for a shared or public server.
-            </Trans>
-          ) : (
-            <Trans>
-              This computer runs shell commands with your account, including files in your home
-              folder. Do not turn it on for a shared or public server.
-            </Trans>
-          )}
+          <Trans>
+            On {hostLabel}, bots can access your files and run commands without asking. Avoid this
+            on shared or public servers.
+          </Trans>
         </p>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
Simplifies the first-run computer choice by removing repeated technical explanations, updating its translation catalogs, and adding browser screenshot coverage for both platform labels; the explanation and file-access warning stay visible because they are needed before choosing where bots run.

Replacement copy:

> Docker gives bots a separate workspace.

> On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.

Validation: web typecheck, all 208 web unit tests, changed-file formatting, translation compilation, and both focused browser tests passed; all CI checks passed


CI screenshots: [Mac](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34151118284-1/screenshots/images/135-host-computer-choice-darwin.png) · [Windows](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34151118284-1/screenshots/images/136-host-computer-choice-win32.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Experience**
  - Simplified the host selection dialog with clearer, platform-neutral guidance.
  - Added messaging that Docker provides bots with a separate workspace.
  - Added a warning that bots running on the selected computer can access files and execute commands without additional prompts.

- **Localization**
  - Updated translated message catalogs to reflect the revised Docker and host-access guidance.

- **Tests**
  - Added coverage for the dialog, platform-specific labels, warnings, and available host options on macOS and Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->