### PR TITLE
Open desktop model sign-in in the default browser

### DIFF
--- a/apps/desktop/src/browser-auth.test.ts
+++ b/apps/desktop/src/browser-auth.test.ts
@@ -77,14 +77,9 @@ describe("system browser authentication", () => {
     expect(options.onCallback).toHaveBeenCalledOnce();
   });
 
-  it.each([
-    ["127.0.0.1", "EADDRNOTAVAIL"],
-    ["::1", "EADDRNOTAVAIL"],
-    ["127.0.0.1", "EADDRINUSE"],
-    ["::1", "EADDRINUSE"],
-  ] as const)(
-    "uses the remaining loopback family when %s fails with %s",
-    async (unavailable, code) => {
+  it.each(["127.0.0.1", "::1"])(
+    "uses the remaining loopback family when %s is unavailable",
+    async (unavailable) => {
       const { authorization, callback, options } = await setup();
       const localCallback = callback.replace("127.0.0.1", "localhost");
       authorization.searchParams.set("redirect_uri", localCallback);
@@ -92,7 +87,7 @@ describe("system browser authentication", () => {
       vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server, ...args) {
         if (args[1] === unavailable) {
           queueMicrotask(() =>
-            this.emit("error", Object.assign(new Error("Unavailable"), { code })),
+            this.emit("error", Object.assign(new Error("Unavailable"), { code: "EADDRNOTAVAIL" })),
           );
           return this;
         }
@@ -129,6 +124,25 @@ describe("system browser authentication", () => {
     await expect(openBrowserAuth(authorization.href, options)).rejects.toThrow(
       "No loopback address is available.",
     );
+    expect(options.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a localhost family hits EADDRINUSE", async () => {
+    const { authorization, callback, options } = await setup();
+    authorization.searchParams.set("redirect_uri", callback.replace("127.0.0.1", "localhost"));
+    const listen = Server.prototype.listen;
+    vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server, ...args) {
+      if (args[1] === "127.0.0.1") {
+        queueMicrotask(() =>
+          this.emit("error", Object.assign(new Error("In use"), { code: "EADDRINUSE" })),
+        );
+        return this;
+      }
+      return Reflect.apply(listen, this, args);
+    });
+    await expect(openBrowserAuth(authorization.href, options)).rejects.toMatchObject({
+      code: "EADDRINUSE",
+    });
     expect(options.openExternal).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/browser-auth.test.ts
+++ b/apps/desktop/src/browser-auth.test.ts
@@ -112,6 +112,21 @@ describe("system browser authentication", () => {
     },
   );
 
+  it("does not open the browser when no loopback family can bind", async () => {
+    const { authorization, callback, options } = await setup();
+    authorization.searchParams.set("redirect_uri", callback.replace("127.0.0.1", "localhost"));
+    vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server) {
+      queueMicrotask(() =>
+        this.emit("error", Object.assign(new Error("Unavailable"), { code: "EAFNOSUPPORT" })),
+      );
+      return this;
+    });
+    await expect(openBrowserAuth(authorization.href, options)).rejects.toThrow(
+      "No loopback address is available.",
+    );
+    expect(options.openExternal).not.toHaveBeenCalled();
+  });
+
   it("rejects an unrelated Host header", async () => {
     const { authorization, callback, options } = await setup();
     await openBrowserAuth(authorization.href, options);

--- a/apps/desktop/src/browser-auth.test.ts
+++ b/apps/desktop/src/browser-auth.test.ts
@@ -1,11 +1,13 @@
 import { get } from "node:http";
-import { createServer } from "node:net";
+import { createServer, Server } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { openBrowserAuth } from "./browser-auth.js";
 
 const controllers: AbortController[] = [];
 afterEach(() => {
   for (const controller of controllers) controller.abort();
+  controllers.length = 0;
+  vi.restoreAllMocks();
 });
 async function setup() {
   const reservation = createServer();
@@ -74,6 +76,41 @@ describe("system browser authentication", () => {
     expect((await fetch(`${localCallback}?code=x&state=test-state`)).status).toBe(200);
     expect(options.onCallback).toHaveBeenCalledOnce();
   });
+
+  it.each(["127.0.0.1", "::1"])(
+    "uses the remaining loopback family when %s is unavailable",
+    async (unavailable) => {
+      const { authorization, callback, options } = await setup();
+      const localCallback = callback.replace("127.0.0.1", "localhost");
+      authorization.searchParams.set("redirect_uri", localCallback);
+      const listen = Server.prototype.listen;
+      vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server, ...args) {
+        if (args[1] === unavailable) {
+          queueMicrotask(() =>
+            this.emit("error", Object.assign(new Error("Unavailable"), { code: "EADDRNOTAVAIL" })),
+          );
+          return this;
+        }
+        return Reflect.apply(listen, this, args);
+      });
+      await openBrowserAuth(authorization.href, options);
+      const remaining = unavailable === "::1" ? "127.0.0.1" : "[::1]";
+      const status = await new Promise<number | undefined>((resolve, reject) => {
+        get(
+          `${callback.replace("127.0.0.1", remaining)}?code=x&state=test-state`,
+          {
+            headers: { Host: new URL(localCallback).host },
+          },
+          (response) => {
+            response.resume();
+            resolve(response.statusCode);
+          },
+        ).on("error", reject);
+      });
+      expect(status).toBe(200);
+      expect(options.onCallback).toHaveBeenCalledOnce();
+    },
+  );
 
   it("rejects an unrelated Host header", async () => {
     const { authorization, callback, options } = await setup();

--- a/apps/desktop/src/browser-auth.test.ts
+++ b/apps/desktop/src/browser-auth.test.ts
@@ -77,9 +77,14 @@ describe("system browser authentication", () => {
     expect(options.onCallback).toHaveBeenCalledOnce();
   });
 
-  it.each(["127.0.0.1", "::1"])(
-    "uses the remaining loopback family when %s is unavailable",
-    async (unavailable) => {
+  it.each([
+    ["127.0.0.1", "EADDRNOTAVAIL"],
+    ["::1", "EADDRNOTAVAIL"],
+    ["127.0.0.1", "EADDRINUSE"],
+    ["::1", "EADDRINUSE"],
+  ] as const)(
+    "uses the remaining loopback family when %s fails with %s",
+    async (unavailable, code) => {
       const { authorization, callback, options } = await setup();
       const localCallback = callback.replace("127.0.0.1", "localhost");
       authorization.searchParams.set("redirect_uri", localCallback);
@@ -87,7 +92,7 @@ describe("system browser authentication", () => {
       vi.spyOn(Server.prototype, "listen").mockImplementation(function (this: Server, ...args) {
         if (args[1] === unavailable) {
           queueMicrotask(() =>
-            this.emit("error", Object.assign(new Error("Unavailable"), { code: "EADDRNOTAVAIL" })),
+            this.emit("error", Object.assign(new Error("Unavailable"), { code })),
           );
           return this;
         }

--- a/apps/desktop/src/browser-auth.test.ts
+++ b/apps/desktop/src/browser-auth.test.ts
@@ -1,0 +1,149 @@
+import { get } from "node:http";
+import { createServer } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openBrowserAuth } from "./browser-auth.js";
+
+const controllers: AbortController[] = [];
+afterEach(() => {
+  for (const controller of controllers) controller.abort();
+});
+async function setup() {
+  const reservation = createServer();
+  await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+  const address = reservation.address();
+  if (!address || typeof address === "string") throw new Error("Missing port");
+  await new Promise<void>((resolve) => reservation.close(() => resolve()));
+  const callback = `http://127.0.0.1:${address.port}/callback`;
+  const authorization = new URL("https://provider.example.com/authorize");
+  authorization.searchParams.set("redirect_uri", callback);
+  authorization.searchParams.set("state", "test-state");
+  const controller = new AbortController();
+  controllers.push(controller);
+  const onCallback = vi.fn();
+  const openExternal = vi.fn(async () => undefined);
+  return {
+    callback,
+    authorization,
+    controller,
+    options: { signal: controller.signal, onCallback, openExternal, onClose: vi.fn() },
+  };
+}
+
+describe("system browser authentication", () => {
+  it("starts listening before opening the browser and forwards a matching callback", async () => {
+    const { authorization, callback, options } = await setup();
+    options.openExternal.mockImplementation(async () => {
+      const response = await fetch(`${callback}?code=example-code&state=test-state`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(await response.text()).not.toContain("example-code");
+    });
+    await openBrowserAuth(authorization.href, options);
+    expect(options.onCallback).toHaveBeenCalledExactlyOnceWith({
+      code: "example-code",
+      state: "test-state",
+    });
+    await expect(fetch(`${callback}?code=replay&state=test-state`)).rejects.toThrow();
+    expect(options.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("rejects wrong state, path, method and duplicate parameters without consuming the attempt", async () => {
+    const { authorization, callback, options } = await setup();
+    await openBrowserAuth(authorization.href, options);
+    for (const url of [
+      `${callback}?code=x&state=wrong`,
+      `${callback}/wrong?code=x&state=test-state`,
+      `${callback}?code=x&state=test-state&state=wrong`,
+      `${callback}?code=x&code=y&state=test-state`,
+      `${callback}?error=denied&state=test-state`,
+    ])
+      expect((await fetch(url)).status).toBe(400);
+    expect((await fetch(`${callback}?code=x&state=test-state`, { method: "POST" })).status).toBe(
+      400,
+    );
+    expect(options.onCallback).not.toHaveBeenCalled();
+    expect((await fetch(`${callback}?code=x&state=test-state`)).status).toBe(200);
+    expect(options.onCallback).toHaveBeenCalledOnce();
+  });
+
+  it("accepts localhost callbacks through either loopback address", async () => {
+    const { authorization, callback, options } = await setup();
+    const localCallback = callback.replace("127.0.0.1", "localhost");
+    authorization.searchParams.set("redirect_uri", localCallback);
+    await openBrowserAuth(authorization.href, options);
+    expect((await fetch(`${localCallback}?code=x&state=test-state`)).status).toBe(200);
+    expect(options.onCallback).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an unrelated Host header", async () => {
+    const { authorization, callback, options } = await setup();
+    await openBrowserAuth(authorization.href, options);
+    const status = await new Promise<number | undefined>((resolve, reject) => {
+      get(
+        `${callback}?code=x&state=test-state`,
+        {
+          headers: { Host: "unrelated.example.com" },
+        },
+        (response) => {
+          response.resume();
+          resolve(response.statusCode);
+        },
+      ).on("error", reject);
+    });
+    expect(status).toBe(400);
+    expect(options.onCallback).not.toHaveBeenCalled();
+  });
+
+  it("does not open an already cancelled attempt", async () => {
+    const { authorization, controller, options } = await setup();
+    controller.abort();
+    await expect(openBrowserAuth(authorization.href, options)).rejects.toThrow();
+    expect(options.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("opens device-code flows without a listener", async () => {
+    const { options } = await setup();
+    await openBrowserAuth("https://provider.example.com/device", options);
+    expect(options.openExternal).toHaveBeenCalledWith("https://provider.example.com/device");
+    expect(options.onClose).toHaveBeenCalledOnce();
+    expect(options.onCallback).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "https://remote.example.com/callback",
+    "http://0.0.0.0:54321/callback",
+    "http://127.0.0.1:80/callback",
+    "http://localhost:54321/callback?other=x",
+  ])("rejects unsafe redirects: %s", async (redirect) => {
+    const { authorization, options } = await setup();
+    authorization.searchParams.set("redirect_uri", redirect);
+    await expect(openBrowserAuth(authorization.href, options)).rejects.toThrow();
+    expect(options.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("requires state for automatic capture", async () => {
+    const { authorization, options } = await setup();
+    authorization.searchParams.delete("state");
+    await expect(openBrowserAuth(authorization.href, options)).rejects.toThrow();
+  });
+
+  it("closes the listener on cancellation or browser failure", async () => {
+    const { authorization, callback, controller, options } = await setup();
+    await openBrowserAuth(authorization.href, options);
+    controller.abort();
+    await expect(fetch(callback)).rejects.toThrow();
+    expect(options.onClose).toHaveBeenCalledOnce();
+    const retry = await setup();
+    retry.options.openExternal.mockRejectedValue(new Error("Browser unavailable"));
+    await expect(openBrowserAuth(retry.authorization.href, retry.options)).rejects.toThrow();
+    await expect(fetch(retry.callback)).rejects.toThrow();
+  });
+
+  it("does not open a browser if the callback port is occupied", async () => {
+    const { authorization, options } = await setup();
+    await openBrowserAuth(authorization.href, options);
+    const second = await setup();
+    await expect(openBrowserAuth(authorization.href, second.options)).rejects.toThrow();
+    expect(second.options.openExternal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/browser-auth.ts
+++ b/apps/desktop/src/browser-auth.ts
@@ -108,13 +108,11 @@ export async function openBrowserAuth(
           server.close();
           server.closeAllConnections();
           const code = (error as NodeJS.ErrnoException).code;
-          // For localhost, keep going when one family is missing or occupied;
-          // explicit 127.0.0.1/::1 redirects still fail hard on bind errors.
+          // Skip a disabled address family; still fail on conflicts like EADDRINUSE
+          // so a localhost redirect cannot land on another process's listener.
           if (
             callback.hostname !== "localhost" ||
-            (code !== "EAFNOSUPPORT" &&
-              code !== "EADDRNOTAVAIL" &&
-              code !== "EADDRINUSE")
+            (code !== "EAFNOSUPPORT" && code !== "EADDRNOTAVAIL")
           )
             throw error;
         }

--- a/apps/desktop/src/browser-auth.ts
+++ b/apps/desktop/src/browser-auth.ts
@@ -50,6 +50,7 @@ export async function openBrowserAuth(
         throw new Error("Sign-in requires a loopback redirect and state.");
       }
       let consumed = false;
+      // localhost may resolve to either family; bind whichever is available.
       const hosts =
         callback.hostname === "localhost"
           ? ["127.0.0.1", "::1"]
@@ -89,7 +90,6 @@ export async function openBrowserAuth(
           response.end("You can close this tab and return to Rakazo.", close);
           options.onCallback({ code, state });
         });
-        servers.push(server);
         server.requestTimeout = 10_000;
         server.headersTimeout = 10_000;
         try {
@@ -103,9 +103,12 @@ export async function openBrowserAuth(
               } else resolve();
             });
           });
+          servers.push(server);
         } catch (error) {
+          server.close();
+          server.closeAllConnections();
           const code = (error as NodeJS.ErrnoException).code;
-          // A disabled address family is safe to skip; an occupied port is not.
+          // Skip a disabled address family; still fail on conflicts like EADDRINUSE.
           if (
             callback.hostname !== "localhost" ||
             (code !== "EAFNOSUPPORT" && code !== "EADDRNOTAVAIL")
@@ -113,7 +116,7 @@ export async function openBrowserAuth(
             throw error;
         }
       }
-      if (!servers.some((server) => server.listening)) {
+      if (servers.length === 0) {
         throw new Error("No loopback address is available.");
       }
     }

--- a/apps/desktop/src/browser-auth.ts
+++ b/apps/desktop/src/browser-auth.ts
@@ -108,10 +108,13 @@ export async function openBrowserAuth(
           server.close();
           server.closeAllConnections();
           const code = (error as NodeJS.ErrnoException).code;
-          // Skip a disabled address family; still fail on conflicts like EADDRINUSE.
+          // For localhost, keep going when one family is missing or occupied;
+          // explicit 127.0.0.1/::1 redirects still fail hard on bind errors.
           if (
             callback.hostname !== "localhost" ||
-            (code !== "EAFNOSUPPORT" && code !== "EADDRNOTAVAIL")
+            (code !== "EAFNOSUPPORT" &&
+              code !== "EADDRNOTAVAIL" &&
+              code !== "EADDRINUSE")
           )
             throw error;
         }

--- a/apps/desktop/src/browser-auth.ts
+++ b/apps/desktop/src/browser-auth.ts
@@ -92,16 +92,29 @@ export async function openBrowserAuth(
         servers.push(server);
         server.requestTimeout = 10_000;
         server.headersTimeout = 10_000;
-        await new Promise<void>((resolve, reject) => {
-          server.once("error", reject);
-          server.listen(Number(callback.port), host, () => {
-            // Cancellation may have happened while listen was resolving.
-            if (options.signal.aborted) {
-              close();
-              reject(new Error("Sign-in cancelled."));
-            } else resolve();
+        try {
+          await new Promise<void>((resolve, reject) => {
+            server.once("error", reject);
+            server.listen(Number(callback.port), host, () => {
+              // Cancellation may have happened while listen was resolving.
+              if (options.signal.aborted) {
+                close();
+                reject(new Error("Sign-in cancelled."));
+              } else resolve();
+            });
           });
-        });
+        } catch (error) {
+          const code = (error as NodeJS.ErrnoException).code;
+          // A disabled address family is safe to skip; an occupied port is not.
+          if (
+            callback.hostname !== "localhost" ||
+            (code !== "EAFNOSUPPORT" && code !== "EADDRNOTAVAIL")
+          )
+            throw error;
+        }
+      }
+      if (!servers.some((server) => server.listening)) {
+        throw new Error("No loopback address is available.");
       }
     }
     options.signal.throwIfAborted();

--- a/apps/desktop/src/browser-auth.ts
+++ b/apps/desktop/src/browser-auth.ts
@@ -1,0 +1,114 @@
+import { createServer, type Server } from "node:http";
+import type { RakazoDesktopOAuthCallback } from "@rakazo/contracts";
+import { LOOPBACK_HOSTS } from "./oauth-callback.js";
+
+/** Native transport only: providers still own PKCE, token exchange and persistence. */
+export async function openBrowserAuth(
+  authorizationUrl: string,
+  options: {
+    signal: AbortSignal;
+    openExternal: (url: string) => Promise<unknown>;
+    onCallback: (callback: RakazoDesktopOAuthCallback) => void;
+    onClose?: () => void;
+  },
+): Promise<void> {
+  const url = new URL(authorizationUrl);
+  if (url.protocol !== "https:" || url.username || url.password) {
+    throw new Error("Sign-in requires an HTTPS URL.");
+  }
+  const redirect = url.searchParams.get("redirect_uri");
+  const servers: Server[] = [];
+  let closed = false;
+  const close = () => {
+    options.signal.removeEventListener("abort", close);
+    for (const server of servers) {
+      server.close();
+      server.closeAllConnections();
+    }
+    if (!closed) {
+      closed = true;
+      options.onClose?.();
+    }
+  };
+  options.signal.throwIfAborted();
+  options.signal.addEventListener("abort", close, { once: true });
+  try {
+    if (redirect) {
+      const callback = new URL(redirect);
+      const state = url.searchParams.get("state");
+      if (
+        callback.protocol !== "http:" ||
+        !LOOPBACK_HOSTS.has(callback.hostname) ||
+        callback.username ||
+        callback.password ||
+        callback.search ||
+        callback.hash ||
+        !callback.port ||
+        Number(callback.port) < 1024 ||
+        !state
+      ) {
+        throw new Error("Sign-in requires a loopback redirect and state.");
+      }
+      let consumed = false;
+      const hosts =
+        callback.hostname === "localhost"
+          ? ["127.0.0.1", "::1"]
+          : [callback.hostname === "[::1]" ? "::1" : callback.hostname];
+      for (const host of hosts) {
+        options.signal.throwIfAborted();
+        const server = createServer({ maxHeaderSize: 8192 }, (request, response) => {
+          response.setHeader("Cache-Control", "no-store");
+          response.setHeader("Content-Type", "text/plain; charset=utf-8");
+          response.setHeader("Referrer-Policy", "no-referrer");
+          response.setHeader(
+            "Content-Security-Policy",
+            "default-src 'none'; frame-ancestors 'none'",
+          );
+          if (!URL.canParse(request.url ?? "/", callback.origin)) {
+            response.writeHead(400).end();
+            return;
+          }
+          const target = new URL(request.url ?? "/", callback.origin);
+          const code = target.searchParams.get("code");
+          if (
+            consumed ||
+            request.method !== "GET" ||
+            request.headers.host !== callback.host ||
+            target.origin !== callback.origin ||
+            target.pathname !== callback.pathname ||
+            target.searchParams.getAll("state").length !== 1 ||
+            target.searchParams.get("state") !== state ||
+            target.searchParams.getAll("code").length !== 1 ||
+            !code ||
+            target.searchParams.has("error")
+          ) {
+            response.writeHead(400).end("Sign-in callback rejected. Return to Rakazo to retry.");
+            return;
+          }
+          consumed = true;
+          response.end("You can close this tab and return to Rakazo.", close);
+          options.onCallback({ code, state });
+        });
+        servers.push(server);
+        server.requestTimeout = 10_000;
+        server.headersTimeout = 10_000;
+        await new Promise<void>((resolve, reject) => {
+          server.once("error", reject);
+          server.listen(Number(callback.port), host, () => {
+            // Cancellation may have happened while listen was resolving.
+            if (options.signal.aborted) {
+              close();
+              reject(new Error("Sign-in cancelled."));
+            } else resolve();
+          });
+        });
+      }
+    }
+    options.signal.throwIfAborted();
+    await options.openExternal(url.href);
+    if (!redirect) close();
+  } catch (error) {
+    close();
+    throw error;
+  }
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -9,6 +9,7 @@ import {
   type ElectronAutoUpdater,
   LAUNCH_CHECK_DELAY_MS,
 } from "./auto-update.js";
+import { openBrowserAuth } from "./browser-auth.js";
 import { DOCKER_INSTALL_LINKS, isDesktopSetupLink, runDocker } from "./docker-cli.js";
 import {
   LocalStackController,
@@ -935,6 +936,63 @@ app.whenReady().then(async () => {
   const icon = developmentIcon();
   if (process.platform === "darwin" && icon) app.dock?.setIcon(icon);
   installApplicationMenu();
+  const browserAuthAttempts = new Map<string, AbortController>();
+  const cancelBrowserAuth = () => {
+    for (const attempt of browserAuthAttempts.values()) attempt.abort();
+    browserAuthAttempts.clear();
+  };
+  app.on("before-quit", cancelBrowserAuth);
+  ipcMain.handle("desktop.oauth.open", async (event, url: unknown) => {
+    if (
+      !fromMainWindow(event) ||
+      event.senderFrame !== event.sender.mainFrame ||
+      typeof url !== "string" ||
+      url.length > 16_384
+    )
+      throw new Error("Invalid sign-in request.");
+    if (browserAuthAttempts.has(url) || browserAuthAttempts.size >= 8) {
+      throw new Error("A sign-in attempt is already active. Cancel it and retry.");
+    }
+    const controller = new AbortController();
+    browserAuthAttempts.set(url, controller);
+    const stop = () => controller.abort();
+    const expiry = setTimeout(stop, 10 * 60_000);
+    expiry.unref();
+    event.sender.once("destroyed", stop);
+    event.sender.once("did-navigate", stop);
+    controller.signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(expiry);
+        event.sender.removeListener("destroyed", stop);
+        event.sender.removeListener("did-navigate", stop);
+        if (browserAuthAttempts.get(url) === controller) browserAuthAttempts.delete(url);
+      },
+      { once: true },
+    );
+    try {
+      await openBrowserAuth(url, {
+        signal: controller.signal,
+        onClose: stop,
+        openExternal: (target) => shell.openExternal(target),
+        onCallback: (callback) => {
+          if (!event.sender.isDestroyed()) event.sender.send("desktop.oauth.callback", callback);
+        },
+      });
+    } catch {
+      controller.abort();
+      throw new Error("Could not open browser sign-in. Close other sign-in attempts and retry.");
+    }
+  });
+  ipcMain.handle("desktop.oauth.cancel", (event, url: unknown) => {
+    if (
+      !fromMainWindow(event) ||
+      event.senderFrame !== event.sender.mainFrame ||
+      typeof url !== "string"
+    )
+      return;
+    browserAuthAttempts.get(url)?.abort();
+  });
   ipcMain.handle("desktop.platform", () => process.platform);
   ipcMain.handle("desktop.window.close", (event) => {
     windowFrom(event)?.close();

--- a/apps/desktop/src/oauth-callback.ts
+++ b/apps/desktop/src/oauth-callback.ts
@@ -5,7 +5,7 @@ export type OAuthCallbackFromOptions = {
   excludeOrigins?: readonly string[];
 };
 
-const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+export const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 /**
  * Providers that sign in through a loopback redirect — Anthropic sends the

--- a/apps/desktop/src/preload.cjs
+++ b/apps/desktop/src/preload.cjs
@@ -15,6 +15,8 @@ contextBridge.exposeInMainWorld("rakazoDesktop", {
     install: () => ipcRenderer.invoke("desktop.update.install"),
   },
   oauth: {
+    open: (url) => ipcRenderer.invoke("desktop.oauth.open", url),
+    cancel: (url) => ipcRenderer.invoke("desktop.oauth.cancel", url),
     onCallback: (listener) => {
       // The IpcRendererEvent stays in the preload: the renderer only sees the code.
       const handler = (_event, callback) => listener(callback);

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -40,6 +40,8 @@ describe("desktop preload bridge", () => {
     ]);
     expect(Object.keys(bridge.update).sort()).toEqual(["check", "download", "install", "state"]);
 
+    await bridge.oauth.open?.("https://provider.example.com/authorize");
+    await bridge.oauth.cancel?.("https://provider.example.com/authorize");
     await bridge.window.close();
     await bridge.window.minimize();
     await bridge.window.toggleMaximize();
@@ -49,6 +51,8 @@ describe("desktop preload bridge", () => {
     await bridge.update.download();
     await bridge.update.install();
     expect(invoke.mock.calls.map(([channel]) => channel)).toEqual([
+      "desktop.oauth.open",
+      "desktop.oauth.cancel",
       "desktop.window.close",
       "desktop.window.minimize",
       "desktop.window.toggleMaximize",

--- a/apps/web/e2e/browser-auth.spec.ts
+++ b/apps/web/e2e/browser-auth.spec.ts
@@ -1,0 +1,35 @@
+import { createServer } from "node:net";
+import { expect, test } from "@playwright/test";
+import { openBrowserAuth } from "../../desktop/src/browser-auth";
+import { captureScreenshot } from "./helpers";
+
+test("browser sign-in returns a callback and shows the return-to-app message", async ({
+  page,
+}, testInfo) => {
+  const reservation = createServer();
+  await new Promise<void>((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+  const address = reservation.address();
+  if (!address || typeof address === "string") throw new Error("Missing callback port");
+  await new Promise<void>((resolve) => reservation.close(() => resolve()));
+  const callback = `http://127.0.0.1:${address.port}/callback`;
+  const authorization = new URL("https://provider.example.com/authorize");
+  authorization.searchParams.set("redirect_uri", callback);
+  authorization.searchParams.set("state", "example-state");
+  const controller = new AbortController();
+  const received: unknown[] = [];
+  try {
+    await openBrowserAuth(authorization.href, {
+      signal: controller.signal,
+      // Simulate the provider redirect without contacting a provider.
+      openExternal: async () => {
+        await page.goto(`${callback}?code=example-code&state=example-state`);
+      },
+      onCallback: (value) => received.push(value),
+    });
+    await expect(page.getByText("You can close this tab and return to Rakazo.")).toBeVisible();
+    expect(received).toEqual([{ code: "example-code", state: "example-state" }]);
+    await captureScreenshot(page, testInfo, "browser-auth-complete");
+  } finally {
+    controller.abort();
+  }
+});

--- a/apps/web/src/lib/desktop.ts
+++ b/apps/web/src/lib/desktop.ts
@@ -31,8 +31,8 @@ export function oauthStateOf(verificationUri: string): string | undefined {
 }
 
 /**
- * Sign-in popups in the desktop app redirect to a loopback URL the renderer
- * never sees. The main process captures the code there so the browser flow's
+ * Desktop sign-in redirects to a loopback URL the renderer never sees.
+ * The main process captures the code there so the browser flow's
  * copy-and-paste step can be skipped. No-ops in a browser.
  *
  * Pass the attempt's state to ignore codes captured for any other attempt.

--- a/apps/web/src/lib/use-model-oauth-signin.ts
+++ b/apps/web/src/lib/use-model-oauth-signin.ts
@@ -1,7 +1,7 @@
 import type { ModelOAuthBegin } from "@rakazo/contracts";
 import { cancelModelOAuthAttempt, finishModelOAuthAttempt } from "@rakazo/core";
 import { useEffect, useRef, useState } from "react";
-import { oauthStateOf, onDesktopOAuthCallback } from "./desktop";
+import { desktopBridge, oauthStateOf, onDesktopOAuthCallback } from "./desktop";
 import { waitForModelOAuth } from "./model-auth";
 import { rpc } from "./rpc";
 
@@ -145,7 +145,22 @@ export function useModelOAuthSignIn(options: {
           oauthStateOf(started.verificationUri),
         );
       }
-      window.open(started.verificationUri, "rakazo-model-oauth", "noopener,noreferrer");
+      const browserAuth = desktopBridge()?.oauth;
+      if (browserAuth?.open) {
+        const cancelBrowser = () =>
+          void browserAuth.cancel?.(started.verificationUri).catch(() => undefined);
+        controller.signal.addEventListener("abort", cancelBrowser, { once: true });
+        const releaseCapture = oauthCaptureRef.current;
+        oauthCaptureRef.current = () => {
+          releaseCapture?.();
+          controller.signal.removeEventListener("abort", cancelBrowser);
+          cancelBrowser();
+        };
+        await browserAuth.open(started.verificationUri);
+        if (controller.signal.aborted) return;
+      } else {
+        window.open(started.verificationUri, "rakazo-model-oauth", "noopener,noreferrer");
+      }
       waitingForCode = started.mode === "auth-url";
       if (!waitingForCode) await finishSubscriptionSignIn(started.loginId, controller);
     } catch (err) {
@@ -157,6 +172,7 @@ export function useModelOAuthSignIn(options: {
       setOauth(null);
     } finally {
       if (!waitingForCode) {
+        if (oauthAbortRef.current === controller) releaseOAuthCapture();
         finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
       }
     }

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -47,7 +47,13 @@ export interface RakazoDesktop {
   update: RakazoDesktopUpdate;
   oauth: {
     /**
-     * Authorization codes captured from a sign-in popup's loopback redirect.
+     * Open system-browser auth. A redirect_uri must be HTTP loopback with state;
+     * URLs without a redirect use backend polling. Optional for older desktops.
+     */
+    open?: (authorizationUrl: string) => Promise<void>;
+    cancel?: (authorizationUrl: string) => Promise<void>;
+    /**
+     * Authorization codes captured from the system browser or a legacy popup.
      * Returns an unsubscribe function.
      */
     onCallback: (listener: (callback: RakazoDesktopOAuthCallback) => void) => () => void;


### PR DESCRIPTION
Desktop model sign-in now opens the default browser so existing account sessions are available, using one provider-neutral browser handoff with validated loopback callbacks for authorization-code flows and existing backend polling for device-code flows.

The shared desktop bridge handles cancellation, expiry, and cleanup, preserves browser/older-desktop fallback, and reuses the existing loopback host list; other integration flows remain unchanged.

New copy appears only when relevant: “You can close this tab and return to Rakazo.” confirms the browser handoff; “Sign-in callback rejected. Return to Rakazo to retry.” identifies an invalid callback; “Invalid sign-in request.”, “A sign-in attempt is already active. Cancel it and retry.”, and “Could not open browser sign-in. Close other sign-in attempts and retry.” explain failures and recovery, so removing these messages would leave a blank browser page or unexplained failure.

Validation: 308 scoped tests passed, repository-wide type checks passed, and lint passed with existing warnings; CI browser E2E passed and captured the [callback page](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34153962024-1/screenshots/images/103-browser-auth-complete.png), while live provider authentication and local Electron E2E were not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure system-browser sign-in for the desktop app.
  - OAuth callbacks are validated and delivered back to the app.
  - Added controls to open or cancel browser-based authentication.
  - Web sign-in uses the desktop browser flow when available, with the existing fallback retained.

- **Bug Fixes**
  - Added cancellation and cleanup when authentication expires, fails, or is interrupted.

- **Tests**
  - Added coverage for browser authentication, callback validation, cancellation, and end-to-end sign-in behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->