### PR TITLE
Clarify the security and local-access tradeoff

### DIFF
--- a/apps/web/e2e/host-computer-prompt.spec.ts
+++ b/apps/web/e2e/host-computer-prompt.spec.ts
@@ -38,14 +38,19 @@ for (const platform of ["darwin", "win32"]) {
     await page.reload();
     const dialog = page.getByRole("dialog", { name: "Where should bots run?" });
     await expect(dialog).toBeVisible();
-    await expect(dialog.getByText("Docker gives bots a separate workspace.")).toBeVisible();
     const host = platform === "darwin" ? "this Mac" : "this computer";
     await expect(
       dialog.getByText(
-        `On ${host}, bots can access your files and run commands without asking. Avoid this on shared or public servers.`,
+        `Docker limits access to your computer for added security. Using ${host} lets bots work with your local files and tools.`,
       ),
     ).toBeVisible();
-    await expect(dialog.getByRole("button", { name: "Docker (recommended)" })).toBeVisible();
+    await expect(
+      dialog.getByText(
+        "Local access lets bots run commands without asking. Avoid it on shared or public servers.",
+      ),
+    ).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Docker", exact: true })).toBeVisible();
+    await expect(dialog.getByText(/recommended/i)).toHaveCount(0);
     await expect(dialog.getByRole("button", { name: `Use ${host}` })).toBeVisible();
     await captureScreenshot(page, testInfo, `host-computer-choice-${platform}`);
   });

--- a/apps/web/e2e/host-computer-prompt.spec.ts
+++ b/apps/web/e2e/host-computer-prompt.spec.ts
@@ -38,6 +38,9 @@ for (const platform of ["darwin", "win32"]) {
     await page.reload();
     const dialog = page.getByRole("dialog", { name: "Where should bots run?" });
     await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAccessibleDescription(
+      /Local access lets bots run commands without asking\. Avoid it on shared or public servers\./,
+    );
     const host = platform === "darwin" ? "this Mac" : "this computer";
     await expect(
       dialog.getByText(

--- a/apps/web/scripts/translations-de.json
+++ b/apps/web/scripts/translations-de.json
@@ -252,7 +252,6 @@
   "Dismissed. Reconnect anytime from MCP settings.": "Verworfen. Du kannst die Verbindung jederzeit in den MCP-Einstellungen wiederherstellen.",
   "Display name": "Anzeigename",
   "Do not type passwords into the demo. Use Take control for credentials.": "Gib keine Passwörter in die Demo ein. Verwende „Kontrolle übernehmen“ für Zugangsdaten.",
-  "Docker (recommended)": "Docker (empfohlen)",
   "Docker is the default: bots use a shared Team Computer.": "Docker ist der Standard: Bots verwenden einen gemeinsamen Team-Computer.",
   "Don’t have an account?": "Du hast noch kein Konto?",
   "Done": "Fertig",
@@ -580,6 +579,7 @@
   "This chat is view-only": "Dieser Chat ist schreibgeschützt",
   "Could not load this chat.": "Dieser Chat konnte nicht geladen werden.",
   "No messages with {peerBotName} yet.": "Noch keine Nachrichten mit {peerBotName}.",
-  "Docker gives bots a separate workspace.": "Docker gibt Bots einen separaten Arbeitsbereich.",
-  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "Wenn {hostLabel} verwendet wird, können Bots ohne Rückfrage auf deine Dateien zugreifen und Befehle ausführen. Vermeide dies auf gemeinsam genutzten oder öffentlichen Servern."
+  "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker begrenzt für mehr Sicherheit den Zugriff auf deinen Computer. Wenn {hostLabel} verwendet wird, können Bots mit deinen lokalen Dateien und Werkzeugen arbeiten.",
+  "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "Mit lokalem Zugriff können Bots ohne Rückfrage Befehle ausführen. Vermeide dies auf gemeinsam genutzten oder öffentlichen Servern.",
+  "Docker": "Docker"
 }

--- a/apps/web/scripts/translations-es.json
+++ b/apps/web/scripts/translations-es.json
@@ -300,7 +300,6 @@
   "Dismissed. Reconnect anytime from MCP settings.": "Descartado: puedes volver a conectar cuando quieras desde la configuración de MCP.",
   "Display name": "Nombre para mostrar",
   "Do not type passwords into the demo. Use Take control for credentials.": "No escribas contraseñas en la demo. Usa Tomar control para las credenciales.",
-  "Docker (recommended)": "Docker (recomendado)",
   "Docker is the default: bots use a shared Team Computer.": "Docker es el valor predeterminado: los bots usan una Team Computer compartida.",
   "Don’t have an account?": "¿No tienes una cuenta?",
   "Done": "Listo",
@@ -723,6 +722,7 @@
   "Asleep": "En reposo",
   "at <0/>": "a las <0/>",
   "Authorization expired — reconnect required": "Autorización expirada: se requiere reconectar",
-  "Docker gives bots a separate workspace.": "Docker les da a los bots un espacio de trabajo separado.",
-  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "En {hostLabel}, los bots pueden acceder a tus archivos y ejecutar comandos sin preguntar. Evita esta opción en servidores compartidos o públicos."
+  "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker limita el acceso a tu computadora para mayor seguridad. Usar {hostLabel} permite que los bots trabajen con tus archivos y herramientas locales.",
+  "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "El acceso local permite que los bots ejecuten comandos sin preguntar. Evítalo en servidores compartidos o públicos.",
+  "Docker": "Docker"
 }

--- a/apps/web/scripts/translations-hi.json
+++ b/apps/web/scripts/translations-hi.json
@@ -247,7 +247,6 @@
   "Dismissed. Reconnect anytime from MCP settings.": "खारिज किया गया। MCP सेटिंग्स से कभी भी पुनः कनेक्ट करें।",
   "Display name": "प्रदर्शित नाम",
   "Do not type passwords into the demo. Use Take control for credentials.": "डेमो में पासवर्ड टाइप न करें। क्रेडेंशियल्स के लिए 'टेक कंट्रोल' (Take control) का इस्तेमाल करें।",
-  "Docker (recommended)": "Docker (अनुशंसित)",
   "Docker is the default: bots use a shared Team Computer.": "Docker डिफ़ॉल्ट है: बॉट एक साझा टीम कंप्यूटर का उपयोग करते हैं।",
   "Don’t have an account?": "खाता नहीं है?",
   "Done": "पूर्ण",
@@ -583,6 +582,7 @@
   "This chat is view-only": "यह चैट केवल देखने के लिए है",
   "Could not load this chat.": "यह चैट लोड नहीं हो सकी.",
   "No messages with {peerBotName} yet.": "{peerBotName} के साथ अभी कोई संदेश नहीं.",
-  "Docker gives bots a separate workspace.": "Docker बॉट्स को अलग कार्यक्षेत्र देता है।",
-  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "{hostLabel} चुनने पर बॉट्स बिना पूछे आपकी फ़ाइलें खोल सकते हैं और कमांड चला सकते हैं। साझा या सार्वजनिक सर्वर पर इस विकल्प से बचें।"
+  "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker अतिरिक्त सुरक्षा के लिए आपके कंप्यूटर तक पहुँच सीमित करता है। {hostLabel} चुनने पर बॉट्स आपकी स्थानीय फ़ाइलों और टूल्स के साथ काम कर सकते हैं।",
+  "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "स्थानीय पहुँच मिलने पर बॉट्स बिना पूछे कमांड चला सकते हैं। साझा या सार्वजनिक सर्वर पर इससे बचें।",
+  "Docker": "Docker"
 }

