### PR TITLE
Add server-owned integration setup and app connections

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import type {
 import {
   applyMessagingOutboundStatus,
   ChatSdkMessagingSurface,
+  ComposioConnector,
   type ComposioProvider,
   type ConnectorRegistry,
   createBackgroundJobHandlers,
@@ -35,6 +36,7 @@ import {
   InMemoryJobQueue,
   InMemoryRealtimeFanout,
   InstalledConnectorProvider,
+  IntegrationProviderSettings,
   isComposioEnabled,
   isMessagingSurfaceEnabled,
   isPipedreamEnabled,
@@ -251,9 +253,19 @@ export async function createApp(
       ? new SmtpEmailProvider({ url: env.smtpUrl, from: env.emailFrom ?? "" })
       : localEmailEmulator);
   const installed = new InstalledConnectorProvider(prisma, secrets, remoteConnectors);
-  const stack = createConnectorStack(isComposioEnabled(env.composioApiKey), composioOverride, [
+  const integrationSettings = new IntegrationProviderSettings(prisma, secrets, env.encryptionKey, {
+    composio:
+      composioOverride ??
+      (isComposioEnabled(env.composioApiKey)
+        ? new ComposioConnector(env.composioApiKey)
+        : undefined),
+    pipedream,
+  });
+  const stack = createConnectorStack(false, composioOverride, [
     installed,
-    ...(pipedream ? [pipedream] : []),
+    ...integrationSettings
+      .providers()
+      .filter((provider) => !composioOverride || provider.describe().id !== "composio"),
     mcp,
   ]);
   const connector = stack.destination;
@@ -327,7 +339,17 @@ export async function createApp(
     artifacts,
     connector: stack.connector,
     connectors: stack.connector,
-    listConnectedPluginSlugs: stack.composio?.listConnectedSlugs.bind(stack.composio),
+    listConnectedPluginSlugs: async (userId) => {
+      const provider = await integrationSettings.resolve("composio");
+      if (!provider) throw new Error("Integration provider is unavailable");
+      return provider.listConnectedExternalIds({
+        userId,
+        spaceId: "",
+        operationId: "connections.sync",
+        traceId: "connections.sync",
+        signal: AbortSignal.timeout(15_000),
+      });
+    },
     secrets: [
       env.deploymentModelKey ?? "",
       env.composioApiKey ?? "",
@@ -384,6 +406,7 @@ export async function createApp(
     home,
     secrets,
     oauthLogins,
+    integrationSettings,
     mcpOAuth,
     composio: stack.composio,
     connectors: stack.connector,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -270,8 +270,7 @@ export async function createApp(
   ]);
   const connector = stack.destination;
   await connector.start();
-  void stack.composio?.warmDirectory().catch(() => undefined);
-  void pipedream?.warmDirectory?.().catch(() => undefined);
+  integrationSettings.warmDirectories();
   const runtime =
     env.agentRuntime === "scripted"
       ? new ScriptedAgentRuntime()
@@ -341,7 +340,7 @@ export async function createApp(
     connectors: stack.connector,
     listConnectedPluginSlugs: async (userId) => {
       const provider = await integrationSettings.resolve("composio");
-      if (!provider) throw new Error("Integration provider is unavailable");
+      if (!provider) return [];
       return provider.listConnectedExternalIds({
         userId,
         spaceId: "",

--- a/apps/api/src/onboarding.test.ts
+++ b/apps/api/src/onboarding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { chooseFocus } from "./onboarding.js";
+import { chooseFocus, markAppConnected } from "./onboarding.js";
 
 const posted = vi.hoisted(() => [] as Array<{ blocks: unknown[] }>);
 vi.mock("@rakazo/db", async (original) => ({
@@ -33,7 +33,7 @@ function fixture(catalog: unknown[]) {
     email: "user@rakazo.test",
     isDeploymentOwner: true,
   };
-  return { deps, actor };
+  return { deps, actor, tx };
 }
 describe("onboarding connection suggestions", () => {
   it("does not invent authorization cards when no connector has an app catalog", async () => {
@@ -56,5 +56,22 @@ describe("onboarding connection suggestions", () => {
     ).toEqual([
       expect.objectContaining({ connectorId: "pipedream", provider: "slack", name: "Slack" }),
     ]);
+  });
+});
+
+it("marks only the authorized connector when provider slugs collide", async () => {
+  const { deps, actor, tx } = fixture([]);
+  const blocks = ["composio", "pipedream"].map((connectorId) => ({
+    kind: "app_connect",
+    connectorId,
+    provider: "slack",
+    name: "Slack",
+    status: "pending",
+  }));
+  deps.prisma.message = { findMany: vi.fn(async () => [{ id: "cards", blocks }]) } as never;
+  await markAppConnected(deps, actor, "bot", "slack", "pipedream");
+  expect(tx.message.update).toHaveBeenCalledWith({
+    where: { id: "cards" },
+    data: { blocks: [blocks[0], { ...blocks[1], status: "connected" }] },
   });
 });

--- a/apps/api/src/onboarding.test.ts
+++ b/apps/api/src/onboarding.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { chooseFocus } from "./onboarding.js";
+
+const posted = vi.hoisted(() => [] as Array<{ blocks: unknown[] }>);
+vi.mock("@rakazo/db", async (original) => ({
+  ...(await original<typeof import("@rakazo/db")>()),
+  createThreadMessageInTransaction: vi.fn(async (_tx, input) => {
+    posted.push(input);
+    return { id: "posted" };
+  }),
+  appendEventInTransaction: vi.fn(async () => ({ seq: 1 })),
+}));
+function fixture(catalog: unknown[]) {
+  posted.length = 0;
+  const tx = {
+    $executeRaw: vi.fn(),
+    message: {
+      findMany: vi.fn(async () => [{ id: "choice", blocks: [{ kind: "choice", answerId: null }] }]),
+      update: vi.fn(),
+    },
+  };
+  const deps = {
+    prisma: {
+      bot: { findFirst: vi.fn(async () => ({ id: "bot", thread: { id: "thread" } })) },
+      $transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(tx)),
+    },
+    events: { notify: vi.fn() },
+    connectors: { managedProviders: () => [{ catalog: async () => catalog }] },
+  } as unknown as Parameters<typeof chooseFocus>[0];
+  const actor = {
+    userId: "user",
+    spaceId: "space",
+    email: "user@rakazo.test",
+    isDeploymentOwner: true,
+  };
+  return { deps, actor };
+}
+describe("onboarding connection suggestions", () => {
+  it("does not invent authorization cards when no connector has an app catalog", async () => {
+    const { deps, actor } = fixture([]);
+    await chooseFocus(deps, actor, "bot", "day");
+    expect(posted.flatMap((message) => message.blocks)).not.toContainEqual(
+      expect.objectContaining({ kind: "app_connect" }),
+    );
+    expect(posted.length).toBeGreaterThan(0);
+  });
+  it("uses the available connector and omits unavailable apps", async () => {
+    const { deps, actor } = fixture([
+      { connectorId: "pipedream", slug: "slack", name: "Slack", connected: false, logo: null },
+    ]);
+    await chooseFocus(deps, actor, "bot", "day");
+    expect(
+      posted
+        .flatMap((message) => message.blocks)
+        .filter((block) => (block as { kind: string }).kind === "app_connect"),
+    ).toEqual([
+      expect.objectContaining({ connectorId: "pipedream", provider: "slack", name: "Slack" }),
+    ]);
+  });
+});

--- a/apps/api/src/onboarding.ts
+++ b/apps/api/src/onboarding.ts
@@ -344,6 +344,7 @@ export async function markAppConnected(
   actor: Actor,
   botId: string,
   provider: string,
+  connectorId = "composio",
 ): Promise<void> {
   const { bot, thread } = await requireBotThread(deps, actor, botId);
   const target = { spaceId: actor.spaceId, botId: bot.id, threadId: thread.id };
@@ -359,13 +360,16 @@ export async function markAppConnected(
       !blocks.some(
         (block) =>
           block.kind === "app_connect" &&
+          (block.connectorId ?? "composio") === connectorId &&
           featuredConnectorProvidersMatch(block.provider, provider) &&
           block.status !== "connected",
       )
     )
       continue;
     const next = blocks.map((block) =>
-      block.kind === "app_connect" && featuredConnectorProvidersMatch(block.provider, provider)
+      block.kind === "app_connect" &&
+      (block.connectorId ?? "composio") === connectorId &&
+      featuredConnectorProvidersMatch(block.provider, provider)
         ? { ...block, status: "connected" as const }
         : block,
     );

--- a/apps/api/src/onboarding.ts
+++ b/apps/api/src/onboarding.ts
@@ -1,4 +1,4 @@
-import type { ComposioProvider } from "@rakazo/adapters";
+import type { ConnectorRegistry } from "@rakazo/adapters";
 import type { Actor, MessageBlock } from "@rakazo/contracts";
 import { featuredConnectorProvidersMatch } from "@rakazo/core";
 import {
@@ -12,14 +12,14 @@ import {
 
 /**
  * First-run conversational onboarding, seeded deterministically into the bot's
- * thread: greeting, a focus choice, and Composio app cards the user authorizes
+ * thread: greeting, a focus choice, and available app cards the user authorizes
  * inline. Focus must not rename the bot. No model tokens are spent.
  */
 
 type OnboardingDeps = {
   prisma: PrismaClient;
   events: ThreadEvents;
-  composio?: Pick<ComposioProvider, "catalog">;
+  connectors: ConnectorRegistry;
 };
 
 type FocusOption = {
@@ -68,15 +68,6 @@ const APP_DESCRIPTIONS: Record<string, string> = {
   notion: "Search and edit pages and databases.",
   googledocs: "Draft and edit documents.",
   hackernews: "Search stories and discussions.",
-};
-
-const APP_NAMES: Record<string, string> = {
-  gmail: "Gmail",
-  googlecalendar: "Google Calendar",
-  googledocs: "Google Docs",
-  hackernews: "Hacker News",
-  notion: "Notion",
-  slack: "Slack",
 };
 
 async function requireBotThread(deps: OnboardingDeps, actor: Actor, botId: string) {
@@ -289,30 +280,46 @@ export async function chooseFocus(
     },
   ]);
 
-  const catalog = deps.composio
-    ? await deps.composio
-        .catalog({
-          operationId: "onboarding.choose",
-          traceId: "onboarding.choose",
-          spaceId: actor.spaceId,
-          userId: actor.userId,
-          botId: bot.id,
-          signal: new AbortController().signal,
-        })
-        .catch(() => [])
-    : [];
-  const bySlug = new Map(catalog.map((entry) => [entry.slug.toLowerCase(), entry]));
-  const cards: MessageBlock[] = option.apps.map((slug) => {
-    const entry = bySlug.get(slug.toLowerCase());
-    return {
-      kind: "app_connect",
-      provider: entry?.slug ?? slug,
-      name: entry?.name ?? APP_NAMES[slug] ?? capitalize(slug),
-      description: APP_DESCRIPTIONS[slug] ?? `Connect ${entry?.name ?? slug} to your account.`,
-      logo: entry?.logo ?? null,
-      status: entry?.connected ? "connected" : "pending",
-    };
+  const providers = deps.connectors.managedProviders();
+  const catalog = (
+    await Promise.all(
+      providers.map((provider) =>
+        provider
+          .catalog({
+            operationId: "onboarding.choose",
+            traceId: "onboarding.choose",
+            spaceId: actor.spaceId,
+            userId: actor.userId,
+            botId: bot.id,
+            signal: AbortSignal.timeout(15_000),
+          })
+          .catch(() => []),
+      ),
+    )
+  ).flat();
+  const cards: MessageBlock[] = option.apps.flatMap((slug) => {
+    const entry = catalog.find(
+      (item) =>
+        item.slug.toLowerCase() === slug.toLowerCase() ||
+        featuredConnectorProvidersMatch(item.slug, slug),
+    );
+    if (!entry) return [];
+    return [
+      {
+        kind: "app_connect" as const,
+        connectorId: entry.connectorId ?? "composio",
+        provider: entry.slug,
+        name: entry.name,
+        description: APP_DESCRIPTIONS[slug] ?? "",
+        logo: entry.logo ?? null,
+        status: entry.connected ? ("connected" as const) : ("pending" as const),
+      },
+    ];
   });
+  if (!cards.length) {
+    await post(deps, target, [{ kind: "text", text: "What would you like to work on first?" }]);
+    return;
+  }
   const cardNames = cards
     .map((card) => (card.kind === "app_connect" ? card.name : ""))
     .filter(Boolean);

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -632,3 +632,35 @@ describe("computer screen url", () => {
     expect(updateMany).not.toHaveBeenCalled();
   });
 });
+
+describe("integration setup authorization", () => {
+  it("rejects provider credentials from a non-owner before verification or persistence", async () => {
+    const save = vi.fn();
+    const deps = {
+      prisma: {},
+      env: { webOrigin: "https://example.test" },
+      integrationSettings: { save },
+    } as unknown as RouterDeps;
+    const handler = new RPCHandler(createRouter(deps));
+    const { response } = await handler.handle(
+      new Request("https://example.test/rpc/integrationSetup/save", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { provider: "composio", apiKey: "fake-key" } }),
+      }),
+      {
+        prefix: "/rpc",
+        context: {
+          actor: {
+            userId: "member",
+            spaceId: "space",
+            email: "member@rakazo.test",
+            isDeploymentOwner: false,
+          },
+        },
+      },
+    );
+    expect(response.status).toBe(403);
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -659,6 +659,47 @@ describe("computer screen url", () => {
 });
 
 describe("integration setup authorization", () => {
+  it.each([
+    { owner: false, configured: false, needsSetup: false },
+    { owner: true, configured: false, needsSetup: true },
+    { owner: true, configured: true, needsSetup: false },
+  ])(
+    "offers server setup only to an owner without configured providers: %j",
+    async ({ owner, configured, needsSetup }) => {
+      const lookup = vi.fn(async () => configured);
+      const deps = {
+        prisma: {},
+        env: { webOrigin: "https://example.test" },
+        integrationSettings: { configured: lookup },
+      } as unknown as RouterDeps;
+      const handler = new RPCHandler(createRouter(deps));
+      const { response } = await handler.handle(
+        new Request("https://example.test/rpc/integrationSetup/get", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ json: null }),
+        }),
+        {
+          prefix: "/rpc",
+          context: {
+            actor: {
+              userId: "user",
+              spaceId: "space",
+              email: "user@rakazo.test",
+              isDeploymentOwner: owner,
+            },
+          },
+        },
+      );
+      const result = (await response.json()).json;
+      expect(result).toMatchObject({ canConfigure: owner, needsSetup });
+      if (!owner) {
+        expect(result.providers).toEqual([]);
+        expect(lookup).not.toHaveBeenCalled();
+      }
+    },
+  );
+
   it("rejects provider credentials from a non-owner before verification or persistence", async () => {
     const save = vi.fn();
     const deps = {

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -41,6 +41,31 @@ describe("account preferences", () => {
     return { update, deps, actor, handler: new RPCHandler(createRouter(deps)) };
   }
 
+  it("keeps an unconfigured catalog offline unless explicitly requested", async () => {
+    const { actor, deps } = preferencesDeps("robot");
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ results: [] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    deps.remoteConnectors = { fetch } as RouterDeps["remoteConnectors"];
+    const handler = new RPCHandler(createRouter(deps));
+    const request = async (usePublicCatalog?: boolean) =>
+      handler.handle(
+        new Request("http://127.0.0.1/rpc/capabilities/catalogSearch", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ json: { query: "notion", usePublicCatalog } }),
+        }),
+        { prefix: "/rpc", context: { actor } },
+      );
+    const { response } = await request();
+    await expect(response.json()).resolves.toEqual({ json: { enabled: false, results: [] } });
+    expect(fetch).not.toHaveBeenCalled();
+    await request(true);
+    expect(fetch).toHaveBeenCalled();
+  });
+
   it("persists and returns the selected avatar style", async () => {
     const { update, actor, handler } = preferencesDeps("organic");
 

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -2945,18 +2945,25 @@ export function createRouter(deps: RouterDeps) {
       }),
     },
     integrationSetup: {
-      get: authed.integrationSetup.get.handler(async ({ context }) => ({
-        canConfigure: context.actor.isDeploymentOwner,
-        webUrl: new URL("/integrations/setup", deps.env.webOrigin).toString(),
-        providers: await Promise.all(
-          IntegrationProviderIdSchema.options.map(async (id) => ({
-            id,
-            configured: deps.integrationSettings
-              ? await deps.integrationSettings.configured(id)
-              : Boolean(deps.connectors.managed(id)),
-          })),
-        ),
-      })),
+      get: authed.integrationSetup.get.handler(async ({ context }) => {
+        const canConfigure = context.actor.isDeploymentOwner;
+        const providers = canConfigure
+          ? await Promise.all(
+              IntegrationProviderIdSchema.options.map(async (id) => ({
+                id,
+                configured: deps.integrationSettings
+                  ? await deps.integrationSettings.configured(id)
+                  : Boolean(deps.connectors.managed(id)),
+              })),
+            )
+          : [];
+        return {
+          canConfigure,
+          needsSetup: canConfigure && !providers.some((provider) => provider.configured),
+          webUrl: new URL("/integrations/setup", deps.env.webOrigin).toString(),
+          providers,
+        };
+      }),
       save: authed.integrationSetup.save.handler(async ({ context, input }) => {
         if (!context.actor.isDeploymentOwner) throw new ORPCError("FORBIDDEN");
         if (!deps.integrationSettings) throw new ORPCError("NOT_IMPLEMENTED");

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -2934,7 +2934,13 @@ export function createRouter(deps: RouterDeps) {
         return { ok: true as const };
       }),
       appConnected: authed.onboarding.appConnected.handler(async ({ context, input }) => {
-        await markAppConnected(onboardingDeps, context.actor, input.botId, input.provider);
+        await markAppConnected(
+          onboardingDeps,
+          context.actor,
+          input.botId,
+          input.provider,
+          input.connectorId,
+        );
         return { ok: true as const };
       }),
     },

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -15,6 +15,7 @@ import {
   runJobKey,
   type SandboxProvider,
 } from "@rakazo/adapter-kit";
+import type { IntegrationProviderSettings } from "@rakazo/adapters";
 import {
   acquireComputerExecutionLease,
   applyTeachingDesktopInput,
@@ -76,6 +77,7 @@ import {
   type Actor,
   appContract,
   type ComputerStatus,
+  IntegrationProviderIdSchema,
   type McpServer,
   type Me,
   OPENAI_COMPATIBLE_PROVIDER_ID,
@@ -407,6 +409,7 @@ export interface RouterDeps {
   home: AgentHomeStore;
   secrets: EncryptedSecretStore;
   oauthLogins: PiOAuthLogins;
+  integrationSettings?: IntegrationProviderSettings;
   composio?: ComposioProvider;
   mcpOAuth?: McpOAuthBroker;
   connectors: ConnectorRegistry;
@@ -434,6 +437,7 @@ export interface RouterDeps {
 export function createRouter(deps: RouterDeps) {
   const os = implement(appContract).$context<{ actor: Actor | null; signal?: AbortSignal }>();
   const repos = createRepos(deps.prisma);
+  const onboardingDeps = { prisma: deps.prisma, events: deps.events, connectors: deps.connectors };
   const mcpOAuth = deps.mcpOAuth ?? new McpOAuthBroker(deps.prisma, deps.secrets);
   const groupRepos = createGroupRepos(deps.prisma);
   const taughtSkills = createTaughtSkillsService({
@@ -2368,7 +2372,7 @@ export function createRouter(deps: RouterDeps) {
         }));
       }),
       catalogSearch: authed.capabilities.catalogSearch.handler(async ({ context, input }) => {
-        const baseUrl = deps.env.integrationsCatalogUrl;
+        const baseUrl = deps.env.integrationsCatalogUrl ?? "https://integrations.sh";
         if (!baseUrl) return { enabled: false, results: [] };
         try {
           const results = await searchIntegrationCatalog({
@@ -2895,45 +2899,52 @@ export function createRouter(deps: RouterDeps) {
     },
     onboarding: {
       start: authed.onboarding.start.handler(async ({ context, input }) => {
-        await startOnboarding(
-          { prisma: deps.prisma, events: deps.events, composio: deps.composio },
-          context.actor,
-          input.botId,
-        );
+        await startOnboarding(onboardingDeps, context.actor, input.botId);
         return { ok: true as const };
       }),
       promptFocus: authed.onboarding.promptFocus.handler(async ({ context, input }) => {
-        await promptFocus(
-          { prisma: deps.prisma, events: deps.events, composio: deps.composio },
-          context.actor,
-          input.botId,
-        );
+        await promptFocus(onboardingDeps, context.actor, input.botId);
         return { ok: true as const };
       }),
       choose: authed.onboarding.choose.handler(async ({ context, input }) => {
-        await chooseFocus(
-          { prisma: deps.prisma, events: deps.events, composio: deps.composio },
-          context.actor,
-          input.botId,
-          input.optionId,
-        );
+        await chooseFocus(onboardingDeps, context.actor, input.botId, input.optionId);
         return { ok: true as const };
       }),
       dismissFocus: authed.onboarding.dismissFocus.handler(async ({ context, input }) => {
-        await dismissFocus(
-          { prisma: deps.prisma, events: deps.events, composio: deps.composio },
-          context.actor,
-          input.botId,
-        );
+        await dismissFocus(onboardingDeps, context.actor, input.botId);
         return { ok: true as const };
       }),
       appConnected: authed.onboarding.appConnected.handler(async ({ context, input }) => {
-        await markAppConnected(
-          { prisma: deps.prisma, events: deps.events, composio: deps.composio },
-          context.actor,
-          input.botId,
-          input.provider,
-        );
+        await markAppConnected(onboardingDeps, context.actor, input.botId, input.provider);
+        return { ok: true as const };
+      }),
+    },
+    integrationSetup: {
+      get: authed.integrationSetup.get.handler(async ({ context }) => ({
+        canConfigure: context.actor.isDeploymentOwner,
+        webUrl: new URL("/integrations/setup", deps.env.webOrigin).toString(),
+        providers: await Promise.all(
+          IntegrationProviderIdSchema.options.map(async (id) => ({
+            id,
+            configured: deps.integrationSettings
+              ? await deps.integrationSettings.configured(id)
+              : Boolean(deps.connectors.managed(id)),
+          })),
+        ),
+      })),
+      save: authed.integrationSetup.save.handler(async ({ context, input }) => {
+        if (!context.actor.isDeploymentOwner) throw new ORPCError("FORBIDDEN");
+        if (!deps.integrationSettings) throw new ORPCError("NOT_IMPLEMENTED");
+        try {
+          await deps.integrationSettings.save(
+            input,
+            connectionContext(context.actor, "integrationSetup.save", context.signal),
+          );
+        } catch {
+          throw new ORPCError("BAD_REQUEST", {
+            message: "Could not verify or save these credentials",
+          });
+        }
         return { ok: true as const };
       }),
     },
@@ -2990,7 +3001,11 @@ export function createRouter(deps: RouterDeps) {
         }));
       }),
       begin: authed.connections.begin.handler(async ({ context, input }) => {
-        const connector = deps.connectors.managed(input.connectorId);
+        const connector =
+          deps.integrationSettings &&
+          (input.connectorId === "composio" || input.connectorId === "pipedream")
+            ? await deps.integrationSettings.resolve(input.connectorId)
+            : deps.connectors.managed(input.connectorId);
         if (!connector) {
           throw new ORPCError("BAD_REQUEST", {
             message: `Connector ${input.connectorId} is not configured`,

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -2372,7 +2372,9 @@ export function createRouter(deps: RouterDeps) {
         }));
       }),
       catalogSearch: authed.capabilities.catalogSearch.handler(async ({ context, input }) => {
-        const baseUrl = deps.env.integrationsCatalogUrl ?? "https://integrations.sh";
+        const baseUrl =
+          deps.env.integrationsCatalogUrl ??
+          (input.usePublicCatalog ? "https://integrations.sh" : undefined);
         if (!baseUrl) return { enabled: false, results: [] };
         try {
           const results = await searchIntegrationCatalog({
@@ -2610,7 +2612,6 @@ export function createRouter(deps: RouterDeps) {
           return mcpServerDto(row, await mcpOAuth.statusFor(row, context.actor));
         }),
         update: authed.mcp.servers.update.handler(async ({ context, input }) => {
-          const config = input.config;
           const row = await deps.prisma.$transaction(async (tx) => {
             // Share the OAuth broker's per-server lock so a stale authorization
             // snapshot cannot overwrite a simultaneous credential edit.
@@ -2644,6 +2645,22 @@ export function createRouter(deps: RouterDeps) {
                 /* Existing malformed secrets are replaced only when new credentials are supplied. */
               }
             }
+            const config =
+              "config" in input
+                ? input.config
+                : {
+                    slug: existing.slug,
+                    name: existing.name,
+                    description: existing.description,
+                    enabled: existing.enabled,
+                    transport: existing.transport as "streamable_http" | "sse",
+                    endpoint: existing.endpoint!,
+                    headers: (existingMaterial.headers ?? {}) as Record<string, string>,
+                    secret: input.secret,
+                  };
+            if (!("config" in input) && existing.transport === "stdio") {
+              throw new ORPCError("BAD_REQUEST", { message: "A remote MCP server is required" });
+            }
             const nextEndpoint = "endpoint" in config ? config.endpoint : null;
             const update = buildMcpUpdateMaterial(existingMaterial, config, {
               clearOAuth: existing.endpoint !== nextEndpoint,
@@ -2656,6 +2673,17 @@ export function createRouter(deps: RouterDeps) {
                   )
                 : null;
             const clearing = update.action === "store" && Object.keys(update.material).length === 0;
+            if (stored) {
+              await tx.secret.create({
+                data: {
+                  id: stored.id,
+                  userId: context.actor.userId,
+                  spaceId: context.actor.spaceId,
+                  kind: "mcp",
+                  ciphertext: stored.ciphertext,
+                },
+              });
+            }
             const updated = await tx.mcpServer.update({
               where: { id: existing.id },
               data: {
@@ -2678,15 +2706,6 @@ export function createRouter(deps: RouterDeps) {
               },
             });
             if (stored) {
-              await tx.secret.create({
-                data: {
-                  id: stored.id,
-                  userId: context.actor.userId,
-                  spaceId: context.actor.spaceId,
-                  kind: "mcp",
-                  ciphertext: stored.ciphertext,
-                },
-              });
               if (existing.secretId)
                 await tx.secret.deleteMany({
                   where: {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -70,6 +70,7 @@ export default function Layout() {
               >
                 <Stack.Screen name="index" options={{ headerShown: false, title: "Rakazo" }} />
                 <Stack.Screen name="sign-in" options={{ headerShown: false }} />
+                <Stack.Screen name="integration-setup" options={{ title: t("Connect apps") }} />
                 <Stack.Screen name="account" options={{ title: t("Account") }} />
                 <Stack.Screen
                   name="change-password"

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -70,7 +70,10 @@ export default function Layout() {
               >
                 <Stack.Screen name="index" options={{ headerShown: false, title: "Rakazo" }} />
                 <Stack.Screen name="sign-in" options={{ headerShown: false }} />
-                <Stack.Screen name="integration-setup" options={{ title: t("Connect apps") }} />
+                <Stack.Screen
+                  name="integration-setup"
+                  options={{ title: t("Server integrations") }}
+                />
                 <Stack.Screen name="account" options={{ title: t("Account") }} />
                 <Stack.Screen
                   name="change-password"

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -425,6 +425,16 @@ export default function Account() {
           <Text style={styles.chevron}>›</Text>
         </Pressable>
 
+        {me?.isDeploymentOwner ? (
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => router.push("/integration-setup")}
+            style={styles.settingsButton}
+          >
+            <Text style={styles.settingsTitle}>{t("Server integrations")}</Text>
+          </Pressable>
+        ) : null}
+
         <Pressable
           accessibilityRole="button"
           disabled={pending}

--- a/apps/mobile/app/integration-setup.tsx
+++ b/apps/mobile/app/integration-setup.tsx
@@ -29,7 +29,13 @@ export default function IntegrationSetup() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     void rpc<IntegrationSetupState>("integrationSetup/get")
-      .then(setState)
+      .then((setup) => {
+        if (!setup.canConfigure) {
+          router.replace("/integrations");
+          return;
+        }
+        setState(setup);
+      })
       .catch(() => setError(t("Could not load integrations")));
   }, []);
   const choices = [
@@ -76,6 +82,8 @@ export default function IntegrationSetup() {
       </Pressable>
     );
   }
+  if (!state) return error ? <Text accessibilityRole="alert">{error}</Text> : <ActivityIndicator />;
+
   return (
     <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
       <View style={styles.choices}>

--- a/apps/mobile/app/integration-setup.tsx
+++ b/apps/mobile/app/integration-setup.tsx
@@ -1,0 +1,207 @@
+import type { IntegrationSetupState } from "@rakazo/contracts";
+import { useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { rpc } from "../lib/api";
+import { mobileTokens } from "../lib/appearance";
+import { useI18n } from "../lib/i18n";
+import { useThemedStyles } from "../lib/native";
+
+export default function IntegrationSetup() {
+  const router = useRouter();
+  const { t } = useI18n();
+  const styles = useThemedStyles(createStyles);
+  const [state, setState] = useState<IntegrationSetupState | null>(null);
+  const [choice, setChoice] = useState("direct");
+  const [key, setKey] = useState("");
+  const [clientId, setClientId] = useState("");
+  const [projectId, setProjectId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    void rpc<IntegrationSetupState>("integrationSetup/get")
+      .then(setState)
+      .catch(() => setError(t("Could not load integrations")));
+  }, []);
+  const choices = [
+    { id: "direct", label: t("Direct MCP") },
+    { id: "composio", label: "Composio" },
+    { id: "pipedream", label: "Pipedream" },
+    { id: "executor", label: "Executor" },
+  ];
+  const managed = choice === "composio" || choice === "pipedream";
+  const configured = state?.providers.find((provider) => provider.id === choice)?.configured;
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      await rpc(
+        "integrationSetup/save",
+        choice === "composio"
+          ? { provider: "composio", apiKey: key }
+          : {
+              provider: "pipedream",
+              clientId,
+              clientSecret: key,
+              projectId,
+              environment: "production",
+            },
+      );
+      setKey("");
+      router.replace("/integrations");
+    } catch {
+      setError(t("Could not verify or save these credentials"));
+    } finally {
+      setBusy(false);
+    }
+  }
+  function button(label: string, onPress: () => void, disabled = false) {
+    return (
+      <Pressable
+        accessibilityRole="button"
+        disabled={disabled}
+        onPress={onPress}
+        style={[styles.button, disabled && { opacity: 0.5 }]}
+      >
+        <Text style={styles.buttonText}>{label}</Text>
+      </Pressable>
+    );
+  }
+  return (
+    <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+      <View style={styles.choices}>
+        {choices.map(({ id, label }) => (
+          <Pressable
+            key={id}
+            accessibilityRole="radio"
+            accessibilityState={{ checked: choice === id, disabled: busy }}
+            disabled={busy}
+            onPress={() => {
+              setChoice(id);
+              setKey("");
+              setError(null);
+            }}
+            style={[styles.choice, choice === id && styles.selected]}
+          >
+            <Text style={styles.text}>{label}</Text>
+          </Pressable>
+        ))}
+      </View>
+      {choice === "composio" || choice === "pipedream" ? (
+        <>
+          {configured ? <Text style={styles.text}>{t("Connected")}</Text> : null}
+          {state?.canConfigure ? (
+            <>
+              {choice === "pipedream" ? (
+                <>
+                  <Text style={styles.text}>{t("Client ID")}</Text>
+                  <TextInput
+                    accessibilityLabel={t("Client ID")}
+                    value={clientId}
+                    onChangeText={setClientId}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    style={styles.input}
+                  />
+                  <Text style={styles.text}>{t("Project ID")}</Text>
+                  <TextInput
+                    accessibilityLabel={t("Project ID")}
+                    value={projectId}
+                    onChangeText={setProjectId}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    style={styles.input}
+                  />
+                </>
+              ) : null}
+              <Text style={styles.text}>
+                {choice === "composio" ? t("API key") : t("Client secret")}
+              </Text>
+              <TextInput
+                accessibilityLabel={choice === "composio" ? t("API key") : t("Client secret")}
+                value={key}
+                onChangeText={setKey}
+                secureTextEntry
+                autoCapitalize="none"
+                autoCorrect={false}
+                style={styles.input}
+              />
+              {button(t("Get credentials"), () => {
+                void Linking.openURL(
+                  choice === "composio"
+                    ? "https://dashboard.composio.dev"
+                    : "https://pipedream.com/docs/connect/mcp/developers",
+                );
+              })}
+            </>
+          ) : state && !configured ? (
+            <Text style={styles.text}>{t("Ask the server owner to configure this provider.")}</Text>
+          ) : null}
+        </>
+      ) : (
+        <>
+          <Text style={styles.text}>
+            {choice === "executor"
+              ? t("Set up Executor on your server in the web app.")
+              : t("Finish MCP authorization in the web app.")}
+          </Text>
+          {button(
+            t("Open web app"),
+            () => {
+              if (state) void Linking.openURL(state.webUrl);
+            },
+            !state,
+          )}
+        </>
+      )}
+      {busy ? <ActivityIndicator /> : null}
+      {error ? (
+        <Text accessibilityRole="alert" style={styles.error}>
+          {error}
+        </Text>
+      ) : null}
+      {button(
+        t("Continue"),
+        () => {
+          if (managed && key.trim()) void save();
+          else router.replace("/");
+        },
+        busy ||
+          (managed &&
+            state?.canConfigure &&
+            !configured &&
+            (!key.trim() || (choice === "pipedream" && (!clientId.trim() || !projectId.trim())))),
+      )}
+      {button(t("Skip"), () => router.replace("/"), busy)}
+    </ScrollView>
+  );
+}
+function createStyles() {
+  const tokens = mobileTokens();
+  return StyleSheet.create({
+    content: { padding: 20, gap: 16 },
+    choices: { borderWidth: 1, borderColor: tokens.border, borderRadius: 12, overflow: "hidden" },
+    choice: { padding: 16 },
+    selected: { backgroundColor: tokens.muted },
+    text: { color: tokens.foreground, fontSize: 16 },
+    input: {
+      borderWidth: 1,
+      borderColor: tokens.border,
+      borderRadius: 10,
+      padding: 12,
+      color: tokens.foreground,
+    },
+    button: { padding: 14, borderRadius: 10, backgroundColor: tokens.muted },
+    buttonText: { color: tokens.foreground, textAlign: "center", fontSize: 16 },
+    error: { color: tokens.destructive },
+  });
+}

--- a/apps/mobile/app/integration-setup.tsx
+++ b/apps/mobile/app/integration-setup.tsx
@@ -165,7 +165,9 @@ export default function IntegrationSetup() {
           {button(
             t("Open web app"),
             () => {
-              if (state) void Linking.openURL(state.webUrl);
+              const url = new URL(state.webUrl);
+              if (choice === "direct") url.searchParams.set("mode", "mcp");
+              void Linking.openURL(url.toString());
             },
             !state,
           )}

--- a/apps/mobile/app/integrations.tsx
+++ b/apps/mobile/app/integrations.tsx
@@ -7,6 +7,7 @@ import {
   filterConnectionCatalogItems,
   humanizeToolName,
 } from "@rakazo/core";
+import { useRouter } from "expo-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -35,6 +36,7 @@ function itemKey(item: Pick<ConnectionCatalogItem, "connectorId" | "slug">) {
 }
 
 export default function Integrations() {
+  const router = useRouter();
   const styles = useThemedStyles(createIntegrationsStyles);
   const { t } = useI18n();
   const { width } = useWindowDimensions();
@@ -523,7 +525,15 @@ export default function Integrations() {
   return (
     <SafeAreaView edges={["bottom"]} style={styles.screen}>
       <ScrollView keyboardShouldPersistTaps="handled" contentContainerStyle={styles.content}>
-        {!detailItem ? <Text style={styles.explanation}>{t("Connect apps.")}</Text> : null}
+        {!detailItem ? (
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => router.push("/integration-setup")}
+            style={styles.cardButton}
+          >
+            <Text style={styles.buttonLabel}>{t("Connect apps")}</Text>
+          </Pressable>
+        ) : null}
 
         {!detailItem ? (
           <TextInput

--- a/apps/mobile/app/integrations.tsx
+++ b/apps/mobile/app/integrations.tsx
@@ -7,7 +7,6 @@ import {
   filterConnectionCatalogItems,
   humanizeToolName,
 } from "@rakazo/core";
-import { useRouter } from "expo-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -36,7 +35,6 @@ function itemKey(item: Pick<ConnectionCatalogItem, "connectorId" | "slug">) {
 }
 
 export default function Integrations() {
-  const router = useRouter();
   const styles = useThemedStyles(createIntegrationsStyles);
   const { t } = useI18n();
   const { width } = useWindowDimensions();
@@ -529,16 +527,6 @@ export default function Integrations() {
   return (
     <SafeAreaView edges={["bottom"]} style={styles.screen}>
       <ScrollView keyboardShouldPersistTaps="handled" contentContainerStyle={styles.content}>
-        {!detailItem ? (
-          <Pressable
-            accessibilityRole="button"
-            onPress={() => router.push("/integration-setup")}
-            style={styles.cardButton}
-          >
-            <Text style={styles.buttonLabel}>{t("Connect apps")}</Text>
-          </Pressable>
-        ) : null}
-
         {!detailItem ? (
           <TextInput
             value={query}

--- a/apps/mobile/app/integrations.tsx
+++ b/apps/mobile/app/integrations.tsx
@@ -184,7 +184,11 @@ export default function Integrations() {
     const botId = lastBotId || (await loadLastBotId());
     if (!botId) return;
     if (botId !== lastBotId) setLastBotId(botId);
-    void rpc("onboarding/appConnected", { botId, provider: item.slug }).catch(() => undefined);
+    void rpc("onboarding/appConnected", {
+      botId,
+      provider: item.slug,
+      connectorId: item.connectorId,
+    }).catch(() => undefined);
   }
 
   async function connect(item: ConnectionCatalogItem) {

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -120,7 +120,7 @@ export default function SignIn() {
       } else {
         await signIn(email.trim(), password);
       }
-      router.replace("/");
+      router.replace(mode === "up" ? "/integration-setup" : "/");
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not continue"));
     } finally {

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -1,3 +1,4 @@
+import type { IntegrationSetupState } from "@rakazo/contracts";
 import { Redirect, useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import {
@@ -26,6 +27,7 @@ import {
   probeApiBase,
   requestPasswordReset,
   resetApiBase,
+  rpc,
   saveApiBase,
   signIn,
   signUp,
@@ -120,7 +122,11 @@ export default function SignIn() {
       } else {
         await signIn(email.trim(), password);
       }
-      router.replace(mode === "up" ? "/integration-setup" : "/");
+      const setup =
+        mode === "up"
+          ? await rpc<IntegrationSetupState>("integrationSetup/get").catch(() => null)
+          : null;
+      router.replace(setup?.needsSetup ? "/integration-setup" : "/");
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not continue"));
     } finally {

--- a/apps/mobile/components/AppConnectCard.tsx
+++ b/apps/mobile/components/AppConnectCard.tsx
@@ -39,6 +39,7 @@ export function AppConnectCard({
       const started = await rpc<{ connectionId: string; authorizationUrl: string | null }>(
         "connections/begin",
         {
+          connectorId: block.connectorId,
           provider: block.provider,
           displayName: block.name,
         },

--- a/apps/mobile/components/AppConnectCard.tsx
+++ b/apps/mobile/components/AppConnectCard.tsx
@@ -56,7 +56,11 @@ export function AppConnectCard({
         ).catch(() => undefined);
         if (row?.status === "connected") {
           if (controller.signal.aborted) return;
-          await rpc("onboarding/appConnected", { botId, provider: block.provider });
+          await rpc("onboarding/appConnected", {
+            botId,
+            provider: block.provider,
+            connectorId: block.connectorId,
+          });
           if (controller.signal.aborted) return;
           setLocalStatus("connected");
           return;

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -535,7 +535,14 @@ export type MobileBotSection = BotSection;
 
 export type MobileMe = Pick<
   Me,
-  "name" | "email" | "spaceId" | "defaultProvider" | "defaultModel" | "needsModel" | "avatarStyle"
+  | "name"
+  | "email"
+  | "spaceId"
+  | "defaultProvider"
+  | "defaultModel"
+  | "needsModel"
+  | "avatarStyle"
+  | "isDeploymentOwner"
 >;
 
 export type MobileModel = ModelCatalogEntry;

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -1,4 +1,17 @@
 export const ZH_MESSAGES: Record<string, string> = {
+  "Ask the server owner to configure this provider.": "请联系服务器所有者配置此服务。",
+  "Client ID": "客户端 ID",
+  "Client secret": "客户端密钥",
+  "Connect apps": "连接应用",
+  Continue: "继续",
+  "Could not verify or save these credentials": "无法验证或保存这些凭据",
+  "Direct MCP": "直连 MCP",
+  "Finish MCP authorization in the web app.": "请在网页应用中完成 MCP 授权。",
+  "Get credentials": "获取凭据",
+  "Open web app": "打开网页应用",
+  "Project ID": "项目 ID",
+  "Set up Executor on your server in the web app.": "请在网页应用中为服务器设置 Executor。",
+
   "Cloud agent": "云端智能体",
   "Pull request": "拉取请求",
   running: "运行中",

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -1,4 +1,5 @@
 export const ZH_MESSAGES: Record<string, string> = {
+  "Server integrations": "服务器集成",
   "Ask the server owner to configure this provider.": "请联系服务器所有者配置此服务。",
   "Client ID": "客户端 ID",
   "Client secret": "客户端密钥",

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -26,10 +26,16 @@ export async function rpc<T>(page: Page, procedure: string, body: unknown): Prom
 
 export async function completeOnboarding(page: Page, testInfo?: TestInfo) {
   await page.waitForURL(/\/(onboarding|app)/, { timeout: 20_000 });
-  const heading = page.getByRole("heading", { name: /Connect a model|Create your first bot/ });
+  const heading = page.getByRole("heading", {
+    name: /Connect a model|Connect apps|Create your first bot/,
+  });
   const chief = page.getByText("Chief").first();
   await heading.or(chief).waitFor({ timeout: 20_000 });
   if ((await chief.isVisible().catch(() => false)) && page.url().includes("/app")) return;
+  if (await page.getByRole("heading", { name: "Connect apps", exact: true }).isVisible()) {
+    if (testInfo) await captureScreenshot(page, testInfo, "02-connect-apps");
+    await page.getByRole("button", { name: "Skip", exact: true }).click();
+  }
   if (
     await page
       .getByRole("heading", { name: "Create your first bot" })

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -27,12 +27,12 @@ export async function rpc<T>(page: Page, procedure: string, body: unknown): Prom
 export async function completeOnboarding(page: Page, testInfo?: TestInfo) {
   await page.waitForURL(/\/(onboarding|app)/, { timeout: 20_000 });
   const heading = page.getByRole("heading", {
-    name: /Connect a model|Connect apps|Create your first bot/,
+    name: /Connect a model|Server integrations|Create your first bot/,
   });
   const chief = page.getByText("Chief").first();
   await heading.or(chief).waitFor({ timeout: 20_000 });
   if ((await chief.isVisible().catch(() => false)) && page.url().includes("/app")) return;
-  if (await page.getByRole("heading", { name: "Connect apps", exact: true }).isVisible()) {
+  if (await page.getByRole("heading", { name: "Server integrations", exact: true }).isVisible()) {
     if (testInfo) await captureScreenshot(page, testInfo, "02-connect-apps");
     await page.getByRole("button", { name: "Skip", exact: true }).click();
   }

--- a/apps/web/e2e/integration-setup.spec.ts
+++ b/apps/web/e2e/integration-setup.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, signup } from "./helpers";
+
+test("setup exposes all integration choices and saves only the selected provider", async ({
+  page,
+}, testInfo) => {
+  const saved: unknown[] = [];
+  await page.route("**/rpc/integrationSetup/get", (route) =>
+    route.fulfill({
+      json: {
+        json: {
+          canConfigure: true,
+          webUrl: "https://example.test/integrations/setup",
+          providers: [
+            { id: "composio", configured: false },
+            { id: "pipedream", configured: false },
+          ],
+        },
+      },
+    }),
+  );
+  await page.route("**/rpc/integrationSetup/save", (route) => {
+    saved.push(route.request().postDataJSON());
+    return route.fulfill({ json: { json: { ok: true } } });
+  });
+  await signup(page, `integration-setup-${Date.now()}@rakazo.test`, "password12", "Setup Test");
+  await expect(page.getByRole("heading", { name: "Connect apps" })).toBeVisible();
+  for (const name of ["Direct MCP", "Composio", "Pipedream", "Executor"]) {
+    await expect(page.getByRole("button", { name, exact: true })).toBeVisible();
+  }
+  await expect(page.getByLabel("API key", { exact: true })).toBeHidden();
+  await captureScreenshot(page, testInfo, "integration-setup-options");
+  await page.getByRole("button", { name: "Pipedream", exact: true }).click();
+  await expect(page.getByLabel("Client ID", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Project ID", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Client secret", { exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "integration-setup-pipedream");
+  await page.getByRole("button", { name: "Composio", exact: true }).click();
+  await page.getByLabel("API key", { exact: true }).fill("fake-composio-key");
+  await captureScreenshot(page, testInfo, "integration-setup-composio");
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Create your first bot" })).toBeVisible();
+  expect(saved).toEqual([{ json: { provider: "composio", apiKey: "fake-composio-key" } }]);
+});
+
+test("direct MCP connects a catalog result without asking for a URL and assigns it to the first bot", async ({
+  page,
+}, testInfo) => {
+  let serverId = "";
+  await page.route("**/rpc/capabilities/catalogSearch", (route) =>
+    route.fulfill({
+      json: {
+        json: {
+          enabled: true,
+          results: [
+            {
+              domain: "notion.example.test",
+              name: "Notion",
+              description: "",
+              pageUrl: null,
+              surfaces: [
+                {
+                  kind: "mcp",
+                  slug: "notion",
+                  source: "https://mcp.notion.example.test/mcp",
+                  auth: null,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    }),
+  );
+  await page.route("**/rpc/mcp/oauth/begin", (route) => {
+    serverId = route.request().postDataJSON().json.serverId;
+    return route.fulfill({ json: { json: { status: "already_connected" } } });
+  });
+  await signup(page, `direct-mcp-setup-${Date.now()}@rakazo.test`, "password12", "Direct MCP");
+  await page.getByRole("textbox", { name: "Search apps", exact: true }).fill("Notion");
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+  await expect(page.getByText("Notion", { exact: true })).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Server URL" })).toBeHidden();
+  await page.getByRole("button", { name: "Connect", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Connected", exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "integration-setup-direct-connected");
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await page.getByLabel("Name", { exact: true }).fill("Connected Bot");
+  const assigned = page.waitForResponse(
+    (response) => response.url().includes("/rpc/mcp/assignments/approve") && response.ok(),
+  );
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  const response = await assigned;
+  expect(response.request().postDataJSON().json.serverId).toBe(serverId);
+  await page.waitForURL(/\/app\//);
+});

--- a/apps/web/e2e/integration-setup.spec.ts
+++ b/apps/web/e2e/integration-setup.spec.ts
@@ -86,10 +86,24 @@ test("direct MCP connects a catalog result without asking for a URL and assigns 
   await captureScreenshot(page, testInfo, "integration-setup-direct-connected");
   await page.getByRole("button", { name: "Continue", exact: true }).click();
   await page.getByLabel("Name", { exact: true }).fill("Connected Bot");
+  let createCalls = 0;
+  let releaseCreate!: () => void;
+  const createGate = new Promise<void>((resolve) => {
+    releaseCreate = resolve;
+  });
+  await page.route("**/rpc/bots/create", async (route) => {
+    createCalls += 1;
+    await createGate;
+    await route.continue();
+  });
+
   const assigned = page.waitForResponse(
     (response) => response.url().includes("/rpc/mcp/assignments/approve") && response.ok(),
   );
   await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Continue", exact: true })).toBeDisabled();
+  await expect.poll(() => createCalls).toBe(1);
+  releaseCreate();
   const response = await assigned;
   expect(response.request().postDataJSON().json.serverId).toBe(serverId);
   await page.waitForURL(/\/app\//);

--- a/apps/web/e2e/integration-setup.spec.ts
+++ b/apps/web/e2e/integration-setup.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { captureScreenshot, signup } from "./helpers";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
 
 test("setup exposes all integration choices and saves only the selected provider", async ({
   page,
@@ -10,6 +10,7 @@ test("setup exposes all integration choices and saves only the selected provider
       json: {
         json: {
           canConfigure: true,
+          needsSetup: true,
           webUrl: "https://example.test/integrations/setup",
           providers: [
             { id: "composio", configured: false },
@@ -24,7 +25,7 @@ test("setup exposes all integration choices and saves only the selected provider
     return route.fulfill({ json: { json: { ok: true } } });
   });
   await signup(page, `integration-setup-${Date.now()}@rakazo.test`, "password12", "Setup Test");
-  await expect(page.getByRole("heading", { name: "Connect apps" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Server integrations" })).toBeVisible();
   for (const name of ["Direct MCP", "Composio", "Pipedream", "Executor"]) {
     await expect(page.getByRole("button", { name, exact: true })).toBeVisible();
   }
@@ -46,6 +47,18 @@ test("setup exposes all integration choices and saves only the selected provider
 test("direct MCP connects a catalog result without asking for a URL and assigns it to the first bot", async ({
   page,
 }, testInfo) => {
+  await page.route("**/rpc/integrationSetup/get", (route) =>
+    route.fulfill({
+      json: {
+        json: {
+          canConfigure: true,
+          needsSetup: true,
+          webUrl: "https://example.test/integrations/setup",
+          providers: [],
+        },
+      },
+    }),
+  );
   let serverId = "";
   await page.route("**/rpc/capabilities/catalogSearch", (route) =>
     route.fulfill({
@@ -110,8 +123,20 @@ test("direct MCP connects a catalog result without asking for a URL and assigns 
 });
 
 test("Executor reconnect saves a replacement token before authorization", async ({ page }) => {
+  await page.route("**/rpc/integrationSetup/get", (route) =>
+    route.fulfill({
+      json: {
+        json: {
+          canConfigure: true,
+          needsSetup: true,
+          webUrl: "https://example.test/integrations/setup",
+          providers: [],
+        },
+      },
+    }),
+  );
   await signup(page, `executor-reconnect-${Date.now()}@rakazo.test`, "password12", "Executor Test");
-  await expect(page.getByRole("heading", { name: "Connect apps" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Server integrations" })).toBeVisible();
   const server = await page.evaluate(async () => {
     const response = await fetch("/rpc/mcp/servers/create", {
       method: "POST",
@@ -158,4 +183,73 @@ test("Executor reconnect saves a replacement token before authorization", async 
   await page.getByRole("button", { name: "Connect", exact: true }).click();
   await expect.poll(() => saved).toBe(true);
   await expect(page.getByRole("alert")).toBeHidden();
+});
+
+test("remote members skip server setup and keep direct MCP connections", async ({
+  page,
+}, testInfo) => {
+  await page.route("**/rpc/integrationSetup/get", (route) =>
+    route.fulfill({
+      json: {
+        json: {
+          canConfigure: false,
+          needsSetup: false,
+          providers: [],
+          webUrl: "https://example.test/integrations/setup",
+        },
+      },
+    }),
+  );
+  await signup(page, `remote-member-${Date.now()}@rakazo.test`, "password12", "Remote Member");
+  await expect(page.getByRole("heading", { name: "Create your first bot" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Server integrations" })).toBeHidden();
+  await captureScreenshot(page, testInfo, "remote-member-onboarding");
+  await completeOnboarding(page);
+  await page.goto("/integrations/setup?mode=mcp");
+  await expect(page.getByRole("heading", { name: "Add MCP server" })).toBeVisible();
+  for (const name of ["Composio", "Pipedream", "Executor"]) {
+    await expect(page.getByRole("button", { name, exact: true })).toBeHidden();
+  }
+  await expect(page.getByRole("textbox", { name: "Search apps", exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "remote-member-mcp");
+  await page.goto("/integrations/setup");
+  await page.waitForURL(/\/app/);
+  await expect(page.getByRole("heading", { name: "Server integrations" })).toBeHidden();
+});
+
+test("configured server owners manage providers from settings", async ({ page }, testInfo) => {
+  await page.route("**/rpc/bootstrap", async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    await route.fulfill({
+      response,
+      json: { json: { ...body.json, me: { ...body.json.me, isDeploymentOwner: true } } },
+    });
+  });
+  await page.route("**/rpc/integrationSetup/get", (route) =>
+    route.fulfill({
+      json: {
+        json: {
+          canConfigure: true,
+          needsSetup: false,
+          providers: [{ id: "composio", configured: true }],
+          webUrl: "https://example.test/integrations/setup",
+        },
+      },
+    }),
+  );
+  await signup(page, `configured-owner-${Date.now()}@rakazo.test`, "password12", "Server Owner");
+  await expect(page.getByRole("heading", { name: "Create your first bot" })).toBeVisible();
+  await completeOnboarding(page);
+  await page.getByTestId("user-menu-trigger").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  const settings = page.getByTestId("user-settings");
+  const link = settings.getByRole("link", { name: "Server integrations", exact: true });
+  await expect(link).toBeVisible();
+  await captureScreenshot(page, testInfo, "server-integrations-settings");
+  await link.click();
+  await expect(page.getByRole("heading", { name: "Server integrations" })).toBeVisible();
+  await page.getByRole("button", { name: "Composio", exact: true }).click();
+  await expect(page.getByText("Connected", { exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "server-integrations-configured");
 });

--- a/apps/web/e2e/integration-setup.spec.ts
+++ b/apps/web/e2e/integration-setup.spec.ts
@@ -78,7 +78,7 @@ test("direct MCP connects a catalog result without asking for a URL and assigns 
   });
   await signup(page, `direct-mcp-setup-${Date.now()}@rakazo.test`, "password12", "Direct MCP");
   await page.getByRole("textbox", { name: "Search apps", exact: true }).fill("Notion");
-  await page.getByRole("button", { name: "Search", exact: true }).click();
+  await page.getByRole("button", { name: "Search integrations.sh", exact: true }).click();
   await expect(page.getByText("Notion", { exact: true })).toBeVisible();
   await expect(page.getByRole("textbox", { name: "Server URL" })).toBeHidden();
   await page.getByRole("button", { name: "Connect", exact: true }).click();
@@ -93,4 +93,55 @@ test("direct MCP connects a catalog result without asking for a URL and assigns 
   const response = await assigned;
   expect(response.request().postDataJSON().json.serverId).toBe(serverId);
   await page.waitForURL(/\/app\//);
+});
+
+test("Executor reconnect saves a replacement token before authorization", async ({ page }) => {
+  await signup(page, `executor-reconnect-${Date.now()}@rakazo.test`, "password12", "Executor Test");
+  await expect(page.getByRole("heading", { name: "Connect apps" })).toBeVisible();
+  const server = await page.evaluate(async () => {
+    const response = await fetch("/rpc/mcp/servers/create", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-rakazo-space-id": localStorage.getItem("rakazo:space-id") ?? "",
+      },
+      body: JSON.stringify({
+        json: {
+          slug: "existing-executor",
+          name: "Executor",
+          transport: "streamable_http",
+          endpoint: "http://localhost:8765/mcp",
+          secret: "fake-old-token",
+          headers: { "X-Test": "fake-header" },
+        },
+      }),
+    });
+    if (!response.ok) throw new Error(`Server creation failed: ${response.status}`);
+    return (await response.json()).json;
+  });
+  let saved = false;
+  await page.route("**/rpc/mcp/servers/update", async (route) => {
+    expect(route.request().postDataJSON()).toEqual({
+      json: { id: server.id, secret: "fake-new-token" },
+    });
+    const response = await route.fetch();
+    expect(response.ok()).toBe(true);
+    const updated = (await response.json()).json;
+    expect(updated.headerKeys).toEqual(["X-Test"]);
+    expect(updated.revision).toBe(server.revision + 1);
+    saved = true;
+    await route.fulfill({ response });
+  });
+  await page.route("**/rpc/mcp/oauth/begin", (route) => {
+    expect(saved).toBe(true);
+    return route.fulfill({ json: { json: { status: "already_connected" } } });
+  });
+  await page.getByRole("button", { name: "Executor", exact: true }).click();
+  await page
+    .getByRole("textbox", { name: "Server URL", exact: true })
+    .fill("http://localhost:8765/mcp");
+  await page.getByLabel("Access token", { exact: true }).fill("fake-new-token");
+  await page.getByRole("button", { name: "Connect", exact: true }).click();
+  await expect.poll(() => saved).toBe(true);
+  await expect(page.getByRole("alert")).toBeHidden();
 });

--- a/apps/web/e2e/onboarding-model-auto-skip.spec.ts
+++ b/apps/web/e2e/onboarding-model-auto-skip.spec.ts
@@ -13,6 +13,18 @@ test("onboarding skips model connect when a default model is already available",
     });
   });
 
+  await page.route("**/rpc/integrationSetup/get", (route) =>
+    route.fulfill({
+      json: {
+        json: {
+          canConfigure: false,
+          needsSetup: false,
+          webUrl: "https://example.test/integrations/setup",
+          providers: [],
+        },
+      },
+    }),
+  );
   const stamp = Date.now();
   await signup(
     page,
@@ -21,9 +33,13 @@ test("onboarding skips model connect when a default model is already available",
     `Model auto skip ${stamp}`,
   );
 
-  await expect(page.getByRole("heading", { name: "Connect apps" })).toBeVisible({
+  await expect(page.getByRole("heading", { name: "Create your first bot" })).toBeVisible({
     timeout: 20_000,
   });
+  await expect(page.getByRole("heading", { name: "Server integrations" })).toBeHidden();
+  for (const name of ["Composio", "Pipedream", "Executor"]) {
+    await expect(page.getByRole("button", { name, exact: true })).toBeHidden();
+  }
   await expect(page.getByRole("heading", { name: "Connect a model" })).toBeHidden();
   await expect(page.getByRole("button", { name: "Skip for now" })).toBeHidden();
   await captureScreenshot(page, testInfo, "onboarding-model-auto-skip");

--- a/apps/web/e2e/onboarding-model-auto-skip.spec.ts
+++ b/apps/web/e2e/onboarding-model-auto-skip.spec.ts
@@ -21,7 +21,7 @@ test("onboarding skips model connect when a default model is already available",
     `Model auto skip ${stamp}`,
   );
 
-  await expect(page.getByRole("heading", { name: "Create your first bot" })).toBeVisible({
+  await expect(page.getByRole("heading", { name: "Connect apps" })).toBeVisible({
     timeout: 20_000,
   });
   await expect(page.getByRole("heading", { name: "Connect a model" })).toBeHidden();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Button, Skeleton } from "@rakazo/ui-web";
 import { lazy, Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useSearchParams } from "react-router-dom";
 import { LoadingState } from "./components/ai/primitives";
 import { authClient } from "./lib/auth";
 import { markAfterPaint, markOnce } from "./lib/performance";
@@ -11,6 +11,7 @@ import {
   sessionRetryDelayMs,
   showSessionUnavailable,
 } from "./lib/session-gate";
+import { IntegrationSetupPage } from "./pages/IntegrationSetup";
 import { McpOAuthCallbackPage } from "./pages/McpOAuthCallback";
 import { ShellPage } from "./pages/Shell";
 
@@ -28,6 +29,9 @@ const WelcomePage = lazy(() =>
 );
 
 export function App() {
+  const [searchParams] = useSearchParams();
+  const signInDestination =
+    searchParams.get("next") === "/integrations/setup" ? "/integrations/setup" : "/app";
   const session = authClient.useSession();
   const gate = sessionGate(session);
   const [holdingUnreachable, setHoldingUnreachable] = useState(false);
@@ -64,7 +68,9 @@ export function App() {
           <Route path="/" element={user ? <Navigate to="/app" replace /> : <WelcomePage />} />
           <Route
             path="/sign-in"
-            element={user ? <Navigate to="/app" replace /> : <AuthPage key="in" mode="in" />}
+            element={
+              user ? <Navigate to={signInDestination} replace /> : <AuthPage key="in" mode="in" />
+            }
           />
           <Route
             path="/sign-up"
@@ -84,6 +90,16 @@ export function App() {
           <Route
             path="/mcp/oauth/callback"
             element={user ? <McpOAuthCallbackPage /> : <Navigate to="/sign-in" replace />}
+          />
+          <Route
+            path="/integrations/setup"
+            element={
+              user ? (
+                <IntegrationSetupPage />
+              ) : (
+                <Navigate to="/sign-in?next=/integrations/setup" replace />
+              )
+            }
           />
           <Route path="/app" element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />} />
           <Route

--- a/apps/web/src/components/integrations/IntegrationSetup.tsx
+++ b/apps/web/src/components/integrations/IntegrationSetup.tsx
@@ -104,6 +104,9 @@ export function IntegrationSetup({
           endpoint: url,
           ...(apiKey.trim() ? { secret: apiKey.trim() } : {}),
         }));
+      if (existing && apiKey.trim()) {
+        await rpc.mcp.servers.update({ id: existing.id, secret: apiKey.trim() });
+      }
       const result = await connectMcpOauth(server.id);
       if (result === "cancelled") return;
       if (botId) await rpc.mcp.assignments.approve({ botId, serverId: server.id });
@@ -215,7 +218,10 @@ export function IntegrationSetup({
             onSubmit={(event) => {
               event.preventDefault();
               void run(async () => {
-                const response = await rpc.capabilities.catalogSearch({ query });
+                const response = await rpc.capabilities.catalogSearch({
+                  query,
+                  usePublicCatalog: true,
+                });
                 setResults(response.results);
                 setSearched(true);
               });
@@ -228,7 +234,7 @@ export function IntegrationSetup({
               onChange={(event) => setQuery(event.target.value)}
             />
             <Button type="submit" disabled={busy || !query.trim()}>
-              <Trans>Search</Trans>
+              <Trans>Search integrations.sh</Trans>
             </Button>
           </form>
           {remoteResults.map((result) => (

--- a/apps/web/src/components/integrations/IntegrationSetup.tsx
+++ b/apps/web/src/components/integrations/IntegrationSetup.tsx
@@ -1,0 +1,345 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { IntegrationCatalogResult, IntegrationSetupState } from "@rakazo/contracts";
+import { Button, Input } from "@rakazo/ui-web";
+import { Check } from "lucide-react";
+import { useEffect, useId, useState } from "react";
+import { connectMcpOauth } from "../../lib/mcp-connect";
+import { rpc } from "../../lib/rpc";
+
+type Choice = "direct" | "composio" | "pipedream" | "executor";
+
+export function IntegrationSetup({
+  onDone,
+  botId,
+  onServerConnected,
+}: {
+  onDone?: () => void;
+  botId?: string;
+  onServerConnected?: (id: string) => void;
+}) {
+  const { t } = useLingui();
+  const fieldId = useId();
+  const [state, setState] = useState<IntegrationSetupState | null>(null);
+  const [choice, setChoice] = useState<Choice>("direct");
+  const [apiKey, setApiKey] = useState("");
+  const [clientId, setClientId] = useState("");
+  const [projectId, setProjectId] = useState("");
+  const [endpoint, setEndpoint] = useState("");
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<IntegrationCatalogResult[]>([]);
+  const [searched, setSearched] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [connected, setConnected] = useState<string[]>([]);
+  const choices: { id: Choice; label: string }[] = [
+    { id: "direct", label: t`Direct MCP` },
+    { id: "composio", label: "Composio" },
+    { id: "pipedream", label: "Pipedream" },
+    { id: "executor", label: "Executor" },
+  ];
+  const managed = choice === "composio" || choice === "pipedream";
+  const hasCredentials = Boolean(apiKey.trim());
+  const credentialsReady =
+    hasCredentials && (choice !== "pipedream" || Boolean(clientId.trim() && projectId.trim()));
+  const remoteResults = [
+    ...new Map(
+      results.flatMap((result) =>
+        result.surfaces
+          .filter((surface) => surface.kind === "mcp" && surface.source?.startsWith("https://"))
+          .map(
+            (surface) =>
+              [surface.source!, { name: result.name, endpoint: surface.source! }] as const,
+          ),
+      ),
+    ).values(),
+  ];
+  const configured = state?.providers.find((provider) => provider.id === choice)?.configured;
+  useEffect(() => {
+    void rpc.integrationSetup
+      .get()
+      .then(setState)
+      .catch(() => setError(t`Could not load integrations`));
+  }, []);
+
+  async function run(action: () => Promise<void>) {
+    setBusy(true);
+    setError(null);
+    try {
+      await action();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t`Could not connect`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function saveProvider() {
+    await run(async () => {
+      await rpc.integrationSetup.save(
+        choice === "composio"
+          ? { provider: "composio", apiKey }
+          : {
+              provider: "pipedream",
+              clientId,
+              clientSecret: apiKey,
+              projectId,
+              environment: "production",
+            },
+      );
+      setApiKey("");
+      setState(await rpc.integrationSetup.get());
+      onDone?.();
+    });
+  }
+
+  async function connect(name: string, url: string) {
+    await run(async () => {
+      const existing = (await rpc.mcp.servers.list()).find((server) => server.endpoint === url);
+      const server =
+        existing ??
+        (await rpc.mcp.servers.create({
+          slug: `integration-${crypto.randomUUID().slice(0, 8)}`,
+          name,
+          transport: "streamable_http",
+          endpoint: url,
+          ...(apiKey.trim() ? { secret: apiKey.trim() } : {}),
+        }));
+      const result = await connectMcpOauth(server.id);
+      if (result === "cancelled") return;
+      if (botId) await rpc.mcp.assignments.approve({ botId, serverId: server.id });
+      setConnected((current) => [...current, url]);
+      onServerConnected?.(server.id);
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-[32px] font-medium text-foreground">
+        <Trans>Connect apps</Trans>
+      </h1>
+      <fieldset
+        aria-label={t`Integration options`}
+        className="overflow-hidden rounded-xl border border-border"
+      >
+        {choices.map(({ id, label }) => (
+          <button
+            key={id}
+            type="button"
+            aria-pressed={choice === id}
+            disabled={busy}
+            onClick={() => {
+              setChoice(id);
+              setApiKey("");
+              setError(null);
+            }}
+            className={`flex min-h-11 w-full items-center justify-between border-b border-border px-3.5 py-2.5 text-left last:border-0 ${choice === id ? "bg-muted" : "hover:bg-accent"}`}
+          >
+            <span>{label}</span>
+            {choice === id ? <Check className="size-4" aria-hidden /> : null}
+          </button>
+        ))}
+      </fieldset>
+      {choice === "composio" || choice === "pipedream" ? (
+        <>
+          {configured ? (
+            <p className="text-sm text-success">
+              <Trans>Connected</Trans>
+            </p>
+          ) : null}
+          {state?.canConfigure ? (
+            <>
+              {choice === "pipedream" ? (
+                <>
+                  <label htmlFor={`${fieldId}-client-id`} className="block text-sm">
+                    <Trans>Client ID</Trans>
+                    <Input
+                      id={`${fieldId}-client-id`}
+                      className="mt-2"
+                      value={clientId}
+                      onChange={(event) => setClientId(event.target.value)}
+                      autoComplete="off"
+                    />
+                  </label>
+                  <label htmlFor={`${fieldId}-project-id`} className="block text-sm">
+                    <Trans>Project ID</Trans>
+                    <Input
+                      id={`${fieldId}-project-id`}
+                      className="mt-2"
+                      value={projectId}
+                      onChange={(event) => setProjectId(event.target.value)}
+                      autoComplete="off"
+                    />
+                  </label>
+                </>
+              ) : null}
+              <label htmlFor={`${fieldId}-key`} className="block text-sm">
+                {choice === "composio" ? t`API key` : t`Client secret`}
+                <Input
+                  id={`${fieldId}-key`}
+                  className="mt-2"
+                  type="password"
+                  value={apiKey}
+                  onChange={(event) => setApiKey(event.target.value)}
+                  autoComplete="new-password"
+                />
+              </label>
+              <a
+                className="text-sm text-muted-foreground underline"
+                href={
+                  choice === "composio"
+                    ? "https://dashboard.composio.dev"
+                    : "https://pipedream.com/docs/connect/mcp/developers"
+                }
+                target="_blank"
+                rel="noreferrer"
+              >
+                <Trans>Get credentials</Trans>
+              </a>
+              {!onDone ? (
+                <Button disabled={busy || !credentialsReady} onClick={() => void saveProvider()}>
+                  {busy ? t`Connecting…` : t`Connect`}
+                </Button>
+              ) : null}
+            </>
+          ) : state && !configured ? (
+            <p className="text-sm text-muted-foreground">
+              <Trans>Ask the server owner to configure this provider.</Trans>
+            </p>
+          ) : null}
+        </>
+      ) : null}
+      {choice === "direct" ? (
+        <>
+          <form
+            className="flex gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void run(async () => {
+                const response = await rpc.capabilities.catalogSearch({ query });
+                setResults(response.results);
+                setSearched(true);
+              });
+            }}
+          >
+            <Input
+              aria-label={t`Search apps`}
+              placeholder={t`Search apps`}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+            <Button type="submit" disabled={busy || !query.trim()}>
+              <Trans>Search</Trans>
+            </Button>
+          </form>
+          {remoteResults.map((result) => (
+            <div key={result.endpoint} className="flex items-center justify-between gap-3">
+              <span className="min-w-0 truncate">{result.name}</span>
+              <Button
+                variant="outline"
+                disabled={busy || connected.includes(result.endpoint)}
+                onClick={() => void connect(result.name, result.endpoint)}
+              >
+                {connected.includes(result.endpoint) ? t`Connected` : t`Connect`}
+              </Button>
+            </div>
+          ))}
+          {searched && !remoteResults.length ? (
+            <p className="text-sm text-muted-foreground">
+              <Trans>No remote MCP servers found</Trans>
+            </p>
+          ) : null}
+          <details className="text-sm text-muted-foreground">
+            <summary className="cursor-pointer">
+              <Trans>Add server URL</Trans>
+            </summary>
+            <div className="mt-3 space-y-3">
+              <Input
+                aria-label={t`Server URL`}
+                value={endpoint}
+                onChange={(event) => setEndpoint(event.target.value)}
+                placeholder="https://example.com/mcp"
+              />
+              <Button
+                disabled={busy || !endpoint.trim()}
+                onClick={() => void connect("MCP server", endpoint.trim())}
+              >
+                <Trans>Connect</Trans>
+              </Button>
+            </div>
+          </details>
+        </>
+      ) : null}
+      {choice === "executor" ? (
+        <div className="space-y-3">
+          <label htmlFor={`${fieldId}-endpoint`} className="block text-sm">
+            <Trans>Server URL</Trans>
+            <Input
+              id={`${fieldId}-endpoint`}
+              className="mt-2"
+              value={endpoint}
+              onChange={(event) => setEndpoint(event.target.value)}
+              placeholder="http://localhost:8000/mcp"
+            />
+          </label>
+          <label htmlFor={`${fieldId}-token`} className="block text-sm">
+            <Trans>Access token</Trans>
+            <Input
+              id={`${fieldId}-token`}
+              className="mt-2"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+              type="password"
+              autoComplete="new-password"
+            />
+          </label>
+          <Button
+            disabled={busy || !endpoint.trim()}
+            onClick={() => void connect("Executor", endpoint.trim())}
+          >
+            <Trans>Connect</Trans>
+          </Button>
+          <details className="text-sm text-muted-foreground">
+            <summary className="cursor-pointer">
+              <Trans>Setup help</Trans>
+            </summary>
+            <a
+              href="https://executor.sh/#get-started"
+              target="_blank"
+              rel="noreferrer"
+              className="mt-2 block underline"
+            >
+              <Trans>Download Executor</Trans>
+            </a>
+          </details>
+        </div>
+      ) : null}
+      {error ? (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+      {onDone ? (
+        <div className="flex gap-3">
+          <Button
+            disabled={
+              busy ||
+              (managed &&
+                state?.canConfigure &&
+                !credentialsReady &&
+                (!configured || hasCredentials))
+            }
+            onClick={() => {
+              if (managed && hasCredentials) void saveProvider();
+              else onDone();
+            }}
+          >
+            {busy ? t`Connecting…` : t`Continue`}
+          </Button>
+          <Button variant="ghost" disabled={busy} onClick={onDone}>
+            <Trans>Skip</Trans>
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/IntegrationSetup.tsx
+++ b/apps/web/src/components/integrations/IntegrationSetup.tsx
@@ -10,17 +10,22 @@ type Choice = "direct" | "composio" | "pipedream" | "executor";
 
 export function IntegrationSetup({
   onDone,
+  serverSetup = false,
+  initialState,
   botId,
   onServerConnected,
 }: {
   onDone?: () => void;
+  serverSetup?: boolean;
+  initialState?: IntegrationSetupState | null;
   botId?: string;
   onServerConnected?: (id: string) => void;
 }) {
   const { t } = useLingui();
   const fieldId = useId();
-  const [state, setState] = useState<IntegrationSetupState | null>(null);
-  const [choice, setChoice] = useState<Choice>("direct");
+  const [state, setState] = useState<IntegrationSetupState | null>(initialState ?? null);
+  const [selectedChoice, setChoice] = useState<Choice>("direct");
+  const choice = serverSetup ? selectedChoice : "direct";
   const [apiKey, setApiKey] = useState("");
   const [clientId, setClientId] = useState("");
   const [projectId, setProjectId] = useState("");
@@ -55,11 +60,12 @@ export function IntegrationSetup({
   ];
   const configured = state?.providers.find((provider) => provider.id === choice)?.configured;
   useEffect(() => {
+    if (!serverSetup || initialState) return;
     void rpc.integrationSetup
       .get()
       .then(setState)
       .catch(() => setError(t`Could not load integrations`));
-  }, []);
+  }, [serverSetup, initialState]);
 
   async function run(action: () => Promise<void>) {
     setBusy(true);
@@ -115,33 +121,37 @@ export function IntegrationSetup({
     });
   }
 
+  if (serverSetup && !state?.canConfigure) return error ? <p role="alert">{error}</p> : null;
+
   return (
     <div className="space-y-6">
       <h1 className="text-[32px] font-medium text-foreground">
-        <Trans>Connect apps</Trans>
+        {serverSetup ? t`Server integrations` : t`Add MCP server`}
       </h1>
-      <fieldset
-        aria-label={t`Integration options`}
-        className="overflow-hidden rounded-xl border border-border"
-      >
-        {choices.map(({ id, label }) => (
-          <button
-            key={id}
-            type="button"
-            aria-pressed={choice === id}
-            disabled={busy}
-            onClick={() => {
-              setChoice(id);
-              setApiKey("");
-              setError(null);
-            }}
-            className={`flex min-h-11 w-full items-center justify-between border-b border-border px-3.5 py-2.5 text-left last:border-0 ${choice === id ? "bg-muted" : "hover:bg-accent"}`}
-          >
-            <span>{label}</span>
-            {choice === id ? <Check className="size-4" aria-hidden /> : null}
-          </button>
-        ))}
-      </fieldset>
+      {serverSetup ? (
+        <fieldset
+          aria-label={t`Integration options`}
+          className="overflow-hidden rounded-xl border border-border"
+        >
+          {choices.map(({ id, label }) => (
+            <button
+              key={id}
+              type="button"
+              aria-pressed={choice === id}
+              disabled={busy}
+              onClick={() => {
+                setChoice(id);
+                setApiKey("");
+                setError(null);
+              }}
+              className={`flex min-h-11 w-full items-center justify-between border-b border-border px-3.5 py-2.5 text-left last:border-0 ${choice === id ? "bg-muted" : "hover:bg-accent"}`}
+            >
+              <span>{label}</span>
+              {choice === id ? <Check className="size-4" aria-hidden /> : null}
+            </button>
+          ))}
+        </fieldset>
+      ) : null}
       {choice === "composio" || choice === "pipedream" ? (
         <>
           {configured ? (

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -20,6 +20,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { Link } from "react-router-dom";
 import { ApprovalRulesSettings } from "../components/ApprovalRulesSettings";
 import { SuccessPop } from "../components/ai/primitives";
 import {
@@ -217,6 +218,12 @@ export function AccountSettingsOverlay({
             <Trans>Model spend uses your provider keys.</Trans>
           </p>
         </div>
+
+        {isDeploymentOwner ? (
+          <Button className="mt-5" variant="outline" render={<Link to="/integrations/setup" />}>
+            <Trans>Server integrations</Trans>
+          </Button>
+        ) : null}
 
         <DesktopUpdateSection />
         <SoftwareUpdateSection isDeploymentOwner={isDeploymentOwner} />

--- a/apps/web/src/pages/Auth.tsx
+++ b/apps/web/src/pages/Auth.tsx
@@ -104,7 +104,13 @@ export function AuthPage({ mode }: { mode: AuthMode }) {
         return;
       }
       clearSpaceSelection();
-      navigate(mode === "up" ? "/onboarding" : "/app");
+      navigate(
+        mode === "up"
+          ? "/onboarding"
+          : searchParams.get("next") === "/integrations/setup"
+            ? "/integrations/setup"
+            : "/app",
+      );
     } catch {
       setError(t`Could not reach the server`);
     } finally {

--- a/apps/web/src/pages/IntegrationSetup.tsx
+++ b/apps/web/src/pages/IntegrationSetup.tsx
@@ -1,32 +1,48 @@
 import { useLingui } from "@lingui/react/macro";
-import type { Bot } from "@rakazo/contracts";
+import type { Bot, IntegrationSetupState } from "@rakazo/contracts";
 import { NativeSelect, NativeSelectOption } from "@rakazo/ui-web";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { IntegrationSetup } from "../components/integrations/IntegrationSetup";
 import { rpc } from "../lib/rpc";
 
 export function IntegrationSetupPage() {
   const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const serverSetup = params.get("mode") !== "mcp";
   const { t } = useLingui();
   const [bots, setBots] = useState<Bot[]>([]);
   const [botId, setBotId] = useState("");
   const [ready, setReady] = useState(false);
+  const [setupState, setSetupState] = useState<IntegrationSetupState | null>(null);
   const [error, setError] = useState(false);
   useEffect(() => {
-    void rpc.bots
-      .list()
-      .then((rows) => {
+    setReady(false);
+    setError(false);
+    let cancelled = false;
+    void Promise.all([rpc.bots.list(), serverSetup ? rpc.integrationSetup.get() : null])
+      .then(([rows, setup]) => {
+        if (cancelled) return;
+        if (serverSetup && !setup?.canConfigure) {
+          navigate("/app", { replace: true });
+          return;
+        }
         if (!rows.length) {
           navigate("/onboarding", { replace: true });
           return;
         }
+        setSetupState(setup);
         setBots(rows);
         setBotId(rows[0]?.id ?? "");
         setReady(true);
       })
-      .catch(() => setError(true));
-  }, []);
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [serverSetup, navigate]);
   return (
     <div className="min-h-full bg-background px-6 py-12">
       <div className="mx-auto max-w-[560px]">
@@ -46,6 +62,9 @@ export function IntegrationSetupPage() {
         ) : null}
         {ready ? (
           <IntegrationSetup
+            key={serverSetup ? "server" : "mcp"}
+            serverSetup={serverSetup}
+            initialState={setupState}
             botId={botId || undefined}
             onDone={() => navigate(bots.length ? "/app" : "/onboarding")}
           />

--- a/apps/web/src/pages/IntegrationSetup.tsx
+++ b/apps/web/src/pages/IntegrationSetup.tsx
@@ -1,0 +1,58 @@
+import { useLingui } from "@lingui/react/macro";
+import type { Bot } from "@rakazo/contracts";
+import { NativeSelect, NativeSelectOption } from "@rakazo/ui-web";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { IntegrationSetup } from "../components/integrations/IntegrationSetup";
+import { rpc } from "../lib/rpc";
+
+export function IntegrationSetupPage() {
+  const navigate = useNavigate();
+  const { t } = useLingui();
+  const [bots, setBots] = useState<Bot[]>([]);
+  const [botId, setBotId] = useState("");
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState(false);
+  useEffect(() => {
+    void rpc.bots
+      .list()
+      .then((rows) => {
+        if (!rows.length) {
+          navigate("/onboarding", { replace: true });
+          return;
+        }
+        setBots(rows);
+        setBotId(rows[0]?.id ?? "");
+        setReady(true);
+      })
+      .catch(() => setError(true));
+  }, []);
+  return (
+    <div className="min-h-full bg-background px-6 py-12">
+      <div className="mx-auto max-w-[560px]">
+        {bots.length > 1 ? (
+          <NativeSelect
+            aria-label={t`Bot`}
+            value={botId}
+            onChange={(event) => setBotId(event.target.value)}
+            className="mb-6 w-full"
+          >
+            {bots.map((bot) => (
+              <NativeSelectOption key={bot.id} value={bot.id}>
+                {bot.name}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        ) : null}
+        {ready ? (
+          <IntegrationSetup
+            botId={botId || undefined}
+            onDone={() => navigate(bots.length ? "/app" : "/onboarding")}
+          />
+        ) : (
+          <p>{error ? t`Could not load bots. Reload to try again.` : t`Loading…`}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -32,6 +32,8 @@ export function OnboardingPage() {
   const navigate = useNavigate();
   const fieldId = useId();
   const [step, setStep] = useState<"loading" | "model" | "integrations" | "bot">("loading");
+  const creatingBot = useRef(false);
+  const [creating, setCreating] = useState(false);
   const createdBot = useRef<Awaited<ReturnType<typeof rpc.bots.create>> | null>(null);
   const [integrationServers, setIntegrationServers] = useState<string[]>([]);
   const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
@@ -210,6 +212,9 @@ export function OnboardingPage() {
   }
 
   async function createBot() {
+    if (creatingBot.current) return;
+    creatingBot.current = true;
+    setCreating(true);
     setError(null);
     try {
       const bot =
@@ -237,6 +242,9 @@ export function OnboardingPage() {
       navigate(`/app/${bot.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : t`Could not create your bot`);
+    } finally {
+      creatingBot.current = false;
+      setCreating(false);
     }
   }
 
@@ -626,7 +634,11 @@ export function OnboardingPage() {
               />
             </label>
             {error ? <p className="mt-3 text-sm text-destructive">{error}</p> : null}
-            <Button className="mt-6" disabled={!name.trim()} onClick={() => void createBot()}>
+            <Button
+              className="mt-6"
+              disabled={creating || !name.trim()}
+              onClick={() => void createBot()}
+            >
               <Trans>Continue</Trans>
             </Button>
           </div>

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -19,8 +19,9 @@ import {
   Textarea,
 } from "@rakazo/ui-web";
 import { Check } from "lucide-react";
-import { useEffect, useId, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { IntegrationSetup } from "../components/integrations/IntegrationSetup";
 import { localizedProviderHint } from "../lib/localized-provider-hint";
 import type { ModelCatalogEntry } from "../lib/model-auth";
 import { rpc } from "../lib/rpc";
@@ -30,7 +31,9 @@ export function OnboardingPage() {
   const { t } = useLingui();
   const navigate = useNavigate();
   const fieldId = useId();
-  const [step, setStep] = useState<"loading" | "model" | "bot">("loading");
+  const [step, setStep] = useState<"loading" | "model" | "integrations" | "bot">("loading");
+  const createdBot = useRef<Awaited<ReturnType<typeof rpc.bots.create>> | null>(null);
+  const [integrationServers, setIntegrationServers] = useState<string[]>([]);
   const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
   const [query, setQuery] = useState("");
   const [showAllProviders, setShowAllProviders] = useState(false);
@@ -61,7 +64,7 @@ export function OnboardingPage() {
     onClearError: () => setError(null),
     onError: setError,
     onFinished: () => {
-      setStep("bot");
+      setStep("integrations");
     },
   });
 
@@ -79,9 +82,9 @@ export function OnboardingPage() {
           setProvider(preferred.provider);
           setModelId(preferred.provider === OPENAI_COMPATIBLE_PROVIDER_ID ? "" : preferred.id);
         }
-        setStep(me.needsModel ? "model" : "bot");
+        setStep(me.needsModel ? "model" : "integrations");
       })
-      .catch(() => setStep("bot"));
+      .catch(() => setStep("integrations"));
     return () => {
       modelProbe.invalidate();
     };
@@ -192,7 +195,7 @@ export function OnboardingPage() {
           label: selected?.providerName ?? provider,
         });
       }
-      setStep("bot");
+      setStep("integrations");
     } catch (err) {
       setError(err instanceof Error ? err.message : t`Could not save model`);
     }
@@ -209,13 +212,19 @@ export function OnboardingPage() {
   async function createBot() {
     setError(null);
     try {
-      const bot = await rpc.bots.create({
-        name: name.trim(),
-        title,
-        description,
-        instructions: description,
-        notifyOnFinish: true,
-      });
+      const bot =
+        createdBot.current ??
+        (await rpc.bots.create({
+          name: name.trim(),
+          title,
+          description,
+          instructions: description,
+          notifyOnFinish: true,
+        }));
+      createdBot.current = bot;
+      for (const serverId of integrationServers) {
+        await rpc.mcp.assignments.approve({ botId: bot.id, serverId });
+      }
       // Onboarding continues conversationally in the thread: greeting first,
       // then the focus choice (immediate for the first bot).
       const started = await rpc.onboarding
@@ -565,6 +574,14 @@ export function OnboardingPage() {
               </Button>
             </div>
           </div>
+        ) : null}
+        {step === "integrations" ? (
+          <IntegrationSetup
+            onDone={() => setStep("bot")}
+            onServerConnected={(id) =>
+              setIntegrationServers((current) => [...new Set([...current, id])])
+            }
+          />
         ) : null}
         {step === "bot" ? (
           <div>

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -1,5 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
+  type IntegrationSetupState,
   OPENAI_COMPATIBLE_PROVIDER_ID,
   openAiCompatibleConnectReady,
   openAiCompatibleProbeSuccessMessage,
@@ -32,6 +33,8 @@ export function OnboardingPage() {
   const navigate = useNavigate();
   const fieldId = useId();
   const [step, setStep] = useState<"loading" | "model" | "integrations" | "bot">("loading");
+  const [integrationSetup, setIntegrationSetup] = useState<IntegrationSetupState | null>(null);
+  const needsIntegrationSetup = integrationSetup?.needsSetup ?? false;
   const creatingBot = useRef(false);
   const [creating, setCreating] = useState(false);
   const createdBot = useRef<Awaited<ReturnType<typeof rpc.bots.create>> | null>(null);
@@ -66,13 +69,18 @@ export function OnboardingPage() {
     onClearError: () => setError(null),
     onError: setError,
     onFinished: () => {
-      setStep("integrations");
+      setStep(needsIntegrationSetup ? "integrations" : "bot");
     },
   });
 
   useEffect(() => {
-    void Promise.all([rpc.me(), rpc.models.list().catch(() => [])])
-      .then(([me, models]) => {
+    void Promise.all([
+      rpc.me(),
+      rpc.models.list().catch(() => []),
+      rpc.integrationSetup.get().catch(() => null),
+    ])
+      .then(([me, models, integrations]) => {
+        setIntegrationSetup(integrations);
         setCatalog(models);
         const preferred =
           models.find(
@@ -84,9 +92,9 @@ export function OnboardingPage() {
           setProvider(preferred.provider);
           setModelId(preferred.provider === OPENAI_COMPATIBLE_PROVIDER_ID ? "" : preferred.id);
         }
-        setStep(me.needsModel ? "model" : "integrations");
+        setStep(me.needsModel ? "model" : integrations?.needsSetup ? "integrations" : "bot");
       })
-      .catch(() => setStep("integrations"));
+      .catch(() => setStep("bot"));
     return () => {
       modelProbe.invalidate();
     };
@@ -197,7 +205,7 @@ export function OnboardingPage() {
           label: selected?.providerName ?? provider,
         });
       }
-      setStep("integrations");
+      setStep(needsIntegrationSetup ? "integrations" : "bot");
     } catch (err) {
       setError(err instanceof Error ? err.message : t`Could not save model`);
     }
@@ -585,6 +593,8 @@ export function OnboardingPage() {
         ) : null}
         {step === "integrations" ? (
           <IntegrationSetup
+            serverSetup
+            initialState={integrationSetup}
             onDone={() => setStep("bot")}
             onServerConnected={(id) =>
               setIntegrationServers((current) => [...new Set([...current, id])])

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -31,6 +31,7 @@ import {
 } from "@rakazo/ui-web";
 import { ChevronDown, ChevronLeft, ChevronUp, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { IntegrationSetup } from "../components/integrations/IntegrationSetup";
 import { optionalCatalogFeedProbe } from "../lib/optional-catalog-feed";
 import { rpc } from "../lib/rpc";
 
@@ -78,6 +79,7 @@ export function PluginsOverlay({
   activeBotId?: string;
 }) {
   const { t } = useLingui();
+  const [setupOpen, setSetupOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [visibleCount, setVisibleCount] = useState(CONNECTION_CATALOG_PAGE_SIZE);
   const [catalog, setCatalog] = useState<ConnectionCatalogItem[]>([]);
@@ -699,6 +701,24 @@ export function PluginsOverlay({
         ) : null}
 
         <div id="integration-list" className="rk-scroll flex-1 overflow-y-auto px-8 py-6">
+          <Button
+            variant="outline"
+            className="mb-4"
+            onClick={() => setSetupOpen((current) => !current)}
+          >
+            <Trans>Connect apps</Trans>
+          </Button>
+          {setupOpen ? (
+            <div className="mb-6">
+              <IntegrationSetup
+                botId={activeBotId}
+                onDone={() => {
+                  setSetupOpen(false);
+                  void refresh();
+                }}
+              />
+            </div>
+          ) : null}
           {catalogError ? <p className="mb-4 text-sm text-destructive">{catalogError}</p> : null}
 
           {detailItem ? (

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -706,7 +706,7 @@ export function PluginsOverlay({
             className="mb-4"
             onClick={() => setSetupOpen((current) => !current)}
           >
-            <Trans>Add MCP server</Trans>
+            <Trans>Browse MCP servers</Trans>
           </Button>
           {setupOpen ? (
             <div className="mb-6">

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -706,7 +706,7 @@ export function PluginsOverlay({
             className="mb-4"
             onClick={() => setSetupOpen((current) => !current)}
           >
-            <Trans>Connect apps</Trans>
+            <Trans>Add MCP server</Trans>
           </Button>
           {setupOpen ? (
             <div className="mb-6">

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -205,7 +205,7 @@ export function PluginsOverlay({
   async function notifyAppConnected(item: ConnectionCatalogItem) {
     if (!activeBotId) return;
     await rpc.onboarding
-      .appConnected({ botId: activeBotId, provider: item.slug })
+      .appConnected({ botId: activeBotId, provider: item.slug, connectorId: item.connectorId })
       .catch(() => undefined);
   }
 
@@ -714,7 +714,11 @@ export function PluginsOverlay({
                 botId={activeBotId}
                 onDone={() => {
                   setSetupOpen(false);
-                  void refresh();
+                  void refresh().catch((err: unknown) =>
+                    setCatalogError(
+                      err instanceof Error ? err.message : t`Could not load integrations`,
+                    ),
+                  );
                 }}
               />
             </div>

--- a/apps/web/src/pages/shell/message-cards.tsx
+++ b/apps/web/src/pages/shell/message-cards.tsx
@@ -141,7 +141,7 @@ export function AppConnectCard({
           if (controller.signal.aborted) return;
           setLocalStatus("connected");
           await rpc.onboarding
-            .appConnected({ botId, provider: block.provider })
+            .appConnected({ botId, provider: block.provider, connectorId: block.connectorId })
             .catch(() => undefined);
           return;
         }

--- a/apps/web/src/pages/shell/message-cards.tsx
+++ b/apps/web/src/pages/shell/message-cards.tsx
@@ -125,6 +125,7 @@ export function AppConnectCard({
     setError(null);
     try {
       const started = await rpc.connections.begin({
+        connectorId: block.connectorId,
         provider: block.provider,
         displayName: block.name,
       });

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,4 +1,5 @@
 import type { JobPublisher, JobWorkerHost } from "@rakazo/adapter-kit";
+import { ComposioConnector, IntegrationProviderSettings } from "@rakazo/adapters";
 import { loadRootEnv } from "@rakazo/core/node/load-root-env";
 
 loadRootEnv();
@@ -115,9 +116,20 @@ async function main() {
   })
     ? new ChatSdkMessagingSurface(messagingPlatforms)
     : undefined;
-  const stack = createConnectorStack(isComposioEnabled(process.env.COMPOSIO_API_KEY), undefined, [
+  const integrationSettings = new IntegrationProviderSettings(
+    prisma,
+    secrets,
+    resolveEncryptionKey(process.env),
+    {
+      composio: isComposioEnabled(process.env.COMPOSIO_API_KEY)
+        ? new ComposioConnector(process.env.COMPOSIO_API_KEY)
+        : undefined,
+      pipedream,
+    },
+  );
+  const stack = createConnectorStack(false, undefined, [
     new InstalledConnectorProvider(prisma, secrets),
-    ...(pipedream ? [pipedream] : []),
+    ...integrationSettings.providers(),
     mcp,
   ]);
   const connector = stack.destination;
@@ -140,7 +152,17 @@ async function main() {
     artifacts,
     connector: stack.connector,
     connectors: stack.connector,
-    listConnectedPluginSlugs: stack.composio?.listConnectedSlugs.bind(stack.composio),
+    listConnectedPluginSlugs: async (userId) => {
+      const provider = await integrationSettings.resolve("composio");
+      if (!provider) throw new Error("Integration provider is unavailable");
+      return provider.listConnectedExternalIds({
+        userId,
+        spaceId: "",
+        operationId: "connections.sync",
+        traceId: "connections.sync",
+        signal: AbortSignal.timeout(15_000),
+      });
+    },
     secrets: [
       deploymentModelKey ?? "",
       process.env.COMPOSIO_API_KEY ?? "",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -134,6 +134,7 @@ async function main() {
   ]);
   const connector = stack.destination;
   await connector.start();
+  integrationSettings.warmDirectories();
   const memoryProviders = new SpaceMemoryProviderResolver(prisma, secrets);
   const home = new LocalAgentHomeStore(dataDir);
   const artifacts = new LocalArtifactStore(dataDir);
@@ -154,7 +155,7 @@ async function main() {
     connectors: stack.connector,
     listConnectedPluginSlugs: async (userId) => {
       const provider = await integrationSettings.resolve("composio");
-      if (!provider) throw new Error("Integration provider is unavailable");
+      if (!provider) return [];
       return provider.listConnectedExternalIds({
         userId,
         spaceId: "",

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -204,6 +204,7 @@ export function planLiveConnectionSync(
 }
 
 export class ComposioConnector implements ComposioProvider {
+  constructor(private readonly apiKey?: string) {}
   private client: Composio | undefined;
   private readonly catalogSessions = new Map<string, string>();
   private readonly executeSessions = new Map<string, { sessionId: string; key: string }>();
@@ -551,7 +552,7 @@ export class ComposioConnector implements ComposioProvider {
   }
 
   private sdk(): Composio {
-    this.client ??= new Composio();
+    this.client ??= new Composio(this.apiKey ? { apiKey: this.apiKey } : undefined);
     return this.client;
   }
 }

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -54,6 +54,7 @@ export * from "./group-handoff.js";
 export * from "./home.js";
 export * from "./host-aware-sandbox.js";
 export * from "./installed-connectors.js";
+export * from "./integration-provider-settings.js";
 export * from "./job-reconciler.js";
 export * from "./keyless-http-web.js";
 export * from "./mcp-connector.js";

--- a/packages/adapters/src/integration-provider-settings.test.ts
+++ b/packages/adapters/src/integration-provider-settings.test.ts
@@ -83,4 +83,33 @@ describe("integration provider settings", () => {
     }
     expect(f.factory).not.toHaveBeenCalled();
   });
+  it("warms directories only for configured providers", async () => {
+    const f = fixture();
+    const warm = vi.fn(async () => undefined);
+    const adapter = {
+      listConnectedExternalIds: vi.fn(async () => []),
+      catalog: vi.fn(async () => []),
+      discoverTools: vi.fn(async () => []),
+      warmDirectory: warm,
+    } as unknown as ManagedConnectorProvider;
+    f.factory.mockReturnValue(adapter);
+    const fallbackWarm = vi.fn(async () => undefined);
+    const settings = new IntegrationProviderSettings(
+      f.prisma as unknown as PrismaClient,
+      f.secrets,
+      "test-identity",
+      {
+        pipedream: {
+          warmDirectory: fallbackWarm,
+        } as unknown as ManagedConnectorProvider,
+      },
+      f.factory,
+    );
+    settings.warmDirectories();
+    await vi.waitFor(() => expect(fallbackWarm).toHaveBeenCalledOnce());
+    expect(warm).not.toHaveBeenCalled();
+    await settings.save({ provider: "composio", apiKey: "fake-warm-key" }, context);
+    settings.warmDirectories();
+    await vi.waitFor(() => expect(warm).toHaveBeenCalledOnce());
+  });
 });

--- a/packages/adapters/src/integration-provider-settings.test.ts
+++ b/packages/adapters/src/integration-provider-settings.test.ts
@@ -1,0 +1,86 @@
+import type { AdapterContext, ManagedConnectorProvider } from "@rakazo/adapter-kit";
+import type { PrismaClient } from "@rakazo/db";
+import { describe, expect, it, vi } from "vitest";
+import { IntegrationProviderSettings } from "./integration-provider-settings.js";
+import { EncryptedSecretStore } from "./secrets.js";
+
+const context: AdapterContext = {
+  operationId: "test",
+  traceId: "test",
+  spaceId: "space",
+  userId: "user",
+  signal: new AbortController().signal,
+};
+function fixture() {
+  const rows = new Map<string, { id: string; ciphertext: string }>();
+  const prisma = {
+    integrationProviderConfig: {
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) => rows.get(where.id) ?? null),
+      upsert: vi.fn(async ({ create }: { create: { id: string; ciphertext: string } }) => {
+        rows.set(create.id, create);
+        return create;
+      }),
+    },
+  };
+  const adapter = {
+    listConnectedExternalIds: vi.fn(async () => []),
+    catalog: vi.fn(async () => []),
+    discoverTools: vi.fn(async () => []),
+  } as unknown as ManagedConnectorProvider;
+  const factory = vi.fn(() => adapter);
+  const secrets = new EncryptedSecretStore("test-encryption-key");
+  const settings = new IntegrationProviderSettings(
+    prisma as unknown as PrismaClient,
+    secrets,
+    "test-identity",
+    {},
+    factory,
+  );
+  return { rows, prisma, adapter, factory, secrets, settings };
+}
+describe("integration provider settings", () => {
+  it("encrypts credentials and shares updates with a separately created worker resolver", async () => {
+    const f = fixture();
+    const worker = new IntegrationProviderSettings(
+      f.prisma as unknown as PrismaClient,
+      f.secrets,
+      "test-identity",
+      {},
+      f.factory,
+    );
+    expect(await worker.resolve("composio")).toBeUndefined();
+    await f.settings.save({ provider: "composio", apiKey: "fake-first-key" }, context);
+    expect(JSON.stringify([...f.rows.values()])).not.toContain("fake-first-key");
+    expect(await worker.resolve("composio")).toBe(f.adapter);
+    expect(f.factory).toHaveBeenLastCalledWith({ provider: "composio", apiKey: "fake-first-key" });
+    await f.settings.save({ provider: "composio", apiKey: "fake-replacement-key" }, context);
+    await worker.resolve("composio");
+    expect(f.factory).toHaveBeenLastCalledWith({
+      provider: "composio",
+      apiKey: "fake-replacement-key",
+    });
+  });
+  it("preserves working settings and hides provider error details on failed verification", async () => {
+    const f = fixture();
+    await f.settings.save({ provider: "composio", apiKey: "fake-working-key" }, context);
+    const before = f.rows.get("composio");
+    vi.mocked(f.adapter.listConnectedExternalIds).mockRejectedValueOnce(
+      new Error("fake-secret-in-provider-response"),
+    );
+    await expect(
+      f.settings.save({ provider: "composio", apiKey: "fake-bad-key" }, context),
+    ).rejects.toThrow("Could not verify these credentials");
+    expect(f.rows.get("composio")).toBe(before);
+  });
+  it("returns no tools or catalog for unconfigured providers", async () => {
+    const f = fixture();
+    for (const provider of f.settings.providers()) {
+      expect(await provider.catalog(context)).toEqual([]);
+      expect(await provider.discoverTools(context)).toEqual([]);
+      await expect(
+        provider.begin({ provider: "slack", redirectUrl: "https://example.test" }, context),
+      ).rejects.toThrow("Set up an integration provider");
+    }
+    expect(f.factory).not.toHaveBeenCalled();
+  });
+});

--- a/packages/adapters/src/integration-provider-settings.ts
+++ b/packages/adapters/src/integration-provider-settings.ts
@@ -1,0 +1,144 @@
+import type { AdapterContext, ConnectorCall, ManagedConnectorProvider } from "@rakazo/adapter-kit";
+import {
+  type IntegrationProviderConfig,
+  IntegrationProviderConfigSchema,
+  type IntegrationProviderId,
+  IntegrationProviderIdSchema,
+} from "@rakazo/contracts";
+import type { PrismaClient } from "@rakazo/db";
+import { ComposioConnector } from "./composio-connector.js";
+import { PipedreamConnector } from "./pipedream-connector.js";
+import type { EncryptedSecretStore } from "./secrets.js";
+
+/** Resolve persisted credentials on every operation so API and workers observe changes.
+ * Cache adapters by ciphertext to preserve sessions without retaining old credentials. */
+export class IntegrationProviderSettings {
+  private readonly cache = new Map<
+    string,
+    { ciphertext: string; adapter: ManagedConnectorProvider }
+  >();
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly secrets: EncryptedSecretStore,
+    private readonly identitySecret: string,
+    private readonly fallbacks: Partial<
+      Record<IntegrationProviderId, ManagedConnectorProvider>
+    > = {},
+    private readonly factory?: (config: IntegrationProviderConfig) => ManagedConnectorProvider,
+  ) {}
+
+  private create(config: IntegrationProviderConfig): ManagedConnectorProvider {
+    if (this.factory) return this.factory(config);
+    return config.provider === "composio"
+      ? new ComposioConnector(config.apiKey)
+      : new PipedreamConnector({ ...config, identitySecret: this.identitySecret });
+  }
+
+  async configured(id: IntegrationProviderId): Promise<boolean> {
+    return (
+      Boolean(
+        await this.prisma.integrationProviderConfig.findUnique({
+          where: { id },
+          select: { id: true },
+        }),
+      ) || Boolean(this.fallbacks[id])
+    );
+  }
+
+  async resolve(id: IntegrationProviderId): Promise<ManagedConnectorProvider | undefined> {
+    const row = await this.prisma.integrationProviderConfig.findUnique({ where: { id } });
+    if (!row) {
+      this.cache.delete(id);
+      return this.fallbacks[id];
+    }
+    const cached = this.cache.get(id);
+    if (cached?.ciphertext === row.ciphertext) return cached.adapter;
+    const config = IntegrationProviderConfigSchema.parse(
+      JSON.parse(this.secrets.load(row.ciphertext, `integration-provider:${id}`)),
+    );
+    if (config.provider !== id)
+      throw new Error("Integration provider configuration does not match");
+    const adapter = this.create(config);
+    this.cache.set(id, { ciphertext: row.ciphertext, adapter });
+    return adapter;
+  }
+
+  async save(config: IntegrationProviderConfig, context: AdapterContext): Promise<void> {
+    const adapter = this.create(config);
+    try {
+      // Exercises authenticated access before replacing working credentials.
+      await adapter.listConnectedExternalIds(context);
+    } catch {
+      // Provider errors can contain credentials or account details.
+      throw new Error("Could not verify these credentials");
+    }
+    const stored = await this.secrets.put(
+      JSON.stringify(config),
+      context,
+      `integration-provider:${config.provider}`,
+    );
+    await this.prisma.integrationProviderConfig.upsert({
+      where: { id: config.provider },
+      create: { id: config.provider, ciphertext: stored.ciphertext },
+      update: { ciphertext: stored.ciphertext },
+    });
+    this.cache.set(config.provider, { ciphertext: stored.ciphertext, adapter });
+  }
+
+  providers(): ManagedConnectorProvider[] {
+    return IntegrationProviderIdSchema.options.map(
+      (id) => new ConfiguredIntegrationProvider(id, this),
+    );
+  }
+}
+
+class ConfiguredIntegrationProvider implements ManagedConnectorProvider {
+  constructor(
+    private readonly id: IntegrationProviderId,
+    private readonly settings: IntegrationProviderSettings,
+  ) {}
+  describe() {
+    return {
+      id: this.id,
+      contractVersion: "1",
+      adapterVersion: "0.1.0",
+      capabilities: { discover: true, oauth: true, secretsBrokered: true },
+    };
+  }
+  private async required() {
+    const provider = await this.settings.resolve(this.id);
+    if (!provider) throw new Error("Set up an integration provider in Integrations first");
+    return provider;
+  }
+  async catalog(context: AdapterContext, query?: string) {
+    return (await this.settings.resolve(this.id))?.catalog(context, query) ?? [];
+  }
+  async discoverTools(context: AdapterContext) {
+    return (await this.settings.resolve(this.id))?.discoverTools(context) ?? [];
+  }
+  async listConnectedExternalIds(context: AdapterContext) {
+    return (await this.settings.resolve(this.id))?.listConnectedExternalIds(context) ?? [];
+  }
+  async connectionReady(context: AdapterContext, externalId: string) {
+    return (await this.required()).connectionReady(context, externalId);
+  }
+  async begin(request: Parameters<ManagedConnectorProvider["begin"]>[0], context: AdapterContext) {
+    return (await this.required()).begin(request, context);
+  }
+  async complete(
+    request: Parameters<ManagedConnectorProvider["complete"]>[0],
+    context: AdapterContext,
+  ) {
+    return (await this.required()).complete(request, context);
+  }
+  async revoke(ref: string, context: AdapterContext) {
+    return (await this.required()).revoke(ref, context);
+  }
+  async resolveCall(call: ConnectorCall, context: AdapterContext) {
+    return (await this.required()).resolveCall?.(call, context);
+  }
+  async *execute(call: ConnectorCall, context: AdapterContext) {
+    yield* (await this.required()).execute(call, context);
+  }
+}

--- a/packages/adapters/src/integration-provider-settings.ts
+++ b/packages/adapters/src/integration-provider-settings.ts
@@ -91,6 +91,15 @@ export class IntegrationProviderSettings {
       (id) => new ConfiguredIntegrationProvider(id, this),
     );
   }
+
+  /** Warm catalogs for env- and DB-configured providers. Fire-and-forget. */
+  warmDirectories(): void {
+    for (const id of IntegrationProviderIdSchema.options) {
+      void this.resolve(id)
+        .then((provider) => provider?.warmDirectory?.())
+        .catch(() => undefined);
+    }
+  }
 }
 
 class ConfiguredIntegrationProvider implements ManagedConnectorProvider {

--- a/packages/adapters/src/mcp-oauth.test.ts
+++ b/packages/adapters/src/mcp-oauth.test.ts
@@ -677,3 +677,54 @@ describe("MCP OAuth", () => {
     expect(requests).not.toContain("POST https://mcp.example.test/register");
   });
 });
+
+describe("MCP setup with an existing access token", () => {
+  it.each(["https://mcp.example.test/mcp", "http://127.0.0.1:8080/mcp"])(
+    "verifies %s using the stored token without starting OAuth",
+    async (endpoint) => {
+      const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+        const request = new Request(input, init);
+        expect(request.url).toBe(endpoint);
+        expect(request.headers.get("authorization")).toBe("Bearer fake-executor-token");
+        if (request.method !== "POST") return new Response(null, { status: 405 });
+        const body = (await request.json()) as { id?: number; method: string };
+        if (body.method === "initialize")
+          return Response.json({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              protocolVersion: "2025-03-26",
+              capabilities: {},
+              serverInfo: { name: "test", version: "1" },
+            },
+          });
+        return new Response(null, { status: 202 });
+      });
+      const prisma = {
+        mcpServer: {
+          findFirst: vi.fn(async () => ({ id: "server", endpoint, secretId: "secret" })),
+        },
+        secret: { findFirst: vi.fn(async () => ({ id: "secret", ciphertext: "encrypted" })) },
+        mcpOAuthSession: oauthSessionStore(),
+      };
+      const secrets = {
+        load: vi.fn(() => JSON.stringify({ secret: "fake-executor-token" })),
+        put: vi.fn(),
+      };
+      const broker = new McpOAuthBroker(prisma as never, secrets as never, {
+        ...TEST_NETWORK,
+        fetch,
+      });
+      await expect(
+        broker.begin({
+          serverId: "server",
+          userId: "user",
+          spaceId: "space",
+          redirectUri: "https://app.example.test/mcp/oauth/callback",
+        }),
+      ).resolves.toEqual({ status: "authorization_not_requested" });
+      expect(fetch).toHaveBeenCalled();
+      expect(secrets.put).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/adapters/src/mcp-oauth.test.ts
+++ b/packages/adapters/src/mcp-oauth.test.ts
@@ -129,150 +129,152 @@ describe("MCP OAuth", () => {
     expect(persisted.at(-1)?.oauth?.tokens).toBeUndefined();
   });
 
-  it("lets the official Streamable HTTP transport drive discovery, registration, PKCE, redirect, and token exchange", async () => {
-    const requests: string[] = [];
-    let registration: Record<string, unknown> | undefined;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-        const request = input instanceof Request ? input : new Request(input, init);
-        const url = new URL(request.url);
-        requests.push(`${request.method} ${url.toString()}`);
+  it.each(["https://mcp.example.test", "http://127.0.0.1:8080"])(
+    "drives discovery, registration, PKCE, redirect, and token exchange for %s",
+    async (mcpOrigin) => {
+      const requests: string[] = [];
+      let registration: Record<string, unknown> | undefined;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+          requests.push(`${request.method} ${url.toString()}`);
 
-        if (url.href === "https://mcp.example.test/mcp" && request.method === "POST") {
-          return new Response(null, {
-            status: 401,
-            headers: {
-              "WWW-Authenticate":
-                'Bearer resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource/mcp"',
-            },
-          });
-        }
-        if (url.href === "https://mcp.example.test/.well-known/oauth-protected-resource/mcp") {
-          return Response.json({
-            resource: "https://mcp.example.test/mcp",
-            authorization_servers: ["https://auth.example.test"],
-          });
-        }
-        if (url.href === "https://auth.example.test/.well-known/oauth-authorization-server") {
-          return Response.json({
-            issuer: "https://auth.example.test",
-            authorization_endpoint: "https://auth.example.test/authorize",
-            token_endpoint: "https://auth.example.test/token",
-            registration_endpoint: "https://auth.example.test/register",
-            response_types_supported: ["code"],
-            grant_types_supported: ["authorization_code", "refresh_token"],
-            code_challenge_methods_supported: ["S256"],
-          });
-        }
-        if (url.href === "https://auth.example.test/register" && request.method === "POST") {
-          registration = (await request.json()) as Record<string, unknown>;
-          return Response.json(
-            {
-              client_id: "registered-client-id",
-              redirect_uris: ["http://127.0.0.1:5173/mcp/oauth/callback"],
-              token_endpoint_auth_method: "none",
-            },
-            { status: 201 },
-          );
-        }
-        if (url.href === "https://auth.example.test/token" && request.method === "POST") {
-          return Response.json({
-            access_token: "access-token",
-            refresh_token: "refresh-token",
-            token_type: "bearer",
-            expires_in: 3600,
-          });
-        }
-        throw new Error(`Unexpected request: ${request.method} ${url}`);
-      }),
-    );
-    let secretCounter = 0;
-    const storedPayloads: string[] = [];
-    const put = vi.fn(async (plaintext: string) => {
-      storedPayloads.push(plaintext);
-      secretCounter += 1;
-      return { id: `secret-${secretCounter}`, ciphertext: `encrypted-${secretCounter}` };
-    });
-    const tx = {
-      $executeRaw: vi.fn().mockResolvedValue(1),
-      mcpServer: {
-        findFirst: vi.fn().mockResolvedValue({
-          endpoint: "https://mcp.example.test/mcp",
-          secretId: null,
+          if (url.href === `${mcpOrigin}/mcp` && request.method === "POST") {
+            return new Response(null, {
+              status: 401,
+              headers: {
+                "WWW-Authenticate": `Bearer resource_metadata="${mcpOrigin}/.well-known/oauth-protected-resource/mcp"`,
+              },
+            });
+          }
+          if (url.href === `${mcpOrigin}/.well-known/oauth-protected-resource/mcp`) {
+            return Response.json({
+              resource: `${mcpOrigin}/mcp`,
+              authorization_servers: ["https://auth.example.test"],
+            });
+          }
+          if (url.href === "https://auth.example.test/.well-known/oauth-authorization-server") {
+            return Response.json({
+              issuer: "https://auth.example.test",
+              authorization_endpoint: "https://auth.example.test/authorize",
+              token_endpoint: "https://auth.example.test/token",
+              registration_endpoint: "https://auth.example.test/register",
+              response_types_supported: ["code"],
+              grant_types_supported: ["authorization_code", "refresh_token"],
+              code_challenge_methods_supported: ["S256"],
+            });
+          }
+          if (url.href === "https://auth.example.test/register" && request.method === "POST") {
+            registration = (await request.json()) as Record<string, unknown>;
+            return Response.json(
+              {
+                client_id: "registered-client-id",
+                redirect_uris: ["http://127.0.0.1:5173/mcp/oauth/callback"],
+                token_endpoint_auth_method: "none",
+              },
+              { status: 201 },
+            );
+          }
+          if (url.href === "https://auth.example.test/token" && request.method === "POST") {
+            return Response.json({
+              access_token: "access-token",
+              refresh_token: "refresh-token",
+              token_type: "bearer",
+              expires_in: 3600,
+            });
+          }
+          throw new Error(`Unexpected request: ${request.method} ${url}`);
         }),
-        update: vi.fn().mockResolvedValue({}),
-      },
-      secret: {
-        findFirst: vi.fn(),
-        create: vi.fn().mockResolvedValue({}),
-        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
-      },
-    };
-    const prisma = {
-      mcpServer: {
-        findFirst: vi.fn().mockResolvedValue({
-          id: "server-1",
-          endpoint: "https://mcp.example.test/mcp",
-          secretId: null,
-        }),
-        update: vi.fn().mockResolvedValue({}),
-      },
-      secret: {
-        findFirst: vi.fn(),
-        create: vi.fn().mockResolvedValue({}),
-        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
-      },
-      mcpOAuthSession: oauthSessionStore(),
-      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
-    };
-    const broker = new McpOAuthBroker(prisma as never, { put } as never, TEST_NETWORK);
+      );
+      let secretCounter = 0;
+      const storedPayloads: string[] = [];
+      const put = vi.fn(async (plaintext: string) => {
+        storedPayloads.push(plaintext);
+        secretCounter += 1;
+        return { id: `secret-${secretCounter}`, ciphertext: `encrypted-${secretCounter}` };
+      });
+      const tx = {
+        $executeRaw: vi.fn().mockResolvedValue(1),
+        mcpServer: {
+          findFirst: vi.fn().mockResolvedValue({
+            endpoint: `${mcpOrigin}/mcp`,
+            secretId: null,
+          }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+        secret: {
+          findFirst: vi.fn(),
+          create: vi.fn().mockResolvedValue({}),
+          deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+      };
+      const prisma = {
+        mcpServer: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "server-1",
+            endpoint: `${mcpOrigin}/mcp`,
+            secretId: null,
+          }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+        secret: {
+          findFirst: vi.fn(),
+          create: vi.fn().mockResolvedValue({}),
+          deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+        },
+        mcpOAuthSession: oauthSessionStore(),
+        $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+      };
+      const broker = new McpOAuthBroker(prisma as never, { put } as never, TEST_NETWORK);
 
-    const started = await broker.begin({
-      serverId: "server-1",
-      spaceId: "workspace-1",
-      userId: "user-1",
-      redirectUri: "http://127.0.0.1:5173/mcp/oauth/callback",
-    });
-    expect(started.status).toBe("authorization_required");
-    if (started.status !== "authorization_required") throw new Error("OAuth was not requested");
-    const authorizationUrl = new URL(started.authorizationUrl);
+      const started = await broker.begin({
+        serverId: "server-1",
+        spaceId: "workspace-1",
+        userId: "user-1",
+        redirectUri: "http://127.0.0.1:5173/mcp/oauth/callback",
+      });
+      expect(started.status).toBe("authorization_required");
+      if (started.status !== "authorization_required") throw new Error("OAuth was not requested");
+      const authorizationUrl = new URL(started.authorizationUrl);
 
-    expect(registration).toMatchObject({ client_name: "Rakazo", application_type: "native" });
-    expect(authorizationUrl.origin).toBe("https://auth.example.test");
-    expect(authorizationUrl.searchParams.get("client_id")).toBe("registered-client-id");
-    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe("S256");
-    expect(authorizationUrl.searchParams.get("state")).toBe(started.sessionId);
+      expect(registration).toMatchObject({ client_name: "Rakazo", application_type: "native" });
+      expect(authorizationUrl.origin).toBe("https://auth.example.test");
+      expect(authorizationUrl.searchParams.get("client_id")).toBe("registered-client-id");
+      expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe("S256");
+      expect(authorizationUrl.searchParams.get("state")).toBe(started.sessionId);
 
-    const second = await broker.begin({
-      serverId: "server-1",
-      spaceId: "workspace-1",
-      userId: "user-1",
-      redirectUri: "http://127.0.0.1:5173/mcp/oauth/callback",
-    });
-    expect(second.status).toBe("authorization_required");
-    if (second.status !== "authorization_required") throw new Error("OAuth was not requested");
-    expect(second.sessionId).not.toBe(started.sessionId);
+      const second = await broker.begin({
+        serverId: "server-1",
+        spaceId: "workspace-1",
+        userId: "user-1",
+        redirectUri: "http://127.0.0.1:5173/mcp/oauth/callback",
+      });
+      expect(second.status).toBe("authorization_required");
+      if (second.status !== "authorization_required") throw new Error("OAuth was not requested");
+      expect(second.sessionId).not.toBe(started.sessionId);
 
-    await broker.complete({
-      sessionId: started.sessionId,
-      code: "authorization-code",
-      state: started.sessionId,
-      spaceId: "workspace-1",
-      userId: "user-1",
-    });
+      await broker.complete({
+        sessionId: started.sessionId,
+        code: "authorization-code",
+        state: started.sessionId,
+        spaceId: "workspace-1",
+        userId: "user-1",
+      });
 
-    expect(requests).toContain("POST https://auth.example.test/token");
-    expect(
-      storedPayloads
-        .map((value) => JSON.parse(value))
-        .some((value) => value.oauth?.tokens?.access_token === "access-token"),
-    ).toBe(true);
-    expect(prisma.mcpServer.update).toHaveBeenCalledWith({
-      where: { id: "server-1" },
-      data: { revision: { increment: 1 } },
-    });
-  });
+      expect(requests).toContain("POST https://auth.example.test/token");
+      expect(
+        storedPayloads
+          .map((value) => JSON.parse(value))
+          .some((value) => value.oauth?.tokens?.access_token === "access-token"),
+      ).toBe(true);
+      expect(prisma.mcpServer.update).toHaveBeenCalledWith({
+        where: { id: "server-1" },
+        data: { revision: { increment: 1 } },
+      });
+    },
+  );
 
   it("applies the transport URL policy to OAuth traffic: no plain-HTTP endpoints, no redirects", async () => {
     const fetchCalls: string[] = [];

--- a/packages/adapters/src/mcp-oauth.ts
+++ b/packages/adapters/src/mcp-oauth.ts
@@ -318,7 +318,7 @@ export class McpOAuthBroker {
     const networkFetch = oauthFetch(server.endpoint, this.network, loaded.material);
     const transport = new StreamableHTTPClientTransport(endpoint, {
       requestInit: { headers: networkFetch.headers },
-      authProvider: endpoint.protocol === "http:" ? undefined : provider,
+      authProvider: provider,
       fetch: networkFetch.fetch,
     });
     const client = new Client({ name: "rakazo-oauth", version: "0.1.0" });

--- a/packages/adapters/src/mcp-oauth.ts
+++ b/packages/adapters/src/mcp-oauth.ts
@@ -10,6 +10,7 @@ import type {
   OAuthClientMetadata,
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { isLocalMcpHost } from "@rakazo/contracts";
 import type { PrismaClient } from "@rakazo/db";
 import { secureFetch, validateUrl, withEndpointOriginFallback } from "./mcp-transport.js";
 import type { RemoteTransportDependencies } from "./remote-mcp.js";
@@ -201,10 +202,28 @@ const MAX_PENDING_SESSIONS = 100;
 function oauthFetch(
   endpoint: string,
   network: RemoteTransportDependencies,
-): { fetch: typeof fetch; close: () => Promise<void> } {
+  material: OAuthMaterial = {},
+): { fetch: typeof fetch; close: () => Promise<void>; headers: Record<string, string> } {
   const url = new URL(endpoint);
-  const safeFetch = secureFetch(url, {}, {}, network);
+  const localHttp = url.protocol === "http:" && isLocalMcpHost(url.hostname);
+  const headers = {
+    ...material.headers,
+    ...(material.secret
+      ? {
+          Authorization: material.secret.startsWith("Bearer ")
+            ? material.secret
+            : `Bearer ${material.secret}`,
+        }
+      : {}),
+  };
+  const safeFetch = secureFetch(
+    url,
+    { allowHttpLocalhost: localHttp, allowLocalHttpCredentials: localHttp },
+    { headers },
+    network,
+  );
   return {
+    headers,
     fetch: withEndpointOriginFallback(url.origin, safeFetch),
     close: () => safeFetch.close(),
   };
@@ -296,9 +315,10 @@ export class McpOAuthBroker {
     // cancelled popup), the server keeps its valid connection. The SDK itself
     // invalidates dead tokens when a refresh is rejected with invalid_grant.
     const endpoint = new URL(server.endpoint);
-    const networkFetch = oauthFetch(server.endpoint, this.network);
+    const networkFetch = oauthFetch(server.endpoint, this.network, loaded.material);
     const transport = new StreamableHTTPClientTransport(endpoint, {
-      authProvider: provider,
+      requestInit: { headers: networkFetch.headers },
+      authProvider: endpoint.protocol === "http:" ? undefined : provider,
       fetch: networkFetch.fetch,
     });
     const client = new Client({ name: "rakazo-oauth", version: "0.1.0" });

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -126,6 +126,7 @@ export const MessageBlock = z.discriminatedUnion("kind", [
     /** Inline app authorization card (Composio-backed): logo, name, one-line
         description, and an Authorize button that flips to connected. */
     kind: z.literal("app_connect"),
+    connectorId: z.string().optional(),
     provider: z.string(),
     name: z.string(),
     description: z.string(),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,6 +4,7 @@ export * from "./desktop.js";
 export * from "./domain.js";
 export * from "./events.js";
 export * from "./ids.js";
+export * from "./integration-settings.js";
 export * from "./mcp.js";
 export * from "./openai-compatible-ui.js";
 export * from "./rpc.js";

--- a/packages/contracts/src/integration-settings.ts
+++ b/packages/contracts/src/integration-settings.ts
@@ -15,6 +15,7 @@ export type IntegrationProviderConfig = z.infer<typeof IntegrationProviderConfig
 export type IntegrationProviderId = z.infer<typeof IntegrationProviderIdSchema>;
 export const IntegrationSetupStateSchema = z.object({
   canConfigure: z.boolean(),
+  needsSetup: z.boolean(),
   webUrl: z.string().url(),
   providers: z.array(z.object({ id: IntegrationProviderIdSchema, configured: z.boolean() })),
 });

--- a/packages/contracts/src/integration-settings.ts
+++ b/packages/contracts/src/integration-settings.ts
@@ -1,0 +1,21 @@
+import * as z from "zod";
+
+export const IntegrationProviderIdSchema = z.enum(["composio", "pipedream"]);
+export const IntegrationProviderConfigSchema = z.discriminatedUnion("provider", [
+  z.object({ provider: z.literal("composio"), apiKey: z.string().trim().min(1).max(16384) }),
+  z.object({
+    provider: z.literal("pipedream"),
+    clientId: z.string().trim().min(1).max(512),
+    clientSecret: z.string().trim().min(1).max(16384),
+    projectId: z.string().trim().min(1).max(512),
+    environment: z.enum(["production", "development"]).default("production"),
+  }),
+]);
+export type IntegrationProviderConfig = z.infer<typeof IntegrationProviderConfigSchema>;
+export type IntegrationProviderId = z.infer<typeof IntegrationProviderIdSchema>;
+export const IntegrationSetupStateSchema = z.object({
+  canConfigure: z.boolean(),
+  webUrl: z.string().url(),
+  providers: z.array(z.object({ id: IntegrationProviderIdSchema, configured: z.boolean() })),
+});
+export type IntegrationSetupState = z.infer<typeof IntegrationSetupStateSchema>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -491,12 +491,19 @@ export const appContract = {
   },
   capabilities: {
     list: oc.output(z.array(CapabilityInstallSchema)),
-    catalogSearch: oc.input(z.object({ query: z.string().trim().max(253).default("") })).output(
-      z.object({
-        enabled: z.boolean(),
-        results: z.array(IntegrationCatalogResultSchema),
-      }),
-    ),
+    catalogSearch: oc
+      .input(
+        z.object({
+          query: z.string().trim().max(253).default(""),
+          usePublicCatalog: z.boolean().default(false),
+        }),
+      )
+      .output(
+        z.object({
+          enabled: z.boolean(),
+          results: z.array(IntegrationCatalogResultSchema),
+        }),
+      ),
     install: oc
       .input(
         z.object({
@@ -514,7 +521,14 @@ export const appContract = {
     servers: {
       list: oc.output(z.array(McpServerSchema)),
       create: oc.input(McpServerConfigInput).output(McpServerSchema),
-      update: oc.input(z.object({ id: Id, config: McpServerConfigInput })).output(McpServerSchema),
+      update: oc
+        .input(
+          z.union([
+            z.object({ id: Id, config: McpServerConfigInput }),
+            z.object({ id: Id, secret: z.string().min(1).max(16384) }),
+          ]),
+        )
+        .output(McpServerSchema),
       remove: oc.input(z.object({ id: Id })).output(z.object({ ok: z.literal(true) })),
     },
     assignments: {

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -582,7 +582,9 @@ export const appContract = {
     dismissFocus: oc.input(z.object({ botId: Id })).output(z.object({ ok: z.literal(true) })),
     /** Flip an app_connect card to connected after authorization completes. */
     appConnected: oc
-      .input(z.object({ botId: Id, provider: z.string() }))
+      .input(
+        z.object({ botId: Id, provider: z.string(), connectorId: z.string().default("composio") }),
+      )
       .output(z.object({ ok: z.literal(true) })),
   },
   integrationSetup: {

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -73,6 +73,10 @@ import {
 } from "./domain.js";
 import { ProductEventSchema } from "./events.js";
 import { Id, IsoDate } from "./ids.js";
+import {
+  IntegrationProviderConfigSchema,
+  IntegrationSetupStateSchema,
+} from "./integration-settings.js";
 import { RunsListOutputSchema } from "./runs.js";
 import { SearchQueryOutputSchema } from "./search.js";
 
@@ -566,6 +570,10 @@ export const appContract = {
     appConnected: oc
       .input(z.object({ botId: Id, provider: z.string() }))
       .output(z.object({ ok: z.literal(true) })),
+  },
+  integrationSetup: {
+    get: oc.output(IntegrationSetupStateSchema),
+    save: oc.input(IntegrationProviderConfigSchema).output(z.object({ ok: z.literal(true) })),
   },
   connections: {
     catalog: oc

--- a/packages/db/prisma/migrations/20260908000000_integration_provider_configs/migration.sql
+++ b/packages/db/prisma/migrations/20260908000000_integration_provider_configs/migration.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "integration_provider_configs" (
+  "id" TEXT NOT NULL,
+  "ciphertext" TEXT NOT NULL,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "integration_provider_configs_pkey" PRIMARY KEY ("id")
+);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1267,3 +1267,12 @@ model AgentSecret {
   @@index([spaceId, updatedAt])
   @@map("agent_secrets")
 }
+
+// Deployment-owned integration credentials; never exposed through read DTOs.
+model IntegrationProviderConfig {
+  id         String @id
+  ciphertext String
+  updatedAt  DateTime @updatedAt
+
+  @@map("integration_provider_configs")
+}


### PR DESCRIPTION
New installations need integration-provider configuration before app authorization; this adds server-owner setup with Direct MCP, Composio, Pipedream, and Executor, skips that setup for regular users and already-configured servers, and keeps personal app authorization separate.

Provider credentials are validated and encrypted for use by the API and worker without a restart, direct MCP discovery reuses OAuth and bot assignments, and provider setup remains available from owner settings while users can add MCP servers from Integrations; Executor uses an existing installation with a download link, while mobile MCP authorization hands off to the web app because its callback flow is browser-based (native setup is not captured by web CI).

The visible copy is limited to action and field labels (“Server integrations”, “Add MCP server”, “Browse MCP servers”, “Direct MCP”, “Composio”, “Pipedream”, “Executor”, “Integration options”, “API key”, “Client ID”, “Client secret”, “Project ID”, “Get credentials”, “Search apps”, “Search integrations.sh”, “Connect”, “Connected”, “Connecting…”, “Continue”, “Skip”, “Add server URL”, “Server URL”, “Access token”, “Setup help”, “Download Executor”, “Bot”, “Open web app”, and “Loading…”), plus contextual recovery copy (“Could not load integrations”, “Could not connect”, “A remote MCP server is required”, “Could not verify or save these credentials”, “Could not verify these credentials”, “Set up an integration provider in Integrations first”, “No remote MCP servers found”, “Ask the server owner to configure this provider.”, “Set up Executor on your server in the web app.”, “Finish MCP authorization in the web app.”, “Could not load bots. Reload to try again.”, and “What would you like to work on first?”): controls need names to be discoverable and the search action identifies the external catalog, while fields, help links, errors, and platform explanations appear only when relevant rather than as persistent explanations.

Validation: deterministic authorization, provider, OAuth, and mobile translation tests passed, targeted browser scenarios cover owner setup/settings and remote-member onboarding/MCP connections, workspace type checks passed, and repository lint reported existing warnings; CI passes, with screenshots of [server configuration](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34156769320-1/screenshots/images/203-server-integrations-configured.png), and [remote-user MCP connections](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34156769320-1/screenshots/images/185-remote-member-mcp.png).