### PR TITLE
feat(subagents): allow connected model selection

### DIFF
--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -327,6 +327,22 @@ export interface AgentSteeringMessage {
   images?: AgentInputImage[];
 }
 
+export interface AgentRunModel {
+  provider: string;
+  id: string;
+  apiKey?: string;
+  baseUrl?: string;
+  /** Whether this custom connection accepts standard reasoning_effort. */
+  reasoning?: boolean;
+  /** Preferred thinking effort for reasoning models; clamped to the model’s supported set. */
+  thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | null;
+  /** In-process OAuth credential from the encrypted store for this run. */
+  oauth?: {
+    credential: AgentModelOAuthCredential;
+    persist?: (credential: AgentModelOAuthCredential) => Promise<void>;
+  };
+}
+
 export interface AgentRunRequest {
   botId: string;
   threadId: string;
@@ -337,21 +353,9 @@ export interface AgentRunRequest {
   history: Array<{ id?: string; role: "user" | "assistant" | "system"; content: string }>;
   currentTurnImages?: AgentInputImage[];
   tools: ConnectorTool[];
-  model: {
-    provider: string;
-    id: string;
-    apiKey?: string;
-    baseUrl?: string;
-    /** Whether this custom connection accepts standard reasoning_effort. */
-    reasoning?: boolean;
-    /** Preferred thinking effort for reasoning models; clamped to the model’s supported set. */
-    thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | null;
-    /** In-process OAuth credential from the encrypted store for this run. */
-    oauth?: {
-      credential: AgentModelOAuthCredential;
-      persist?: (credential: AgentModelOAuthCredential) => Promise<void>;
-    };
-  };
+  model: AgentRunModel;
+  /** Resolve an explicitly requested helper model within the active user and space scope. */
+  resolveModel?: (provider: string, modelId: string) => Promise<AgentRunModel>;
   resumeFromCheckpoint?: string;
   script?: ScriptedTurn[];
   /**

--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -690,6 +690,14 @@ export const builtinAgentTools: ConnectorTool[] = [
           type: "string",
           description: "Optional extra system instructions for the helper.",
         },
+        model_provider: {
+          type: "string",
+          description: "Optional connected model provider. Set together with model_id.",
+        },
+        model_id: {
+          type: "string",
+          description: "Optional connected model ID. Set together with model_provider.",
+        },
       },
       required: ["name", "task"],
     },

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -1127,6 +1127,49 @@ description: Prepare standup notes
     );
   });
 
+  it("resolves an explicit subagent model within the active user and space", async () => {
+    const preference = modelPreference({
+      provider: "xai",
+      secretId: "secret-xai",
+      modelId: "grok-4.6",
+      isDefault: false,
+    });
+    const findFirst = vi.fn(
+      async (args: { where: { credential?: { provider?: string }; modelId?: string } }) => {
+        if (args.where.credential?.provider !== "xai") return null;
+        if (args.where.modelId && args.where.modelId !== "grok-4.6") return null;
+        return preference;
+      },
+    );
+    const prisma = {
+      spaceModelPreference: { findFirst },
+      userModelCredential: { findFirst: vi.fn(async () => null) },
+      secret: { findFirst: vi.fn(async () => null), findUnique: vi.fn(async () => null) },
+    } as unknown as PrismaClient;
+    const executor = createRunExecutor({
+      prisma,
+      secretStore: { load: vi.fn(), put: vi.fn() },
+    } as unknown as Parameters<typeof createRunExecutor>[0]);
+
+    const model = await executor.resolveConnectedModel(
+      { userId: "user-1", spaceId: "ws-1" },
+      "xai",
+      "grok-4.6",
+    );
+
+    expect(model).toMatchObject({ provider: "xai", id: "grok-4.6", thinkingLevel: null });
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          spaceId: "ws-1",
+          userId: "user-1",
+          modelId: "grok-4.6",
+          credential: { provider: "xai" },
+        }),
+      }),
+    );
+  });
+
   it("falls back to the Space default when the override provider has no credential", async () => {
     const findFirst = vi.fn(
       async (args: { where: { credential?: { provider?: string }; isDefault?: boolean } }) => {

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -1170,6 +1170,45 @@ description: Prepare standup notes
     );
   });
 
+  it("rejects a free-form selection when the owning preference disappears", async () => {
+    const preference = modelPreference({
+      provider: "openai-compatible",
+      secretId: "secret-compat",
+      modelId: "newest-model",
+      isDefault: true,
+    });
+    const findFirst = vi.fn(
+      async (args: {
+        where: { credential?: { provider?: string; userId?: string }; modelId?: string };
+        select?: unknown;
+      }) => {
+        if (args.select) {
+          return args.where.modelId === "private-model" ? { id: "saved" } : null;
+        }
+        if (args.where.modelId === "private-model") return null;
+        if (args.where.credential?.provider === "openai-compatible") return preference;
+        return null;
+      },
+    );
+    const prisma = {
+      spaceModelPreference: { findFirst },
+      userModelCredential: { findFirst: vi.fn(async () => null) },
+      secret: { findFirst: vi.fn(async () => null), findUnique: vi.fn(async () => null) },
+    } as unknown as PrismaClient;
+    const executor = createRunExecutor({
+      prisma,
+      secretStore: { load: vi.fn(), put: vi.fn() },
+    } as unknown as Parameters<typeof createRunExecutor>[0]);
+
+    await expect(
+      executor.resolveConnectedModel(
+        { userId: "user-1", spaceId: "ws-1" },
+        "openai-compatible",
+        "private-model",
+      ),
+    ).rejects.toThrow("Unknown model for that provider");
+  });
+
   it("falls back to the Space default when the override provider has no credential", async () => {
     const findFirst = vi.fn(
       async (args: { where: { credential?: { provider?: string }; isDefault?: boolean } }) => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -211,7 +211,11 @@ import {
 import { loadAgentMemoryContext } from "./memory-context.js";
 import type { MemoryProviderResolver } from "./memory-provider-factory.js";
 import { selectMemoryTools } from "./memory-tools.js";
-import { selectConfiguredModel, validateConnectedModelChoice } from "./model-selection.js";
+import {
+  isCatalogModelChoice,
+  selectConfiguredModel,
+  validateConnectedModelChoice,
+} from "./model-selection.js";
 import {
   filterImageReturningComputerTools,
   IMAGE_RETURNING_COMPUTER_TOOLS,
@@ -721,6 +725,12 @@ export function createRunExecutor(deps: ExecutorDeps) {
     if (validationError) throw new Error(validationError);
     const credential = await findModelCredential(deps.prisma, scope, provider, modelId);
     if (!credential) throw new Error("Connect that model provider first");
+    // Free-form selections must keep the preference that owns this modelId. A
+    // intervening delete/change can make findModelCredential fall back to another
+    // same-provider credential; reject that mismatch instead of mixing baseUrl.
+    if (!isCatalogModelChoice(provider, modelId) && credential.defaultModel !== modelId) {
+      throw new Error("Unknown model for that provider");
+    }
     const resolved = await resolveModelKey(
       deps,
       scope.userId,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -211,7 +211,7 @@ import {
 import { loadAgentMemoryContext } from "./memory-context.js";
 import type { MemoryProviderResolver } from "./memory-provider-factory.js";
 import { selectMemoryTools } from "./memory-tools.js";
-import { selectConfiguredModel } from "./model-selection.js";
+import { selectConfiguredModel, validateConnectedModelChoice } from "./model-selection.js";
 import {
   filterImageReturningComputerTools,
   IMAGE_RETURNING_COMPUTER_TOOLS,
@@ -706,7 +706,43 @@ export function createRunExecutor(deps: ExecutorDeps) {
   const web = deps.web ?? createWebProvider();
   const browser = deps.browser ?? createBrowserProvider(undefined, { sandbox: deps.sandbox });
   const cloudAgent = deps.cloudAgent;
+  const resolveConnectedModel = async (
+    scope: { userId: string; spaceId: string },
+    provider: string,
+    modelId: string,
+    registerSecrets?: (values: string[]) => void,
+  ): Promise<AgentRunRequest["model"]> => {
+    const validationError = await validateConnectedModelChoice(
+      deps.prisma,
+      scope,
+      provider,
+      modelId,
+    );
+    if (validationError) throw new Error(validationError);
+    const credential = await findModelCredential(deps.prisma, scope, provider, modelId);
+    if (!credential) throw new Error("Connect that model provider first");
+    const resolved = await resolveModelKey(
+      deps,
+      scope.userId,
+      scope.spaceId,
+      credential,
+      provider,
+      registerSecrets,
+    );
+    return {
+      provider,
+      id: modelId,
+      apiKey: resolved.oauth ? undefined : resolved.apiKey,
+      baseUrl: resolved.baseUrl,
+      reasoning: resolved.reasoning,
+      thinkingLevel: null,
+      oauth: resolved.oauth
+        ? { credential: resolved.oauth, persist: resolved.persistOAuth }
+        : undefined,
+    };
+  };
   return {
+    resolveConnectedModel,
     async resolveModel(scope: {
       userId: string;
       spaceId: string;
@@ -725,7 +761,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
       const hasOverride = Boolean(override?.modelProvider && override.modelId);
       const [overrideCredential, defaultCredential, settings] = await Promise.all([
         hasOverride
-          ? findModelCredential(deps.prisma, scope, override!.modelProvider!)
+          ? findModelCredential(deps.prisma, scope, override!.modelProvider!, override!.modelId)
           : Promise.resolve(null),
         findDefaultModelCredential(deps.prisma, scope),
         deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
@@ -1071,7 +1107,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         const hasModelOverride = Boolean(bot.modelProvider && bot.modelId);
         const overrideCredential =
           hasModelOverride && bot.modelProvider
-            ? await findModelCredential(deps.prisma, run, bot.modelProvider)
+            ? await findModelCredential(deps.prisma, run, bot.modelProvider, bot.modelId)
             : null;
         runAbortController = new AbortController();
         if (!leaseValid) runAbortController.abort();
@@ -3288,6 +3324,12 @@ export function createRunExecutor(deps: ExecutorDeps) {
               allowSilentEmpty: allowSilentPeerMessage || messagingChannelRun,
               emptyResponseText,
               executeTool: scripted ? undefined : applyTool,
+              resolveModel: scripted
+                ? undefined
+                : (provider, modelId) =>
+                    resolveConnectedModel(run, provider, modelId, (values) =>
+                      runSecrets.push(...values),
+                    ),
               onToolCompleted: (completion) =>
                 appendToolCompletionAudit(
                   deps,

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -69,6 +69,7 @@ export * from "./messaging-delivery.js";
 export * from "./messaging-platforms.js";
 export * from "./messaging-team-chat-emulator.js";
 export * from "./model-connect.js";
+export * from "./model-selection.js";
 export * from "./model-vision.js";
 export * from "./none-sandbox.js";
 export * from "./openai-compatible-url.js";

--- a/packages/adapters/src/model-selection.test.ts
+++ b/packages/adapters/src/model-selection.test.ts
@@ -1,5 +1,7 @@
+import type { Actor } from "@rakazo/contracts";
+import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it } from "vitest";
-import { selectConfiguredModel } from "./model-selection.js";
+import { selectConfiguredModel, validateConnectedModelChoice } from "./model-selection.js";
 
 type SelectionInput = Parameters<typeof selectConfiguredModel>[0];
 
@@ -106,5 +108,50 @@ describe("configured model selection", () => {
     },
   ])("$name", ({ input, expected }) => {
     expect(selectConfiguredModel({ ...defaults, ...input })).toEqual(expected);
+  });
+});
+
+describe("connected model validation", () => {
+  const actor: Pick<Actor, "userId" | "spaceId"> = {
+    userId: "user-1",
+    spaceId: "space-1",
+  };
+
+  it("accepts catalog and saved free-form models but rejects unavailable choices", async () => {
+    const catalogPrisma = {
+      spaceModelPreference: { findFirst: async () => null },
+      userModelCredential: { findFirst: async () => credential("xai", null) },
+    } as unknown as PrismaClient;
+    await expect(
+      validateConnectedModelChoice(catalogPrisma, actor, "xai", "grok-4.6"),
+    ).resolves.toBeUndefined();
+    await expect(
+      validateConnectedModelChoice(catalogPrisma, actor, "xai", "not-a-model"),
+    ).resolves.toBe("Unknown model for that provider");
+
+    const customPreferences = [
+      {
+        credential: credential("openai-compatible", "newest-model"),
+        isDefault: true,
+        modelId: "newest-model",
+      },
+      { id: "older-choice" },
+    ];
+    const customPrisma = {
+      spaceModelPreference: {
+        findFirst: async () => customPreferences.shift() ?? null,
+      },
+    } as unknown as PrismaClient;
+    await expect(
+      validateConnectedModelChoice(customPrisma, actor, "openai-compatible", "private-model"),
+    ).resolves.toBeUndefined();
+
+    const disconnectedPrisma = {
+      spaceModelPreference: { findFirst: async () => null },
+      userModelCredential: { findFirst: async () => null },
+    } as unknown as PrismaClient;
+    await expect(
+      validateConnectedModelChoice(disconnectedPrisma, actor, "anthropic", "claude-opus-4-6"),
+    ).resolves.toBe("Connect that model provider first");
   });
 });

--- a/packages/adapters/src/model-selection.test.ts
+++ b/packages/adapters/src/model-selection.test.ts
@@ -1,6 +1,6 @@
 import type { Actor } from "@rakazo/contracts";
 import type { PrismaClient } from "@rakazo/db";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { selectConfiguredModel, validateConnectedModelChoice } from "./model-selection.js";
 
 type SelectionInput = Parameters<typeof selectConfiguredModel>[0];
@@ -129,22 +129,58 @@ describe("connected model validation", () => {
       validateConnectedModelChoice(catalogPrisma, actor, "xai", "not-a-model"),
     ).resolves.toBe("Unknown model for that provider");
 
-    const customPreferences = [
-      {
-        credential: credential("openai-compatible", "newest-model"),
-        isDefault: true,
-        modelId: "newest-model",
+    const preferenceFindFirst = vi.fn(
+      async (args: {
+        where: {
+          spaceId?: string;
+          userId?: string;
+          modelId?: string;
+          credential?: { provider?: string; userId?: string };
+        };
+      }) => {
+        if (args.where.modelId) {
+          if (
+            args.where.spaceId === actor.spaceId &&
+            args.where.userId === actor.userId &&
+            args.where.modelId === "private-model" &&
+            args.where.credential?.provider === "openai-compatible" &&
+            args.where.credential?.userId === actor.userId
+          ) {
+            return { id: "saved-private-model" };
+          }
+          return null;
+        }
+        if (args.where.credential?.provider === "openai-compatible") {
+          return {
+            credential: credential("openai-compatible", "newest-model"),
+            isDefault: true,
+            modelId: "newest-model",
+          };
+        }
+        return null;
       },
-      { id: "older-choice" },
-    ];
+    );
     const customPrisma = {
-      spaceModelPreference: {
-        findFirst: async () => customPreferences.shift() ?? null,
-      },
+      spaceModelPreference: { findFirst: preferenceFindFirst },
+      userModelCredential: { findFirst: async () => null },
     } as unknown as PrismaClient;
     await expect(
       validateConnectedModelChoice(customPrisma, actor, "openai-compatible", "private-model"),
     ).resolves.toBeUndefined();
+    expect(preferenceFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          spaceId: actor.spaceId,
+          userId: actor.userId,
+          modelId: "private-model",
+          credential: { userId: actor.userId, provider: "openai-compatible" },
+        }),
+        select: { id: true },
+      }),
+    );
+    await expect(
+      validateConnectedModelChoice(customPrisma, actor, "openai-compatible", "missing-model"),
+    ).resolves.toBe("Unknown model for that provider");
 
     const disconnectedPrisma = {
       spaceModelPreference: { findFirst: async () => null },

--- a/packages/adapters/src/model-selection.ts
+++ b/packages/adapters/src/model-selection.ts
@@ -6,8 +6,15 @@ import {
   type PrismaClient,
 } from "@rakazo/db";
 import { listPiCatalog, scriptedCatalogEntry } from "./pi-models.js";
+import { OPENAI_COMPATIBLE_PROVIDER_ID } from "./pi-openai-compatible-provider.js";
 
 type ModelCredential = Awaited<ReturnType<typeof findDefaultModelCredential>>;
+
+export function isCatalogModelChoice(provider: string, modelId: string) {
+  return [...listPiCatalog(), scriptedCatalogEntry].some(
+    (item) => item.provider === provider && item.id === modelId,
+  );
+}
 
 export async function validateConnectedModelChoice(
   prisma: PrismaClient,
@@ -17,10 +24,11 @@ export async function validateConnectedModelChoice(
 ) {
   const credential = await findModelCredential(prisma, actor, provider);
   if (!credential) return "Connect that model provider first";
-  const inCatalog = [...listPiCatalog(), scriptedCatalogEntry].some(
-    (item) => item.provider === provider && item.id === modelId,
-  );
-  if (inCatalog) return undefined;
+  if (isCatalogModelChoice(provider, modelId)) return undefined;
+  // Free-form saved IDs only resolve at runtime for openai-compatible connections.
+  if (provider !== OPENAI_COMPATIBLE_PROVIDER_ID) {
+    return "Unknown model for that provider";
+  }
   const savedChoice = await prisma.spaceModelPreference.findFirst({
     where: {
       spaceId: actor.spaceId,

--- a/packages/adapters/src/model-selection.ts
+++ b/packages/adapters/src/model-selection.ts
@@ -1,7 +1,37 @@
 import type { AgentRunRequest } from "@rakazo/adapter-kit";
-import type { findDefaultModelCredential } from "@rakazo/db";
+import type { Actor } from "@rakazo/contracts";
+import {
+  type findDefaultModelCredential,
+  findModelCredential,
+  type PrismaClient,
+} from "@rakazo/db";
+import { listPiCatalog, scriptedCatalogEntry } from "./pi-models.js";
 
 type ModelCredential = Awaited<ReturnType<typeof findDefaultModelCredential>>;
+
+export async function validateConnectedModelChoice(
+  prisma: PrismaClient,
+  actor: Pick<Actor, "userId" | "spaceId">,
+  provider: string,
+  modelId: string,
+) {
+  const credential = await findModelCredential(prisma, actor, provider);
+  if (!credential) return "Connect that model provider first";
+  const inCatalog = [...listPiCatalog(), scriptedCatalogEntry].some(
+    (item) => item.provider === provider && item.id === modelId,
+  );
+  if (inCatalog) return undefined;
+  const savedChoice = await prisma.spaceModelPreference.findFirst({
+    where: {
+      spaceId: actor.spaceId,
+      userId: actor.userId,
+      modelId,
+      credential: { userId: actor.userId, provider },
+    },
+    select: { id: true },
+  });
+  return savedChoice ? undefined : "Unknown model for that provider";
+}
 
 /** Select configuration without loading secrets or applying a runtime-specific fallback. */
 export function selectConfiguredModel(input: {

--- a/packages/adapters/src/pi-runtime-thinking-level.test.ts
+++ b/packages/adapters/src/pi-runtime-thinking-level.test.ts
@@ -10,6 +10,8 @@ const fakeAgentState = vi.hoisted(() => ({
     maxTokens?: number;
   }>,
   sessionIds: [] as Array<string | undefined>,
+  subagentArgs: { name: "helper", task: "help" } as Record<string, unknown>,
+  lastSubagentResult: undefined as unknown,
   failPrompt: false,
   abortCalls: 0,
 }));
@@ -42,7 +44,10 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
     async prompt() {
       if (fakeAgentState.failPrompt) throw new Error("prompt failed");
       const runSubagent = this.tools.find((tool) => tool.name === "run_subagent");
-      await runSubagent?.execute("subagent-call", { name: "helper", task: "help" });
+      fakeAgentState.lastSubagentResult = await runSubagent?.execute(
+        "subagent-call",
+        fakeAgentState.subagentArgs,
+      );
     }
     async waitForIdle() {}
     abort() {
@@ -97,6 +102,15 @@ async function runWithModel(
   provider = "test",
   signal = new AbortController().signal,
   thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | null,
+  resolveModel?: (
+    provider: string,
+    modelId: string,
+  ) => Promise<{
+    provider: string;
+    id: string;
+    apiKey?: string;
+    thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | null;
+  }>,
 ) {
   const runtime = new PiAgentRuntime();
   for await (const _event of runtime.run(
@@ -110,6 +124,7 @@ async function runWithModel(
       tools: [],
       model: { provider, id: modelId, thinkingLevel },
       executeTool: vi.fn(async () => ({ ok: true })),
+      resolveModel,
     },
     {
       operationId: "1",
@@ -129,6 +144,8 @@ describe("Pi agent thinking level", () => {
     fakeAgentState.thinkingLevels = [];
     fakeAgentState.models = [];
     fakeAgentState.sessionIds = [];
+    fakeAgentState.subagentArgs = { name: "helper", task: "help" };
+    fakeAgentState.lastSubagentResult = undefined;
     fakeAgentState.failPrompt = false;
     vi.unstubAllEnvs();
   });
@@ -150,6 +167,72 @@ describe("Pi agent thinking level", () => {
   it("honors a per-bot thinking level on reasoning models", async () => {
     const levels = await runWithModel("grok-4.6", "xai", new AbortController().signal, "high");
     expect(levels).toEqual(["high", "high"]);
+  });
+
+  it("resolves and runs an explicitly selected subagent model", async () => {
+    fakeAgentState.subagentArgs = {
+      name: "helper",
+      task: "help",
+      model_provider: "xai",
+      model_id: "grok-4.6",
+    };
+    const resolveModel = vi.fn(async (provider: string, modelId: string) => ({
+      provider,
+      id: modelId,
+      apiKey: "subagent-key",
+      thinkingLevel: "high" as const,
+    }));
+
+    const levels = await runWithModel(
+      "plain-model",
+      "test",
+      new AbortController().signal,
+      null,
+      resolveModel,
+    );
+
+    expect(resolveModel).toHaveBeenCalledWith("xai", "grok-4.6");
+    expect(fakeAgentState.models.map((model) => `${model.provider}/${model.id}`)).toEqual([
+      "test/plain-model",
+      "xai/grok-4.6",
+    ]);
+    expect(levels).toEqual(["off", "high"]);
+  });
+
+  it("rejects an incomplete per-call subagent model pair", async () => {
+    fakeAgentState.subagentArgs = {
+      name: "helper",
+      task: "help",
+      model_provider: "xai",
+    };
+    const resolveModel = vi.fn();
+
+    await runWithModel("plain-model", "test", new AbortController().signal, null, resolveModel);
+
+    expect(resolveModel).not.toHaveBeenCalled();
+    expect(fakeAgentState.lastSubagentResult).toMatchObject({
+      details: { result: "Subagent failed: model_provider and model_id must both be set" },
+    });
+  });
+
+  it("surfaces a scoped model-resolution failure without starting the helper", async () => {
+    fakeAgentState.subagentArgs = {
+      name: "helper",
+      task: "help",
+      model_provider: "anthropic",
+      model_id: "claude-opus-4-6",
+    };
+    const resolveModel = vi.fn(async () => {
+      throw new Error("Connect that model provider first");
+    });
+
+    await runWithModel("plain-model", "test", new AbortController().signal, null, resolveModel);
+
+    expect(resolveModel).toHaveBeenCalledWith("anthropic", "claude-opus-4-6");
+    expect(fakeAgentState.models).toHaveLength(1);
+    expect(fakeAgentState.lastSubagentResult).toMatchObject({
+      details: { result: "Subagent failed: Connect that model provider first" },
+    });
   });
 
   it("keeps reasoning off for the main agent and subagent", async () => {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -153,41 +153,16 @@ export class PiAgentRuntime implements AgentRuntime {
 
     const work = (async () => {
       try {
-        const provider =
-          request.model.provider === "scripted" ? "openrouter" : request.model.provider;
-        const envDefaultModel = process.env.PI_DEFAULT_MODEL?.trim();
-        const envDefaultProvider = process.env.PI_DEFAULT_PROVIDER?.trim() || "openrouter";
-        const modelId =
-          request.model.id === "scripted"
-            ? envDefaultModel || DEFAULT_OPENROUTER_MODEL_ID
-            : request.model.id.trim();
-        const models = modelsForRequest(request, provider);
-        let model = models.getModel(provider, modelId);
-        if (!model && provider !== "openrouter" && provider !== OPENAI_COMPATIBLE_PROVIDER_ID) {
-          model = models.getModel("openrouter", modelId);
-        }
-        if (
-          !model &&
-          provider === "openrouter" &&
-          envDefaultProvider === "openrouter" &&
-          modelId === envDefaultModel
-        ) {
-          model = configuredOpenRouterModel(modelId);
-        }
-        if (!model) {
-          queue.push({ type: "text", text: `Unknown model ${provider}/${modelId}` });
+        const selectedModel = resolveRuntimeModel(request.model);
+        if (!selectedModel.model) {
+          queue.push({
+            type: "text",
+            text: `Unknown model ${selectedModel.provider}/${selectedModel.modelId}`,
+          });
           queue.push({ type: "done" });
           return;
         }
-
-        const apiKey = request.model.oauth
-          ? undefined
-          : request.model.provider === OPENAI_COMPATIBLE_PROVIDER_ID
-            ? request.model.apiKey || "local"
-            : // Only OpenRouter may fall back to the OpenRouter env key. Handing it to
-              // another provider would ship our key to a vendor it was not issued for.
-              (request.model.apiKey ??
-              (provider === "openrouter" ? process.env.OPENROUTER_API_KEY : undefined));
+        const { models, model, apiKey } = selectedModel;
         const toolDefs = request.tools.length ? request.tools : builtinAgentTools;
         const nestedAgents = new Set<Agent>();
         const host: ToolHost = {
@@ -480,6 +455,44 @@ function configuredOpenRouterModel(id: string): Model<"openai-completions"> {
   };
 }
 
+function resolveRuntimeModel(modelConfig: AgentRunRequest["model"]): {
+  provider: string;
+  modelId: string;
+  models: Models;
+  model: Model<Api> | undefined;
+  apiKey: string | undefined;
+} {
+  const provider = modelConfig.provider === "scripted" ? "openrouter" : modelConfig.provider;
+  const envDefaultModel = process.env.PI_DEFAULT_MODEL?.trim();
+  const envDefaultProvider = process.env.PI_DEFAULT_PROVIDER?.trim() || "openrouter";
+  const modelId =
+    modelConfig.id === "scripted"
+      ? envDefaultModel || DEFAULT_OPENROUTER_MODEL_ID
+      : modelConfig.id.trim();
+  const models = modelsForRequest({ model: modelConfig }, provider);
+  let model = models.getModel(provider, modelId);
+  if (!model && provider !== "openrouter" && provider !== OPENAI_COMPATIBLE_PROVIDER_ID) {
+    model = models.getModel("openrouter", modelId);
+  }
+  if (
+    !model &&
+    provider === "openrouter" &&
+    envDefaultProvider === "openrouter" &&
+    modelId === envDefaultModel
+  ) {
+    model = configuredOpenRouterModel(modelId);
+  }
+  const apiKey = modelConfig.oauth
+    ? undefined
+    : modelConfig.provider === OPENAI_COMPATIBLE_PROVIDER_ID
+      ? modelConfig.apiKey || "local"
+      : // Only OpenRouter may fall back to the OpenRouter env key. Handing it to
+        // another provider would ship our key to a vendor it was not issued for.
+        (modelConfig.apiKey ??
+        (provider === "openrouter" ? process.env.OPENROUTER_API_KEY : undefined));
+  return { provider, modelId, models, model, apiKey };
+}
+
 export function modelsForRequest(
   request: Pick<AgentRunRequest, "model">,
   provider: string,
@@ -751,6 +764,8 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
           name: String(raw.name ?? "helper"),
           task: String(raw.task ?? ""),
           instructions: raw.instructions ? String(raw.instructions) : "",
+          model_provider: raw.model_provider ? String(raw.model_provider) : "",
+          model_id: raw.model_id ? String(raw.model_id) : "",
         };
       }
       if (tool.name === "spawn_bot") {
@@ -909,14 +924,49 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
     progress: "starting…",
   });
 
+  const requestedProvider = String(args.model_provider ?? "").trim();
+  const requestedModelId = String(args.model_id ?? "").trim();
+  let requestModel = host.request.model;
+  try {
+    if (Boolean(requestedProvider) !== Boolean(requestedModelId)) {
+      throw new Error("model_provider and model_id must both be set");
+    }
+    if (requestedProvider && requestedModelId) {
+      if (!host.request.resolveModel) {
+        throw new Error("Per-call subagent model selection is unavailable");
+      }
+      requestModel = await host.request.resolveModel(requestedProvider, requestedModelId);
+    }
+  } catch (error) {
+    const message = sanitizeError(error instanceof Error ? error.message : String(error));
+    host.queue.push({ type: "subagent", agentId, name, task, status: "failed", result: message });
+    host.subagentGate.release();
+    return `Subagent failed: ${message}`;
+  }
+
+  const selectedModel = resolveRuntimeModel(requestModel);
+  if (!selectedModel.model) {
+    const message = `Unknown model ${selectedModel.provider}/${selectedModel.modelId}`;
+    host.queue.push({ type: "subagent", agentId, name, task, status: "failed", result: message });
+    host.subagentGate.release();
+    return `Subagent failed: ${message}`;
+  }
+  const subagentModel = selectedModel.model;
+
   const childDefs = (host.request.tools.length ? host.request.tools : builtinAgentTools).filter(
     (tool) => !DELEGATION_TOOL_NAMES.has(tool.name),
   );
-  const nestedHost: ToolHost = { ...host, depth: 1 };
+  const nestedHost: ToolHost = {
+    ...host,
+    models: selectedModel.models,
+    model: subagentModel,
+    apiKey: selectedModel.apiKey,
+    depth: 1,
+  };
   const nested = new Agent({
     streamFn: (m, ctx, options) =>
-      host.models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
-    getApiKey: async () => host.apiKey,
+      selectedModel.models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
+    getApiKey: async () => selectedModel.apiKey,
     transformContext: async (messages) => pruneComputerScreenshotContext(messages),
     initialState: {
       systemPrompt: [
@@ -927,8 +977,8 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
       ]
         .filter(Boolean)
         .join(" "),
-      model: host.model,
-      thinkingLevel: thinkingLevelFor(host.model, host.request.model.thinkingLevel),
+      model: subagentModel,
+      thinkingLevel: thinkingLevelFor(subagentModel, requestModel.thinkingLevel),
       tools: toAgentTools(childDefs, nestedHost),
       messages: [],
     },
@@ -976,8 +1026,8 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
           type: "usage",
           inputTokens: event.message.usage.input ?? 0,
           outputTokens: event.message.usage.output ?? 0,
-          provider: host.model.provider,
-          model: host.model.id,
+          provider: subagentModel.provider,
+          model: subagentModel.id,
         });
       }
     }
@@ -1102,6 +1152,8 @@ function builtinParameters(tool: ConnectorTool) {
       name: Type.String(),
       task: Type.String(),
       instructions: Type.Optional(Type.String()),
+      model_provider: Type.Optional(Type.String()),
+      model_id: Type.Optional(Type.String()),
     });
   }
   if (tool.name === "spawn_bot") {

--- a/packages/db/src/model-credentials.test.ts
+++ b/packages/db/src/model-credentials.test.ts
@@ -43,6 +43,51 @@ describe("findModelCredential", () => {
       orderBy: newestModelCredentialOrder,
     });
   });
+
+  it("prefers the preference that owns a free-form modelId over the provider default", async () => {
+    const matching = {
+      credential: {
+        id: "credential-other",
+        userId: "user",
+        provider: "openai-compatible",
+        label: "Other",
+        secretId: "secret-other",
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      },
+      isDefault: false,
+      modelId: "other-model",
+    };
+    const preferenceFindFirst = vi.fn().mockResolvedValue(matching);
+    const prisma = {
+      spaceModelPreference: { findFirst: preferenceFindFirst },
+      userModelCredential: { findFirst: vi.fn() },
+    } as unknown as PrismaClient;
+
+    await expect(
+      findModelCredential(
+        prisma,
+        { userId: "user", spaceId: "space" },
+        "openai-compatible",
+        "other-model",
+      ),
+    ).resolves.toEqual({
+      ...matching.credential,
+      isDefault: false,
+      defaultModel: "other-model",
+    });
+    expect(preferenceFindFirst).toHaveBeenCalledWith({
+      where: {
+        userId: "user",
+        spaceId: "space",
+        modelId: "other-model",
+        credential: { provider: "openai-compatible" },
+      },
+      include: { credential: true },
+      orderBy: [{ isDefault: "desc" }, { updatedAt: "desc" }, { id: "desc" }],
+    });
+    expect(preferenceFindFirst).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("selectSpaceModelPreference", () => {

--- a/packages/db/src/model-credentials.ts
+++ b/packages/db/src/model-credentials.ts
@@ -93,7 +93,23 @@ export async function findModelCredential(
   prisma: PrismaClient,
   scope: ModelCredentialScope,
   provider: string,
+  modelId?: string | null,
 ) {
+  // When a helper or bot selects a free-form model, prefer the preference that owns
+  // that modelId so runtime uses the same credential the picker advertised.
+  if (modelId) {
+    const matching = await prisma.spaceModelPreference.findFirst({
+      where: {
+        spaceId: scope.spaceId,
+        userId: scope.userId,
+        modelId,
+        credential: { provider },
+      },
+      include: { credential: true },
+      orderBy: [{ isDefault: "desc" }, { updatedAt: "desc" }, { id: "desc" }],
+    });
+    if (matching) return withModelPreference(matching);
+  }
   const preference = await prisma.spaceModelPreference.findFirst({
     where: {
       spaceId: scope.spaceId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`run_subagent` always inherited the parent model. Helpers need an optional way for the AI to pick a connected Space model for a short-lived run, without new user UI.

## What

- Add paired optional `model_provider` / `model_id` on `run_subagent`. Omit both to inherit the parent; reject incomplete pairs.
- Resolve explicit choices within the active user and Space (connected catalog models and saved openai-compatible free-form models), load that credential, and run the helper with its key, OAuth/runtime config, thinking default, and usage attribution.
- Free-form selections stay bound to the owning preference; catalog models may still fall back within the provider.
- Shared validation and `findModelCredential(..., modelId)` support the selection path. No create-time / CreateBotForm / spawn_bot UI from the closed #731 stack.

Supersedes #736 (fork force-push blocked by workflows permission). Original work by @fetw882.

Closes #720.

## Test

- Focused suites: model-selection, credentials, executor, and Pi runtime thinking-level tests (58 passed), including free-form mismatch and predicate-aware validation coverage.
- Biome check on touched files: clean.
- Typecheck for `@rakazo/adapters`: clean.
- Remote CI green on `60d08723`: Lint, Typecheck, Unit tests, Postgres journeys, Production builds, Web E2E, Compose installer smokes, image validation.
- Greptile clean; CodeRabbit actionable notes addressed (one later import finding was a false positive; typecheck passes).

Co-authored-by: fetw <fetw882@gmail.com>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a40d868-5b10-442c-b546-fca6d8447217?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a40d868-5b10-442c-b546-fca6d8447217&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Subagents can run with an explicitly selected model provider and model.
  - Custom model selections are supported when configured for the current workspace.
  - Model credentials and settings are resolved consistently for each subagent request.
  - Model selection can be validated against available provider and model catalogs.

- **Bug Fixes**
  - Invalid or incomplete model selections now return clear errors.
  - Requests using disconnected providers or unavailable models are rejected before execution.
  - Selected subagents now use their requested model’s credentials, reasoning settings, and usage tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->