--- a/apps/web/scripts/translations-ko.json
+++ b/apps/web/scripts/translations-ko.json
@@ -252,7 +252,6 @@
   "Dismissed. Reconnect anytime from MCP settings.": "지금은 연결하지 않았습니다. MCP 설정에서 언제든 다시 연결할 수 있습니다.",
   "Display name": "표시 이름",
   "Do not type passwords into the demo. Use Take control for credentials.": "시연 중에는 비밀번호를 입력하지 마세요. 인증이 필요하면 직접 조작을 사용하세요.",
-  "Docker (recommended)": "Docker에서 실행(권장)",
   "Docker is the default: bots use a shared Team Computer.": "기본 설정은 Docker이며, Bot들이 격리된 팀 컴퓨터를 함께 사용합니다.",
   "Don’t have an account?": "계정이 없나요?",
   "Done": "완료",
@@ -580,6 +579,7 @@
   "This chat is view-only": "이 채팅은 읽기 전용입니다",
   "Could not load this chat.": "이 채팅을 불러오지 못했습니다.",
   "No messages with {peerBotName} yet.": "{peerBotName}와의 메시지가 아직 없습니다.",
-  "Docker gives bots a separate workspace.": "Docker는 Bot에게 별도의 작업 공간을 제공합니다.",
-  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "{hostLabel}에서는 Bot이 묻지 않고 파일에 접근하고 명령을 실행할 수 있습니다. 공유 서버나 공개 서버에서는 이 옵션을 사용하지 마세요."
+  "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker는 보안을 위해 컴퓨터 접근을 제한합니다. {hostLabel}에서는 Bot이 로컬 파일과 도구로 작업할 수 있습니다.",
+  "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "로컬 접근을 허용하면 Bot이 묻지 않고 명령을 실행할 수 있습니다. 공유 서버나 공개 서버에서는 허용하지 마세요.",
+  "Docker": "Docker"
 }

