### PR TITLE
Stop CodeRabbit from reviewing CSS with Stylelint

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+reviews:
+  tools:
+    # Biome owns this repo's CSS (see biome.json and `pnpm lint`); Stylelint is not
+    # installed or configured here, so its findings are about rules we do not run.
+    stylelint:
+      enabled: false


### PR DESCRIPTION
## Why

CodeRabbit runs its own bundled Stylelint against every PR and reports findings as though they came from a configured rule; on #780 it asked to rewrite `currentColor` as `currentcolor`, which no linter here enforces and which would have made one stylesheet disagree with every other one in the repo.

## What changed

Adds `.coderabbit.yaml` turning off the Stylelint integration. Biome is the only CSS linter and formatter this repo runs (`biome.json` has the CSS parser section and `pnpm lint` is `biome check .` in CI), and it deliberately leaves keyword case alone while still normalizing hex colors and units — I verified that by running `biome check --write` over a sample stylesheet. Adding Stylelint for real would mean a second CSS toolchain, config, and CI step across the eight stylesheets we have, one of which Biome does not even scan, so declining the finding and silencing its source is the smaller change.

## How it was tested

Config only, no code paths touched: the file validates against the CodeRabbit v2 schema (`reviews.tools.stylelint.enabled` is a documented boolean) and Biome ignores YAML, so `pnpm lint` is unaffected. The real check is that CodeRabbit's next review of a CSS change reports no Stylelint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)