--- a/apps/web/scripts/translations-pt-BR.json
+++ b/apps/web/scripts/translations-pt-BR.json
@@ -247,7 +247,6 @@
   "Dismissed. Reconnect anytime from MCP settings.": "Dispensado. Reconecte a qualquer momento a partir das configurações do MCP.",
   "Display name": "Nome de exibição",
   "Do not type passwords into the demo. Use Take control for credentials.": "Não digite senhas na demonstração. Use Assuma o controle das credenciais.",
-  "Docker (recommended)": "Docker (recomendado)",
   "Docker is the default: bots use a shared Team Computer.": "O Docker é o padrão: os bots usam um Computador de Equipe compartilhado.",
   "Don’t have an account?": "Não tem uma conta?",
   "Done": "Concluído",
@@ -582,6 +581,7 @@
   "This chat is view-only": "Este chat é somente leitura",
   "Could not load this chat.": "Não foi possível carregar este chat.",
   "No messages with {peerBotName} yet.": "Ainda sem mensagens com {peerBotName}.",
-  "Docker gives bots a separate workspace.": "O Docker dá aos bots um espaço de trabalho separado.",
-  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "Ao usar {hostLabel}, os bots podem acessar seus arquivos e executar comandos sem perguntar. Evite esta opção em servidores compartilhados ou públicos."
+  "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "O Docker limita o acesso ao seu computador para maior segurança. Usar {hostLabel} permite que os bots trabalhem com seus arquivos e ferramentas locais.",
+  "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "O acesso local permite que os bots executem comandos sem perguntar. Evite usá-lo em servidores compartilhados ou públicos.",
+  "Docker": "Docker"
 }

--- a/apps/web/scripts/translations-tr.json
+++ b/apps/web/scripts/translations-tr.json
@@ -248,7 +248,6 @@
   "Dismissed. Reconnect anytime from MCP settings.": "Kapatıldı. MCP ayarlarından istediğin zaman yeniden bağlanabilirsin.",
   "Display name": "Görünen ad",
   "Do not type passwords into the demo. Use Take control for credentials.": "Demoya parola yazma. Kimlik bilgileri için Kontrolü al'ı kullan.",
-  "Docker (recommended)": "Docker (önerilen)",
   "Docker is the default: bots use a shared Team Computer.": "Varsayılan Docker'dır: botlar ortak bir Takım Bilgisayarı kullanır.",
   "Don’t have an account?": "Hesabın yok mu?",
   "Done": "Bitti",
@@ -577,6 +576,7 @@
   "This chat is view-only": "Bu sohbet yalnızca görüntülenebilir",
   "Could not load this chat.": "Bu sohbet yüklenemedi.",
   "No messages with {peerBotName} yet.": "{peerBotName} ile henüz mesaj yok.",
-  "Docker gives bots a separate workspace.": "Docker, botlara ayrı bir çalışma alanı sağlar.",
-  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "{hostLabel} kullanıldığında botlar sormadan dosyalarına erişebilir ve komut çalıştırabilir. Paylaşılan veya herkese açık sunucularda bu seçeneği kullanma."
+  "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker, ek güvenlik için bilgisayarına erişimi sınırlar. {hostLabel} kullanıldığında botlar yerel dosyaların ve araçlarınla çalışabilir.",
+  "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "Yerel erişim, botların sormadan komut çalıştırmasına izin verir. Paylaşılan veya herkese açık sunucularda bunu kullanma.",
+  "Docker": "Docker"
 }

--- a/apps/web/scripts/translations-zh-CN.json
+++ b/apps/web/scripts/translations-zh-CN.json
@@ -252,7 +252,6 @@
   "Dismissed. Reconnect anytime from MCP settings.": "已关闭，可随时在 MCP 设置中重新连接。",
   "Display name": "显示名称",
   "Do not type passwords into the demo. Use Take control for credentials.": "不要在示范中输入密码。凭据请用「接管」。",
-  "Docker (recommended)": "Docker（推荐）",
   "Docker is the default: bots use a shared Team Computer.": "默认使用 Docker：Bot 共用一台团队电脑。",
   "Don’t have an account?": "还没有账户？",
   "Done": "完成",
@@ -729,6 +728,7 @@
   "Webhook": "Webhook",
   "What should this routine do each time it runs?": "每次运行时，这个例行任务应做什么？",
   "When a webhook fires": "当 Webhook 触发时",
-  "Docker gives bots a separate workspace.": "Docker 为 Bot 提供独立的工作空间。",
-  "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers.": "使用{hostLabel}时，Bot 可以直接访问你的文件并执行命令，无需询问。请勿在共享或公开服务器上使用此选项。"
+  "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker 限制对你电脑的访问，以提高安全性。使用{hostLabel}时，Bot 可以处理你的本地文件并使用本地工具。",
+  "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "本地访问权限允许 Bot 无需询问就执行命令。请勿在共享或公开服务器上启用。",
+  "Docker": "Docker"
 }

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "Usage"
 msgstr "Nutzung"
 
-#: src/pages/HostComputerPrompt.tsx:84
+#: src/pages/HostComputerPrompt.tsx:92
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} verwenden"
 
@@ -3309,14 +3309,14 @@ msgstr "Executor verbinden"
 msgid "Executor token"
 msgstr "Executor-Token"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Docker"
 msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:62
+#: src/pages/HostComputerPrompt.tsx:63
 msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
 msgstr "Docker begrenzt für mehr Sicherheit den Zugriff auf deinen Computer. Wenn {hostLabel} verwendet wird, können Bots mit deinen lokalen Dateien und Werkzeugen arbeiten."
 
-#: src/pages/HostComputerPrompt.tsx:88
+#: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "Mit lokalem Zugriff können Bots ohne Rückfrage Befehle ausführen. Vermeide dies auf gemeinsam genutzten oder öffentlichen Servern."

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -1391,10 +1391,6 @@ msgstr "Anzeigename"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "Gib keine Passwörter in die Demo ein. Verwende „Kontrolle übernehmen“ für Zugangsdaten."
 
-#: src/pages/HostComputerPrompt.tsx:68
-msgid "Docker (recommended)"
-msgstr "Docker (empfohlen)"
-
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
 msgstr "Du hast noch kein Konto?"
@@ -3076,7 +3072,7 @@ msgstr ""
 msgid "Usage"
 msgstr "Nutzung"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} verwenden"
 
@@ -3313,10 +3309,14 @@ msgstr "Executor verbinden"
 msgid "Executor token"
 msgstr "Executor-Token"
 
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker gives bots a separate workspace."
-msgstr "Docker gibt Bots einen separaten Arbeitsbereich."
+#: src/pages/HostComputerPrompt.tsx:76
+msgid "Docker"
+msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:80
-msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr "Wenn {hostLabel} verwendet wird, können Bots ohne Rückfrage auf deine Dateien zugreifen und Befehle ausführen. Vermeide dies auf gemeinsam genutzten oder öffentlichen Servern."
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
+msgstr "Docker begrenzt für mehr Sicherheit den Zugriff auf deinen Computer. Wenn {hostLabel} verwendet wird, können Bots mit deinen lokalen Dateien und Werkzeugen arbeiten."
+
+#: src/pages/HostComputerPrompt.tsx:88
+msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
+msgstr "Mit lokalem Zugriff können Bots ohne Rückfrage Befehle ausführen. Vermeide dies auf gemeinsam genutzten oder öffentlichen Servern."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -3072,7 +3072,7 @@ msgstr "Updating…"
 msgid "Usage"
 msgstr "Usage"
 
-#: src/pages/HostComputerPrompt.tsx:84
+#: src/pages/HostComputerPrompt.tsx:92
 msgid "Use {hostLabel}"
 msgstr "Use {hostLabel}"
 
@@ -3309,14 +3309,14 @@ msgstr "Connect Executor"
 msgid "Executor token"
 msgstr "Executor token"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Docker"
 msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:62
+#: src/pages/HostComputerPrompt.tsx:63
 msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
 msgstr "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
 
-#: src/pages/HostComputerPrompt.tsx:88
+#: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "Local access lets bots run commands without asking. Avoid it on shared or public servers."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -1391,10 +1391,6 @@ msgstr "Display name"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "Do not type passwords into the demo. Use Take control for credentials."
 
-#: src/pages/HostComputerPrompt.tsx:68
-msgid "Docker (recommended)"
-msgstr "Docker (recommended)"
-
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
 msgstr "Don’t have an account?"
@@ -3076,7 +3072,7 @@ msgstr "Updating…"
 msgid "Usage"
 msgstr "Usage"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Use {hostLabel}"
 msgstr "Use {hostLabel}"
 
@@ -3313,10 +3309,14 @@ msgstr "Connect Executor"
 msgid "Executor token"
 msgstr "Executor token"
 
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker gives bots a separate workspace."
-msgstr "Docker gives bots a separate workspace."
+#: src/pages/HostComputerPrompt.tsx:76
+msgid "Docker"
+msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:80
-msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
+msgstr "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
+
+#: src/pages/HostComputerPrompt.tsx:88
+msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
+msgstr "Local access lets bots run commands without asking. Avoid it on shared or public servers."

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -1365,10 +1365,6 @@ msgstr "Nombre para mostrar"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "No escribas contraseñas en la demo. Usa Tomar control para las credenciales."
 
-#: src/pages/HostComputerPrompt.tsx:68
-msgid "Docker (recommended)"
-msgstr "Docker (recomendado)"
-
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
 msgstr "¿No tienes una cuenta?"
@@ -3036,7 +3032,7 @@ msgstr "Actualizando…"
 msgid "Usage"
 msgstr "Uso"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Use {hostLabel}"
 msgstr "Usar {hostLabel}"
 
@@ -3273,10 +3269,14 @@ msgstr "Conectar Executor"
 msgid "Executor token"
 msgstr "Token de Executor"
 
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker gives bots a separate workspace."
-msgstr "Docker les da a los bots un espacio de trabajo separado."
+#: src/pages/HostComputerPrompt.tsx:76
+msgid "Docker"
+msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:80
-msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr "En {hostLabel}, los bots pueden acceder a tus archivos y ejecutar comandos sin preguntar. Evita esta opción en servidores compartidos o públicos."
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
+msgstr "Docker limita el acceso a tu computadora para mayor seguridad. Usar {hostLabel} permite que los bots trabajen con tus archivos y herramientas locales."
+
+#: src/pages/HostComputerPrompt.tsx:88
+msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
+msgstr "El acceso local permite que los bots ejecuten comandos sin preguntar. Evítalo en servidores compartidos o públicos."

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -3032,7 +3032,7 @@ msgstr "Actualizando…"
 msgid "Usage"
 msgstr "Uso"
 
-#: src/pages/HostComputerPrompt.tsx:84
+#: src/pages/HostComputerPrompt.tsx:92
 msgid "Use {hostLabel}"
 msgstr "Usar {hostLabel}"
 
@@ -3269,14 +3269,14 @@ msgstr "Conectar Executor"
 msgid "Executor token"
 msgstr "Token de Executor"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Docker"
 msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:62
+#: src/pages/HostComputerPrompt.tsx:63
 msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
 msgstr "Docker limita el acceso a tu computadora para mayor seguridad. Usar {hostLabel} permite que los bots trabajen con tus archivos y herramientas locales."
 
-#: src/pages/HostComputerPrompt.tsx:88
+#: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "El acceso local permite que los bots ejecuten comandos sin preguntar. Evítalo en servidores compartidos o públicos."

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3072,7 +3072,7 @@ msgstr "अपडेट हो रहा है…"
 msgid "Usage"
 msgstr "उपयोग"
 
-#: src/pages/HostComputerPrompt.tsx:84
+#: src/pages/HostComputerPrompt.tsx:92
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} का उपयोग करें"
 
@@ -3309,14 +3309,14 @@ msgstr "Executor कनेक्ट करें"
 msgid "Executor token"
 msgstr "Executor टोकन"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Docker"
 msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:62
+#: src/pages/HostComputerPrompt.tsx:63
 msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
 msgstr "Docker अतिरिक्त सुरक्षा के लिए आपके कंप्यूटर तक पहुँच सीमित करता है। {hostLabel} चुनने पर बॉट्स आपकी स्थानीय फ़ाइलों और टूल्स के साथ काम कर सकते हैं।"
 
-#: src/pages/HostComputerPrompt.tsx:88
+#: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "स्थानीय पहुँच मिलने पर बॉट्स बिना पूछे कमांड चला सकते हैं। साझा या सार्वजनिक सर्वर पर इससे बचें।"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -1391,10 +1391,6 @@ msgstr "प्रदर्शित नाम"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "डेमो में पासवर्ड टाइप न करें। क्रेडेंशियल्स के लिए 'टेक कंट्रोल' (Take control) का इस्तेमाल करें।"
 
-#: src/pages/HostComputerPrompt.tsx:68
-msgid "Docker (recommended)"
-msgstr "Docker (अनुशंसित)"
-
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
 msgstr "खाता नहीं है?"
@@ -3076,7 +3072,7 @@ msgstr "अपडेट हो रहा है…"
 msgid "Usage"
 msgstr "उपयोग"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} का उपयोग करें"
 
@@ -3313,10 +3309,14 @@ msgstr "Executor कनेक्ट करें"
 msgid "Executor token"
 msgstr "Executor टोकन"
 
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker gives bots a separate workspace."
-msgstr "Docker बॉट्स को अलग कार्यक्षेत्र देता है।"
+#: src/pages/HostComputerPrompt.tsx:76
+msgid "Docker"
+msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:80
-msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr "{hostLabel} चुनने पर बॉट्स बिना पूछे आपकी फ़ाइलें खोल सकते हैं और कमांड चला सकते हैं। साझा या सार्वजनिक सर्वर पर इस विकल्प से बचें।"
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
+msgstr "Docker अतिरिक्त सुरक्षा के लिए आपके कंप्यूटर तक पहुँच सीमित करता है। {hostLabel} चुनने पर बॉट्स आपकी स्थानीय फ़ाइलों और टूल्स के साथ काम कर सकते हैं।"
+
+#: src/pages/HostComputerPrompt.tsx:88
+msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
+msgstr "स्थानीय पहुँच मिलने पर बॉट्स बिना पूछे कमांड चला सकते हैं। साझा या सार्वजनिक सर्वर पर इससे बचें।"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -1391,10 +1391,6 @@ msgstr "표시 이름"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "시연 중에는 비밀번호를 입력하지 마세요. 인증이 필요하면 직접 조작을 사용하세요."
 
-#: src/pages/HostComputerPrompt.tsx:68
-msgid "Docker (recommended)"
-msgstr "Docker에서 실행(권장)"
-
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
 msgstr "계정이 없나요?"
@@ -3076,7 +3072,7 @@ msgstr "업데이트 중…"
 msgid "Usage"
 msgstr "사용량"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} 사용"
 
@@ -3313,10 +3309,14 @@ msgstr "Executor 연결"
 msgid "Executor token"
 msgstr "Executor 토큰"
 
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker gives bots a separate workspace."
-msgstr "Docker는 Bot에게 별도의 작업 공간을 제공합니다."
+#: src/pages/HostComputerPrompt.tsx:76
+msgid "Docker"
+msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:80
-msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr "{hostLabel}에서는 Bot이 묻지 않고 파일에 접근하고 명령을 실행할 수 있습니다. 공유 서버나 공개 서버에서는 이 옵션을 사용하지 마세요."
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
+msgstr "Docker는 보안을 위해 컴퓨터 접근을 제한합니다. {hostLabel}에서는 Bot이 로컬 파일과 도구로 작업할 수 있습니다."
+
+#: src/pages/HostComputerPrompt.tsx:88
+msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
+msgstr "로컬 접근을 허용하면 Bot이 묻지 않고 명령을 실행할 수 있습니다. 공유 서버나 공개 서버에서는 허용하지 마세요."

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3072,7 +3072,7 @@ msgstr "업데이트 중…"
 msgid "Usage"
 msgstr "사용량"
 
-#: src/pages/HostComputerPrompt.tsx:84
+#: src/pages/HostComputerPrompt.tsx:92
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} 사용"
 
@@ -3309,14 +3309,14 @@ msgstr "Executor 연결"
 msgid "Executor token"
 msgstr "Executor 토큰"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Docker"
 msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:62
+#: src/pages/HostComputerPrompt.tsx:63
 msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
 msgstr "Docker는 보안을 위해 컴퓨터 접근을 제한합니다. {hostLabel}에서는 Bot이 로컬 파일과 도구로 작업할 수 있습니다."
 
-#: src/pages/HostComputerPrompt.tsx:88
+#: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "로컬 접근을 허용하면 Bot이 묻지 않고 명령을 실행할 수 있습니다. 공유 서버나 공개 서버에서는 허용하지 마세요."

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -1391,10 +1391,6 @@ msgstr "Nome de exibição"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "Não digite senhas na demonstração. Use Assuma o controle das credenciais."
 
-#: src/pages/HostComputerPrompt.tsx:68
-msgid "Docker (recommended)"
-msgstr "Docker (recomendado)"
-
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
 msgstr "Não tem uma conta?"
@@ -3076,7 +3072,7 @@ msgstr "Atualizando…"
 msgid "Usage"
 msgstr "Uso"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Use {hostLabel}"
 msgstr "Usar {hostLabel}"
 
@@ -3313,10 +3309,14 @@ msgstr "Conectar Executor"
 msgid "Executor token"
 msgstr "Token do Executor"
 
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker gives bots a separate workspace."
-msgstr "O Docker dá aos bots um espaço de trabalho separado."
+#: src/pages/HostComputerPrompt.tsx:76
+msgid "Docker"
+msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:80
-msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr "Ao usar {hostLabel}, os bots podem acessar seus arquivos e executar comandos sem perguntar. Evite esta opção em servidores compartilhados ou públicos."
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
+msgstr "O Docker limita o acesso ao seu computador para maior segurança. Usar {hostLabel} permite que os bots trabalhem com seus arquivos e ferramentas locais."
+
+#: src/pages/HostComputerPrompt.tsx:88
+msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
+msgstr "O acesso local permite que os bots executem comandos sem perguntar. Evite usá-lo em servidores compartilhados ou públicos."

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3072,7 +3072,7 @@ msgstr "Atualizando…"
 msgid "Usage"
 msgstr "Uso"
 
-#: src/pages/HostComputerPrompt.tsx:84
+#: src/pages/HostComputerPrompt.tsx:92
 msgid "Use {hostLabel}"
 msgstr "Usar {hostLabel}"
 
@@ -3309,14 +3309,14 @@ msgstr "Conectar Executor"
 msgid "Executor token"
 msgstr "Token do Executor"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Docker"
 msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:62
+#: src/pages/HostComputerPrompt.tsx:63
 msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
 msgstr "O Docker limita o acesso ao seu computador para maior segurança. Usar {hostLabel} permite que os bots trabalhem com seus arquivos e ferramentas locais."
 
-#: src/pages/HostComputerPrompt.tsx:88
+#: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "O acesso local permite que os bots executem comandos sem perguntar. Evite usá-lo em servidores compartilhados ou públicos."

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -1391,10 +1391,6 @@ msgstr "Görünen ad"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "Demoya parola yazma. Kimlik bilgileri için Kontrolü al'ı kullan."
 
-#: src/pages/HostComputerPrompt.tsx:68
-msgid "Docker (recommended)"
-msgstr "Docker (önerilen)"
-
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
 msgstr "Hesabın yok mu?"
@@ -3076,7 +3072,7 @@ msgstr ""
 msgid "Usage"
 msgstr "Kullanım"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} kullan"
 
@@ -3313,10 +3309,14 @@ msgstr "Executor'a bağlan"
 msgid "Executor token"
 msgstr "Executor belirteci"
 
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker gives bots a separate workspace."
-msgstr "Docker, botlara ayrı bir çalışma alanı sağlar."
+#: src/pages/HostComputerPrompt.tsx:76
+msgid "Docker"
+msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:80
-msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr "{hostLabel} kullanıldığında botlar sormadan dosyalarına erişebilir ve komut çalıştırabilir. Paylaşılan veya herkese açık sunucularda bu seçeneği kullanma."
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
+msgstr "Docker, ek güvenlik için bilgisayarına erişimi sınırlar. {hostLabel} kullanıldığında botlar yerel dosyaların ve araçlarınla çalışabilir."
+
+#: src/pages/HostComputerPrompt.tsx:88
+msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
+msgstr "Yerel erişim, botların sormadan komut çalıştırmasına izin verir. Paylaşılan veya herkese açık sunucularda bunu kullanma."

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "Usage"
 msgstr "Kullanım"
 
-#: src/pages/HostComputerPrompt.tsx:84
+#: src/pages/HostComputerPrompt.tsx:92
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} kullan"
 
@@ -3309,14 +3309,14 @@ msgstr "Executor'a bağlan"
 msgid "Executor token"
 msgstr "Executor belirteci"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Docker"
 msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:62
+#: src/pages/HostComputerPrompt.tsx:63
 msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
 msgstr "Docker, ek güvenlik için bilgisayarına erişimi sınırlar. {hostLabel} kullanıldığında botlar yerel dosyaların ve araçlarınla çalışabilir."
 
-#: src/pages/HostComputerPrompt.tsx:88
+#: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "Yerel erişim, botların sormadan komut çalıştırmasına izin verir. Paylaşılan veya herkese açık sunucularda bunu kullanma."

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -3072,7 +3072,7 @@ msgstr "正在更新…"
 msgid "Usage"
 msgstr "用量"
 
-#: src/pages/HostComputerPrompt.tsx:84
+#: src/pages/HostComputerPrompt.tsx:92
 msgid "Use {hostLabel}"
 msgstr "使用 {hostLabel}"
 
@@ -3309,14 +3309,14 @@ msgstr "连接 Executor"
 msgid "Executor token"
 msgstr "Executor 令牌"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Docker"
 msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:62
+#: src/pages/HostComputerPrompt.tsx:63
 msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
 msgstr "Docker 限制对你电脑的访问，以提高安全性。使用{hostLabel}时，Bot 可以处理你的本地文件并使用本地工具。"
 
-#: src/pages/HostComputerPrompt.tsx:88
+#: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "本地访问权限允许 Bot 无需询问就执行命令。请勿在共享或公开服务器上启用。"

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -1391,10 +1391,6 @@ msgstr "显示名称"
 msgid "Do not type passwords into the demo. Use Take control for credentials."
 msgstr "不要在示范中输入密码。凭据请用「接管」。"
 
-#: src/pages/HostComputerPrompt.tsx:68
-msgid "Docker (recommended)"
-msgstr "Docker（推荐）"
-
 #: src/pages/Auth.tsx:197
 msgid "Don’t have an account?"
 msgstr "还没有账户？"
@@ -3076,7 +3072,7 @@ msgstr "正在更新…"
 msgid "Usage"
 msgstr "用量"
 
-#: src/pages/HostComputerPrompt.tsx:76
+#: src/pages/HostComputerPrompt.tsx:84
 msgid "Use {hostLabel}"
 msgstr "使用 {hostLabel}"
 
@@ -3313,10 +3309,14 @@ msgstr "连接 Executor"
 msgid "Executor token"
 msgstr "Executor 令牌"
 
-#: src/pages/HostComputerPrompt.tsx:62
-msgid "Docker gives bots a separate workspace."
-msgstr "Docker 为 Bot 提供独立的工作空间。"
+#: src/pages/HostComputerPrompt.tsx:76
+msgid "Docker"
+msgstr "Docker"
 
-#: src/pages/HostComputerPrompt.tsx:80
-msgid "On {hostLabel}, bots can access your files and run commands without asking. Avoid this on shared or public servers."
-msgstr "使用{hostLabel}时，Bot 可以直接访问你的文件并执行命令，无需询问。请勿在共享或公开服务器上使用此选项。"
+#: src/pages/HostComputerPrompt.tsx:62
+msgid "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools."
+msgstr "Docker 限制对你电脑的访问，以提高安全性。使用{hostLabel}时，Bot 可以处理你的本地文件并使用本地工具。"
+
+#: src/pages/HostComputerPrompt.tsx:88
+msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
+msgstr "本地访问权限允许 Bot 无需询问就执行命令。请勿在共享或公开服务器上启用。"

--- a/apps/web/src/pages/HostComputerPrompt.tsx
+++ b/apps/web/src/pages/HostComputerPrompt.tsx
@@ -58,11 +58,19 @@ export function HostComputerPrompt({ initialMe }: { initialMe?: Me }) {
           <DialogTitle className="text-[22px]">
             <Trans>Where should bots run?</Trans>
           </DialogTitle>
-          <DialogDescription className="leading-relaxed">
-            <Trans>
-              Docker limits access to your computer for added security. Using {hostLabel} lets bots
-              work with your local files and tools.
-            </Trans>
+          <DialogDescription className="space-y-2 leading-relaxed">
+            <span className="block">
+              <Trans>
+                Docker limits access to your computer for added security. Using {hostLabel} lets bots
+                work with your local files and tools.
+              </Trans>
+            </span>
+            <span className="block text-xs text-muted-foreground/80">
+              <Trans>
+                Local access lets bots run commands without asking. Avoid it on shared or public
+                servers.
+              </Trans>
+            </span>
           </DialogDescription>
         </DialogHeader>
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
@@ -84,12 +92,6 @@ export function HostComputerPrompt({ initialMe }: { initialMe?: Me }) {
             <Trans>Use {hostLabel}</Trans>
           </Button>
         </div>
-        <p className="text-xs leading-relaxed text-muted-foreground/80">
-          <Trans>
-            Local access lets bots run commands without asking. Avoid it on shared or public
-            servers.
-          </Trans>
-        </p>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/pages/HostComputerPrompt.tsx
+++ b/apps/web/src/pages/HostComputerPrompt.tsx
@@ -59,13 +59,21 @@ export function HostComputerPrompt({ initialMe }: { initialMe?: Me }) {
             <Trans>Where should bots run?</Trans>
           </DialogTitle>
           <DialogDescription className="leading-relaxed">
-            <Trans>Docker gives bots a separate workspace.</Trans>
+            <Trans>
+              Docker limits access to your computer for added security. Using {hostLabel} lets bots
+              work with your local files and tools.
+            </Trans>
           </DialogDescription>
         </DialogHeader>
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
         <div className="flex flex-col gap-2">
-          <Button size="lg" disabled={pending} onClick={() => void choose("docker")}>
-            <Trans>Docker (recommended)</Trans>
+          <Button
+            variant="outline"
+            size="lg"
+            disabled={pending}
+            onClick={() => void choose("docker")}
+          >
+            <Trans>Docker</Trans>
           </Button>
           <Button
             variant="outline"
@@ -78,8 +86,8 @@ export function HostComputerPrompt({ initialMe }: { initialMe?: Me }) {
         </div>
         <p className="text-xs leading-relaxed text-muted-foreground/80">
           <Trans>
-            On {hostLabel}, bots can access your files and run commands without asking. Avoid this
-            on shared or public servers.
+            Local access lets bots run commands without asking. Avoid it on shared or public
+            servers.
           </Trans>
         </p>
       </DialogContent>

--- a/apps/web/src/pages/HostComputerPrompt.tsx
+++ b/apps/web/src/pages/HostComputerPrompt.tsx
@@ -61,8 +61,8 @@ export function HostComputerPrompt({ initialMe }: { initialMe?: Me }) {
           <DialogDescription className="space-y-2 leading-relaxed">
             <span className="block">
               <Trans>
-                Docker limits access to your computer for added security. Using {hostLabel} lets bots
-                work with your local files and tools.
+                Docker limits access to your computer for added security. Using {hostLabel} lets
+                bots work with your local files and tools.
               </Trans>
             </span>
             <span className="block text-xs text-muted-foreground/80">


### PR DESCRIPTION
The first-run choice now presents Docker isolation and local file/tool access neutrally, removing “recommended,” giving both buttons equal styling, and updating all translations; this explanation and warning must be visible before choosing because hiding them would conceal the security and capability tradeoff.

Copy:

> Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.

> Local access lets bots run commands without asking. Avoid it on shared or public servers.

Button: “Docker”

Validation: web typecheck, formatting, translation compilation, catalog tests, and both Mac/Windows browser tests passed; all CI checks passed, including the accessible-description assertion


CI screenshots: [Mac](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34153636151-1/screenshots/images/135-host-computer-choice-darwin.png) · [Windows](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34153636151-1/screenshots/images/136-host-computer-choice-win32.png)
