### PR TITLE
Add background computer update and recovery progress

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -54,6 +54,7 @@ import {
   pushTokenPath,
   type RemoteConnectorDependencies,
   reconcileCloudAgents,
+  reconcileComputerUpdates,
   removePiUserSessions,
   ScriptedAgentRuntime,
   SmtpEmailProvider,
@@ -390,6 +391,7 @@ export async function createApp(
         prisma,
         jobs,
         reconcileCloudAgents: () => reconcileCloudAgents({ prisma, jobs, cloudAgent }),
+        reconcileComputerUpdates: () => reconcileComputerUpdates({ prisma, jobs }),
       })
     : undefined;
   reconciler?.start();

--- a/apps/api/src/computer-status.test.ts
+++ b/apps/api/src/computer-status.test.ts
@@ -39,7 +39,7 @@ describe("toComputerStatus", () => {
         scope: "team",
         controlHolder: "none",
         homeRevision: "r1",
-      }).updateAvailable,
+      }).canUpdate,
     ).toBe(false);
     expect(
       toComputerStatus("bot-1", {
@@ -48,7 +48,7 @@ describe("toComputerStatus", () => {
         scope: "team",
         controlHolder: "none",
         homeRevision: "r1",
-      }).updateAvailable,
+      }).canUpdate,
     ).toBe(true);
   });
 });

--- a/apps/api/src/computer-status.ts
+++ b/apps/api/src/computer-status.ts
@@ -1,3 +1,4 @@
+import { computerSupportsUpdate } from "@rakazo/adapters";
 import type { ComputerStatus } from "@rakazo/contracts";
 import { ACTIVE_RUN_STATUSES, computerScreenSize } from "@rakazo/core";
 import type { PrismaClient } from "@rakazo/db";
@@ -56,11 +57,13 @@ export function toComputerStatus(
     controlBotId?: string | null;
     controlRunId?: string | null;
     homeRevision: string;
+    maintenanceId?: string | null;
   } | null,
   busyBotName: string | null = null,
 ): ComputerStatus {
-  const state =
-    computer?.state === "suspending"
+  const state = computer?.maintenanceId
+    ? "booting"
+    : computer?.state === "suspending"
       ? "running"
       : computer?.state === "stopped" ||
           computer?.state === "booting" ||
@@ -79,11 +82,11 @@ export function toComputerStatus(
     controlHolder: (computer?.controlHolder ?? "none") as ComputerStatus["controlHolder"],
     controlBotId: computer?.controlBotId ?? null,
     takeoverRequested: Boolean(computer?.controlRunId),
-    screenAvailable: state === "running" || state === "booting",
+    screenAvailable: !computer?.maintenanceId && (state === "running" || state === "booting"),
     screenWidth: screen.width,
     screenHeight: screen.height,
     homeRevision: computer?.homeRevision ?? null,
     busyBotName,
-    updateAvailable: kind !== "desktop",
+    canUpdate: computerSupportsUpdate(kind),
   };
 }

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -730,3 +730,80 @@ describe("integration setup authorization", () => {
     expect(save).not.toHaveBeenCalled();
   });
 });
+
+describe("interrupted computer reservation release", () => {
+  function fixture() {
+    const order: string[] = [];
+    const computerUpdate = {
+      findFirst: vi.fn(async () => ({ id: "update-1", computerId: "computer-1" })),
+      updateMany: vi.fn(async () => {
+        order.push("operation");
+        return { count: 1 };
+      }),
+    };
+    const computer = {
+      updateMany: vi.fn(async () => {
+        order.push("computer");
+        return { count: 1 };
+      }),
+    };
+    const prisma = { computer, computerUpdate, $transaction: vi.fn(async (fn) => fn(prisma)) };
+    const handler = new RPCHandler(
+      createRouter({ prisma, env: { sandboxProvider: "fake" } } as unknown as RouterDeps),
+    );
+    const call = async (owner: boolean, workersStopped?: boolean) =>
+      handler.handle(
+        new Request("http://127.0.0.1/rpc/computer/releaseInterrupted", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ json: { id: "update-1", workersStopped } }),
+        }),
+        {
+          prefix: "/rpc",
+          context: {
+            actor: {
+              spaceId: "space-1",
+              userId: "user-1",
+              email: "user@rakazo.test",
+              isDeploymentOwner: owner,
+            },
+          },
+        },
+      );
+    return { prisma, computer, computerUpdate, order, call };
+  }
+  it.each([
+    { owner: false, stopped: true, status: 403 },
+    { owner: true, stopped: false, status: 400 },
+    { owner: true, stopped: undefined, status: 400 },
+  ])(
+    "requires owner authorization and an explicit stopped-workers assertion: %j",
+    async ({ owner, stopped, status }) => {
+      const { call, prisma } = fixture();
+      const { response } = await call(owner, stopped);
+      expect(response.status).toBe(status);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    },
+  );
+  it("atomically releases only an interrupted reservation in the owner's workspace", async () => {
+    const { call, computer, computerUpdate, order } = fixture();
+    const { response } = await call(true, true);
+    expect(response.status).toBe(200);
+    expect(computerUpdate.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "update-1",
+        status: "interrupted",
+        computer: { spaceId: "space-1", bots: { some: { userId: "user-1", archivedAt: null } } },
+      },
+    });
+    expect(computerUpdate.updateMany).toHaveBeenCalledWith({
+      where: { id: "update-1", status: "interrupted" },
+      data: { status: "failed" },
+    });
+    expect(computer.updateMany).toHaveBeenCalledWith({
+      where: { id: "computer-1", maintenanceId: "update-1" },
+      data: { maintenanceId: null, state: "error" },
+    });
+    expect(order).toEqual(["operation", "computer"]);
+  });
+});

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -901,9 +901,12 @@ export function createRouter(deps: RouterDeps) {
         if (currentMode === input.mode) {
           return repos.setBotComputer(context.actor, bot.id, input.mode);
         }
-        const claimed = await deps.prisma.bot.updateMany({
-          where: { id: bot.id, computerSwitching: false, computer: { maintenanceId: null } },
-          data: { computerSwitching: true },
+        const claimed = await deps.prisma.$transaction(async (tx) => {
+          await tx.$queryRaw`SELECT id FROM computers WHERE id = ${bot.computerId} FOR UPDATE`;
+          return tx.bot.updateMany({
+            where: { id: bot.id, computerSwitching: false, computer: { maintenanceId: null } },
+            data: { computerSwitching: true },
+          });
         });
         if (claimed.count !== 1) throw new ORPCError("CONFLICT");
         try {
@@ -1576,7 +1579,36 @@ export function createRouter(deps: RouterDeps) {
           },
           orderBy: { createdAt: "desc" },
         });
-        return rows.map(computerUpdateView);
+        return rows.map((row) => computerUpdateView(row, context.actor.isDeploymentOwner));
+      }),
+      releaseInterrupted: authed.computer.releaseInterrupted.handler(async ({ context, input }) => {
+        if (!context.actor.isDeploymentOwner) throw new ORPCError("FORBIDDEN");
+        // This is an attended lock release, never a heartbeat-based takeover.
+        // The contract requires the operator's explicit workersStopped assertion.
+        await deps.prisma.$transaction(async (tx) => {
+          const update = await tx.computerUpdate.findFirst({
+            where: {
+              id: input.id,
+              status: "interrupted",
+              computer: {
+                spaceId: context.actor.spaceId,
+                bots: { some: { userId: context.actor.userId, archivedAt: null } },
+              },
+            },
+          });
+          if (!update) throw new ORPCError("CONFLICT");
+          const failed = await tx.computerUpdate.updateMany({
+            where: { id: update.id, status: "interrupted" },
+            data: { status: "failed" },
+          });
+          if (failed.count !== 1) throw new ORPCError("CONFLICT");
+          const released = await tx.computer.updateMany({
+            where: { id: update.computerId, maintenanceId: update.id },
+            data: { maintenanceId: null, state: "error" },
+          });
+          if (released.count !== 1) throw new ORPCError("CONFLICT");
+        });
+        return { ok: true as const };
       }),
       dismissUpdate: authed.computer.dismissUpdate.handler(async ({ context, input }) => {
         await deps.prisma.computerUpdate.updateMany({

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1558,7 +1558,7 @@ export function createRouter(deps: RouterDeps) {
       updates: authed.computer.updates.handler(async ({ context }) => {
         const rows = await deps.prisma.computerUpdate.findMany({
           where: {
-            status: { in: ["queued", "running", "failed"] },
+            status: { in: ["queued", "running", "interrupted", "failed"] },
             computer: {
               spaceId: context.actor.spaceId,
               bots: { some: { userId: context.actor.userId, archivedAt: null } },

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -30,6 +30,7 @@ import {
   checkpointAndRecordComputerWorkspace,
   clearInactiveUserComputerControl,
   computerSupportsUpdate,
+  computerUpdateView,
   createVoiceProvider,
   deletePushToken,
   deploymentAutoReviewDefault,
@@ -55,6 +56,7 @@ import {
   prepareGraphqlInstall,
   probeOpenAiCompatibleModels,
   provisionComputer,
+  queueComputerUpdate,
   type RemoteConnectorDependencies,
   releaseComputerExecutionLease,
   replaceComputer,
@@ -900,7 +902,7 @@ export function createRouter(deps: RouterDeps) {
           return repos.setBotComputer(context.actor, bot.id, input.mode);
         }
         const claimed = await deps.prisma.bot.updateMany({
-          where: { id: bot.id, computerSwitching: false },
+          where: { id: bot.id, computerSwitching: false, computer: { maintenanceId: null } },
           data: { computerSwitching: true },
         });
         if (claimed.count !== 1) throw new ORPCError("CONFLICT");
@@ -1460,6 +1462,7 @@ export function createRouter(deps: RouterDeps) {
           where: {
             id: bot.computer.id,
             state: { not: "suspending" },
+            maintenanceId: null,
             executionLeases: {
               none: { botId: { not: bot.id }, expiresAt: { gt: now } },
             },
@@ -1523,15 +1526,72 @@ export function createRouter(deps: RouterDeps) {
         );
         return computerStatus(deps, context.actor, input.botId);
       }),
-      recover: authed.computer.recover.handler(async ({ context, input }) =>
-        runComputerReplace(deps, context, input.botId, "recover", "recover"),
-      ),
+      recover: authed.computer.recover.handler(async ({ context, input }) => {
+        const bot = await repos.getBot(context.actor, input.botId);
+        if (!bot.computer) throw new IsolationError();
+        try {
+          return await queueComputerUpdate(deps, bot.computer.id, bot.id, "recover");
+        } catch (error) {
+          if (error instanceof ComputerBusyError)
+            throw new ORPCError("CONFLICT", { message: "Computer is busy" });
+          throw error;
+        }
+      }),
       reset: authed.computer.reset.handler(async ({ context, input }) =>
         runComputerReplace(deps, context, input.botId, "reset", "reset"),
       ),
-      update: authed.computer.update.handler(async ({ context, input }) =>
-        runComputerReplace(deps, context, input.botId, "update", "update"),
-      ),
+      update: authed.computer.update.handler(async ({ context, input }) => {
+        const bot = await repos.getBot(context.actor, input.botId);
+        if (!bot.computer) throw new IsolationError();
+        if (!computerSupportsUpdate(bot.computer.kind))
+          throw new ORPCError("BAD_REQUEST", {
+            message: "Computer update is not available on this device",
+          });
+        try {
+          return await queueComputerUpdate(deps, bot.computer.id, bot.id);
+        } catch (error) {
+          if (error instanceof ComputerBusyError)
+            throw new ORPCError("CONFLICT", { message: "Computer is busy" });
+          throw error;
+        }
+      }),
+      updates: authed.computer.updates.handler(async ({ context }) => {
+        const rows = await deps.prisma.computerUpdate.findMany({
+          where: {
+            status: { in: ["queued", "running", "failed"] },
+            computer: {
+              spaceId: context.actor.spaceId,
+              bots: { some: { userId: context.actor.userId, archivedAt: null } },
+            },
+          },
+          include: {
+            computer: {
+              include: {
+                bots: {
+                  where: { userId: context.actor.userId, archivedAt: null },
+                  select: { id: true, name: true },
+                },
+              },
+            },
+          },
+          orderBy: { createdAt: "desc" },
+        });
+        return rows.map(computerUpdateView);
+      }),
+      dismissUpdate: authed.computer.dismissUpdate.handler(async ({ context, input }) => {
+        await deps.prisma.computerUpdate.updateMany({
+          where: {
+            id: input.id,
+            status: "failed",
+            computer: {
+              spaceId: context.actor.spaceId,
+              bots: { some: { userId: context.actor.userId, archivedAt: null } },
+            },
+          },
+          data: { status: "dismissed" },
+        });
+        return { ok: true as const };
+      }),
       takeover: authed.computer.takeover.handler(async ({ context, input }) => {
         let bot = await repos.getBot(context.actor, input.botId);
         if (!bot.computer?.providerRef || bot.computer.state !== "running") {
@@ -1613,6 +1673,7 @@ export function createRouter(deps: RouterDeps) {
           where: {
             id: bot.computer.id,
             state: "running",
+            maintenanceId: null,
             controlHolder: { not: "user" },
             controlLeaseId: null,
           },

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import { View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { AvatarStyleProvider } from "../components/avatar-style";
+import { ComputerUpdateProgress } from "../components/computer-update-progress";
 import { currentApiBase, loadApiBase, loadSessionToken, selectedSpaceId } from "../lib/api";
 import { loadAppearancePreference, mobileTokens } from "../lib/appearance";
 import { bootstrapI18n, useI18n } from "../lib/i18n";
@@ -120,6 +121,7 @@ export default function Layout() {
                 <Stack.Screen name="routine" options={{ title: t("Routine") }} />
                 <Stack.Screen name="computer" options={{ title: t("Computer") }} />
               </Stack>
+              <ComputerUpdateProgress />
             </ThemeProvider>
           </AvatarStyleProvider>
         ) : (

--- a/apps/mobile/app/computer.tsx
+++ b/apps/mobile/app/computer.tsx
@@ -273,9 +273,7 @@ export default function Computer() {
           </Pressable>
         )}
       </View>
-      {computer?.state === "error" ||
-      computer?.state === "stopped" ||
-      (computer?.state === "running" && !embeddedScreenUrl) ? (
+      {computer ? (
         <ComputerMaintenanceActions
           botId={botId ?? ""}
           computer={computer}

--- a/apps/mobile/components/computer-maintenance-actions.tsx
+++ b/apps/mobile/components/computer-maintenance-actions.tsx
@@ -2,6 +2,7 @@ import type { ComputerStatus } from "@rakazo/contracts";
 import { useState } from "react";
 import { Alert, Pressable, Text, View } from "react-native";
 import { rpc } from "../lib/api";
+import { computerUpdates } from "../lib/computer-updates";
 import { useI18n } from "../lib/i18n";
 import { useMobileTokens } from "../lib/native";
 
@@ -29,9 +30,9 @@ export function ComputerMaintenanceActions({
     setPending(action);
     setError(null);
     try {
-      if (action === "recover") await rpc("computer/recover", { botId });
+      if (action === "recover") await computerUpdates.start(botId, "recover");
       else if (action === "reset") await rpc("computer/reset", { botId });
-      else await rpc("computer/update", { botId });
+      else await computerUpdates.start(botId);
       await onChanged();
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not update computer"));
@@ -71,7 +72,7 @@ export function ComputerMaintenanceActions({
           {pending === "reset" ? t("Resetting…") : t("Reset computer")}
         </Text>
       </Pressable>
-      {computer.updateAvailable ? (
+      {computer.canUpdate ? (
         <Pressable
           disabled={busy || pending !== null}
           onPress={() => void run("update")}

--- a/apps/mobile/components/computer-update-progress.tsx
+++ b/apps/mobile/components/computer-update-progress.tsx
@@ -2,7 +2,7 @@ import { COMPUTER_UPDATE_STAGES, type ComputerUpdate } from "@rakazo/contracts";
 import { computerUpdateNeedsAttention, computerUpdateStages } from "@rakazo/core";
 import { usePathname } from "expo-router";
 import { useEffect, useState, useSyncExternalStore } from "react";
-import { ActivityIndicator, Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import { ActivityIndicator, Alert, Modal, Pressable, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { computerUpdates } from "../lib/computer-updates";
 import { useI18n } from "../lib/i18n";
@@ -112,6 +112,37 @@ export function ComputerUpdateProgress() {
               <Text accessibilityRole="alert" style={{ color: tokens.destructive }}>
                 {t("Could not complete action")}
               </Text>
+            ) : null}
+            {selected.status === "interrupted" && selected.canReleaseReservation ? (
+              <Pressable
+                accessibilityRole="button"
+                disabled={busy}
+                style={styles.button}
+                onPress={() =>
+                  Alert.alert(
+                    t("Release interrupted computer?"),
+                    t(
+                      "Stop all workers and confirm that provider operations have stopped before releasing this computer.",
+                    ),
+                    [
+                      { text: t("Cancel"), style: "cancel" },
+                      {
+                        text: t("Workers and operations are stopped"),
+                        onPress: () => {
+                          setBusy(true);
+                          setError(false);
+                          void computerUpdates
+                            .releaseInterrupted(selected.id)
+                            .catch(() => setError(true))
+                            .finally(() => setBusy(false));
+                        },
+                      },
+                    ],
+                  )
+                }
+              >
+                <Text style={{ color: tokens.foreground }}>{t("Release computer")}</Text>
+              </Pressable>
             ) : null}
             {selected.status === "failed" ? (
               <Pressable

--- a/apps/mobile/components/computer-update-progress.tsx
+++ b/apps/mobile/components/computer-update-progress.tsx
@@ -1,5 +1,5 @@
 import { COMPUTER_UPDATE_STAGES, type ComputerUpdate } from "@rakazo/contracts";
-import { computerUpdateStages } from "@rakazo/core";
+import { computerUpdateNeedsAttention, computerUpdateStages } from "@rakazo/core";
 import { usePathname } from "expo-router";
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { ActivityIndicator, Modal, Pressable, StyleSheet, Text, View } from "react-native";
@@ -29,7 +29,7 @@ export function ComputerUpdateProgress() {
     t("Reconnecting"),
   ];
   const title = (update: ComputerUpdate) =>
-    update.status === "failed"
+    computerUpdateNeedsAttention(update)
       ? update.action === "recover"
         ? t("Recovery failed")
         : t("Update failed")
@@ -55,7 +55,9 @@ export function ComputerUpdateProgress() {
             }}
             style={[styles.pill, { backgroundColor: tokens.card, borderColor: tokens.border }]}
           >
-            {update.status !== "failed" ? <ActivityIndicator color={tokens.foreground} /> : null}
+            {!computerUpdateNeedsAttention(update) ? (
+              <ActivityIndicator color={tokens.foreground} />
+            ) : null}
             <View>
               <Text style={{ color: tokens.foreground }}>{title(update)}</Text>
               <Text style={[styles.secondary, { color: tokens.mutedForeground }]}>
@@ -76,9 +78,11 @@ export function ComputerUpdateProgress() {
             <Text accessibilityRole="header" style={[styles.title, { color: tokens.foreground }]}>
               {title(selected)}
             </Text>
-            {selected.status === "failed" ? (
+            {computerUpdateNeedsAttention(selected) ? (
               <Text style={{ color: tokens.mutedForeground }}>
-                {t("Recovery restores the last saved workspace. Unsaved work may be lost.")}
+                {selected.status === "interrupted"
+                  ? t("Recovery is unavailable until the previous operation has stopped.")
+                  : t("Recovery restores the last saved workspace. Unsaved work may be lost.")}
               </Text>
             ) : (
               computerUpdateStages(selected.action).map((stage, index) => {

--- a/apps/mobile/components/computer-update-progress.tsx
+++ b/apps/mobile/components/computer-update-progress.tsx
@@ -1,0 +1,163 @@
+import { COMPUTER_UPDATE_STAGES, type ComputerUpdate } from "@rakazo/contracts";
+import { computerUpdateStages } from "@rakazo/core";
+import { usePathname } from "expo-router";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { ActivityIndicator, Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { computerUpdates } from "../lib/computer-updates";
+import { useI18n } from "../lib/i18n";
+import { useMobileTokens } from "../lib/native";
+
+export function ComputerUpdateProgress() {
+  const { t } = useI18n();
+  const tokens = useMobileTokens();
+  const insets = useSafeAreaInsets();
+  const pathname = usePathname();
+  const { updates, openId } = useSyncExternalStore(
+    computerUpdates.subscribe,
+    computerUpdates.getSnapshot,
+  );
+  const [error, setError] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const authenticated = !["/sign-in"].includes(pathname);
+  useEffect(() => (authenticated ? computerUpdates.watch() : undefined), [authenticated]);
+  const labels = [
+    t("Getting ready"),
+    t("Saving your workspace"),
+    t("Recreating the computer"),
+    t("Restoring your workspace"),
+    t("Reconnecting"),
+  ];
+  const title = (update: ComputerUpdate) =>
+    update.status === "failed"
+      ? update.action === "recover"
+        ? t("Recovery failed")
+        : t("Update failed")
+      : update.action === "recover"
+        ? update.mode === "team"
+          ? t("Recovering Team Computer")
+          : t("Recovering {name}’s Computer", { name: update.name })
+        : update.mode === "team"
+          ? t("Updating Team Computer")
+          : t("Updating {name}’s Computer", { name: update.name });
+  const selected = updates.find((item) => item.id === openId);
+  if (!authenticated) return null;
+  return (
+    <>
+      <View pointerEvents="box-none" style={[styles.pills, { top: insets.top + 8 }]}>
+        {updates.map((update) => (
+          <Pressable
+            key={update.id}
+            accessibilityRole="button"
+            onPress={() => {
+              setError(false);
+              computerUpdates.open(update.id);
+            }}
+            style={[styles.pill, { backgroundColor: tokens.card, borderColor: tokens.border }]}
+          >
+            {update.status !== "failed" ? <ActivityIndicator color={tokens.foreground} /> : null}
+            <View>
+              <Text style={{ color: tokens.foreground }}>{title(update)}</Text>
+              <Text style={[styles.secondary, { color: tokens.mutedForeground }]}>
+                {labels[COMPUTER_UPDATE_STAGES.indexOf(update.stage)]}
+              </Text>
+            </View>
+          </Pressable>
+        ))}
+      </View>
+      <Modal
+        visible={Boolean(selected)}
+        presentationStyle="pageSheet"
+        animationType="slide"
+        onRequestClose={() => computerUpdates.open(null)}
+      >
+        {selected ? (
+          <View style={[styles.sheet, { backgroundColor: tokens.background }]}>
+            <Text accessibilityRole="header" style={[styles.title, { color: tokens.foreground }]}>
+              {title(selected)}
+            </Text>
+            {selected.status === "failed" ? (
+              <Text style={{ color: tokens.mutedForeground }}>
+                {t("Recovery restores the last saved workspace. Unsaved work may be lost.")}
+              </Text>
+            ) : (
+              computerUpdateStages(selected.action).map((stage, index) => {
+                const current = computerUpdateStages(selected.action).indexOf(selected.stage);
+                return (
+                  <View key={stage} style={styles.step}>
+                    {index === current ? (
+                      <ActivityIndicator color={tokens.foreground} />
+                    ) : (
+                      <Text style={{ color: tokens.mutedForeground }}>
+                        {index < current ? "✓" : "○"}
+                      </Text>
+                    )}
+                    <Text
+                      accessibilityLiveRegion={index === current ? "polite" : "none"}
+                      style={{
+                        color: index === current ? tokens.foreground : tokens.mutedForeground,
+                      }}
+                    >
+                      {labels[COMPUTER_UPDATE_STAGES.indexOf(stage)]}
+                    </Text>
+                  </View>
+                );
+              })
+            )}
+            {error ? (
+              <Text accessibilityRole="alert" style={{ color: tokens.destructive }}>
+                {t("Could not complete action")}
+              </Text>
+            ) : null}
+            {selected.status === "failed" ? (
+              <Pressable
+                accessibilityRole="button"
+                disabled={busy}
+                onPress={() => {
+                  setBusy(true);
+                  setError(false);
+                  void computerUpdates
+                    .start(selected.botId, "recover")
+                    .catch(() => setError(true))
+                    .finally(() => setBusy(false));
+                }}
+                style={styles.button}
+              >
+                <Text style={{ color: tokens.foreground }}>{t("Recover computer")}</Text>
+              </Pressable>
+            ) : null}
+            <Pressable
+              accessibilityRole="button"
+              style={styles.button}
+              onPress={() => {
+                if (selected.status === "failed")
+                  void computerUpdates.dismiss(selected.id).catch(() => setError(true));
+                else computerUpdates.open(null);
+              }}
+            >
+              <Text style={{ color: tokens.foreground }}>
+                {selected.status === "failed" ? t("Dismiss") : t("Continue in Background")}
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
+      </Modal>
+    </>
+  );
+}
+const styles = StyleSheet.create({
+  pills: { position: "absolute", left: 16, right: 16, zIndex: 100, alignItems: "center", gap: 8 },
+  pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: 12,
+  },
+  secondary: { fontSize: 12, textAlign: "center", marginTop: 3 },
+  sheet: { flex: 1, padding: 24, gap: 24 },
+  title: { fontSize: 22, fontWeight: "600" },
+  step: { flexDirection: "row", alignItems: "center", gap: 16 },
+  button: { minHeight: 44, justifyContent: "center", alignItems: "center" },
+});

--- a/apps/mobile/lib/computer-updates.ts
+++ b/apps/mobile/lib/computer-updates.ts
@@ -1,0 +1,8 @@
+import type { ComputerUpdate } from "@rakazo/contracts";
+import { createComputerUpdates } from "@rakazo/core";
+import { rpc } from "./api";
+export const computerUpdates = createComputerUpdates({
+  list: () => rpc<ComputerUpdate[]>("computer/updates"),
+  start: (botId, action) => rpc<ComputerUpdate>(`computer/${action}`, { botId }),
+  dismiss: (id) => rpc("computer/dismissUpdate", { id }),
+});

--- a/apps/mobile/lib/computer-updates.ts
+++ b/apps/mobile/lib/computer-updates.ts
@@ -4,5 +4,6 @@ import { rpc } from "./api";
 export const computerUpdates = createComputerUpdates({
   list: () => rpc<ComputerUpdate[]>("computer/updates"),
   start: (botId, action) => rpc<ComputerUpdate>(`computer/${action}`, { botId }),
+  releaseInterrupted: (id) => rpc("computer/releaseInterrupted", { id, workersStopped: true }),
   dismiss: (id) => rpc("computer/dismissUpdate", { id }),
 });

--- a/apps/mobile/lib/computer.test.ts
+++ b/apps/mobile/lib/computer.test.ts
@@ -24,7 +24,7 @@ function computer(overrides: Partial<ComputerStatus> = {}): ComputerStatus {
     screenHeight: 800,
     homeRevision: null,
     busyBotName: null,
-    updateAvailable: true,
+    canUpdate: true,
     ...overrides,
   };
 }

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -1,4 +1,10 @@
 export const ZH_MESSAGES: Record<string, string> = {
+  "Release computer": "释放电脑",
+  "Release interrupted computer?": "释放中断的电脑？",
+  "Stop all workers and confirm that provider operations have stopped before releasing this computer.":
+    "释放此电脑前，请停止所有工作进程，并确认服务提供方的操作已经停止。",
+  "Workers and operations are stopped": "工作进程和操作均已停止",
+
   "Recovery is unavailable until the previous operation has stopped.":
     "上一次操作停止之前，无法恢复。",
   "Continue in Background": "在后台继续",

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -1,4 +1,21 @@
 export const ZH_MESSAGES: Record<string, string> = {
+  "Continue in Background": "在后台继续",
+  "Could not complete action": "无法完成操作",
+  Dismiss: "关闭",
+  "Getting ready": "正在准备",
+  Reconnecting: "正在重新连接",
+  "Recovering Team Computer": "正在恢复团队电脑",
+  "Recovering {name}’s Computer": "正在恢复 {name} 的电脑",
+  "Recovery failed": "恢复失败",
+  "Recreating the computer": "正在重建电脑",
+  "Restoring your workspace": "正在还原工作区",
+  "Saving your workspace": "正在保存工作区",
+  "Recovery restores the last saved workspace. Unsaved work may be lost.":
+    "电脑未能完成操作。可从最近保存的工作区恢复；未保存的工作可能会丢失。",
+  "Update failed": "更新失败",
+  "Updating Team Computer": "正在更新团队电脑",
+  "Updating {name}’s Computer": "正在更新 {name} 的电脑",
+
   "Server integrations": "服务器集成",
   "Ask the server owner to configure this provider.": "请联系服务器所有者配置此服务。",
   "Client ID": "客户端 ID",

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -1,4 +1,6 @@
 export const ZH_MESSAGES: Record<string, string> = {
+  "Recovery is unavailable until the previous operation has stopped.":
+    "上一次操作停止之前，无法恢复。",
   "Continue in Background": "在后台继续",
   "Could not complete action": "无法完成操作",
   Dismiss: "关闭",

--- a/apps/web/e2e/computer-update.spec.ts
+++ b/apps/web/e2e/computer-update.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+import type { ComputerUpdate } from "@rakazo/contracts";
+import { activeBotId, captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+test("computer maintenance shows durable background progress and failure recovery", async ({
+  page,
+}, testInfo) => {
+  await page.addInitScript(() => localStorage.setItem("rakazo.uiAppearance", "dark"));
+  await signup(page, `computer-update-${Date.now()}@rakazo.test`, "password12", "Computer Update");
+  await completeOnboarding(page);
+  const botId = activeBotId(page);
+  let updates: ComputerUpdate[] = [];
+  const updating: ComputerUpdate = {
+    id: "update-example",
+    botId,
+    name: "Chief",
+    mode: "team",
+    action: "update",
+    status: "running",
+    stage: "restoring",
+  };
+  await page.route("**/rpc/computer/updates", (route) =>
+    route.fulfill({ json: { json: updates } }),
+  );
+  await page.route("**/rpc/computer/update", (route) => {
+    updates = [updating];
+    return route.fulfill({ json: { json: updating } });
+  });
+  await page.route("**/rpc/computer/recover", (route) => {
+    updates = [{ ...updating, id: "recovery-example", action: "recover", stage: "preparing" }];
+    return route.fulfill({ json: { json: updates[0] } });
+  });
+  await page.getByTitle("Agent computer").click();
+  await expect(page.getByTestId("computer-preview")).toBeVisible();
+  await page.getByTestId("computer-preview").hover();
+  await page.getByTestId("computer-preview-open").click();
+  await page.getByTestId("computer-more-button").click();
+  await page.getByRole("menuitem", { name: "Update computer", exact: true }).click();
+  const dialog = page.getByTestId("computer-update-dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("heading")).toHaveText("Updating Team Computer");
+  await expect(dialog.locator('[aria-current="step"]')).toHaveText("Restoring your workspace");
+  await captureScreenshot(page, testInfo, "computer-update-progress");
+  await dialog.getByRole("button", { name: "Continue in Background" }).click();
+  await expect(dialog).not.toBeVisible();
+  await captureScreenshot(page, testInfo, "computer-update-background");
+  await page.reload();
+  await page.getByRole("button", { name: /Updating Team Computer/ }).click();
+  await expect(dialog).toBeVisible();
+  updates = [{ ...updating, status: "failed" }];
+  await expect(dialog.getByRole("heading")).toHaveText("Update failed");
+  await captureScreenshot(page, testInfo, "computer-update-failed");
+  await dialog.getByRole("button", { name: "Recover computer" }).click();
+  await expect(dialog.getByRole("heading")).toHaveText("Recovering Team Computer");
+  await captureScreenshot(page, testInfo, "computer-recovery-progress");
+  updates = [];
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByRole("button", { name: /Recovering Team Computer/ })).toHaveCount(0);
+});

--- a/apps/web/e2e/computer-update.spec.ts
+++ b/apps/web/e2e/computer-update.spec.ts
@@ -47,6 +47,12 @@ test("computer maintenance shows durable background progress and failure recover
   await page.reload();
   await page.getByRole("button", { name: /Updating Team Computer/ }).click();
   await expect(dialog).toBeVisible();
+  updates = [{ ...updating, status: "interrupted" }];
+  await expect(
+    dialog.getByText("Recovery is unavailable until the previous operation has stopped."),
+  ).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Recover computer" })).toHaveCount(0);
+  await captureScreenshot(page, testInfo, "computer-update-interrupted");
   updates = [{ ...updating, status: "failed" }];
   await expect(dialog.getByRole("heading")).toHaveText("Update failed");
   await captureScreenshot(page, testInfo, "computer-update-failed");

--- a/apps/web/e2e/computer-update.spec.ts
+++ b/apps/web/e2e/computer-update.spec.ts
@@ -30,6 +30,15 @@ test("computer maintenance shows durable background progress and failure recover
     updates = [{ ...updating, id: "recovery-example", action: "recover", stage: "preparing" }];
     return route.fulfill({ json: { json: updates[0] } });
   });
+  let releases = 0;
+  await page.route("**/rpc/computer/releaseInterrupted", (route) => {
+    expect(route.request().postDataJSON()).toMatchObject({
+      json: { id: updating.id, workersStopped: true },
+    });
+    releases++;
+    updates = [{ ...updating, status: "failed" }];
+    return route.fulfill({ json: { json: { ok: true } } });
+  });
   await page.getByTitle("Agent computer").click();
   await expect(page.getByTestId("computer-preview")).toBeVisible();
   await page.getByTestId("computer-preview").hover();
@@ -53,7 +62,18 @@ test("computer maintenance shows durable background progress and failure recover
   ).toBeVisible();
   await expect(dialog.getByRole("button", { name: "Recover computer" })).toHaveCount(0);
   await captureScreenshot(page, testInfo, "computer-update-interrupted");
-  updates = [{ ...updating, status: "failed" }];
+  updates = [{ ...updating, status: "interrupted", canReleaseReservation: true }];
+  await dialog.getByRole("button", { name: "Release computer", exact: true }).click();
+  const confirmation = page.getByRole("alertdialog");
+  await captureScreenshot(page, testInfo, "computer-update-release-confirmation");
+  await confirmation.getByRole("button", { name: "Cancel", exact: true }).click();
+  expect(releases).toBe(0);
+  await dialog.getByRole("button", { name: "Release computer", exact: true }).click();
+  await confirmation
+    .getByRole("button", { name: "Workers and operations are stopped", exact: true })
+    .click();
+  await expect(dialog.getByRole("button", { name: "Recover computer", exact: true })).toBeVisible();
+  expect(releases).toBe(1);
   await expect(dialog.getByRole("heading")).toHaveText("Update failed");
   await captureScreenshot(page, testInfo, "computer-update-failed");
   await dialog.getByRole("button", { name: "Recover computer" }).click();

--- a/apps/web/src/components/ComputerMaintenanceActions.tsx
+++ b/apps/web/src/components/ComputerMaintenanceActions.tsx
@@ -17,6 +17,7 @@ import {
 } from "@rakazo/ui-web";
 import { MoreHorizontal } from "lucide-react";
 import { useState } from "react";
+import { computerUpdates } from "../lib/computer-updates";
 import { rpc } from "../lib/rpc";
 
 type Action = "recover" | "reset" | "update";
@@ -45,7 +46,7 @@ export function ComputerMaintenanceActions({
     computer.state === "suspended" ||
     computer.state === "stopped";
   const showReset = showRecover;
-  const showUpdate = computer.updateAvailable;
+  const showUpdate = computer.canUpdate;
   const hasActions = showRecover || showReset || showUpdate;
   if (!hasActions) return null;
 
@@ -53,12 +54,12 @@ export function ComputerMaintenanceActions({
     setPending(action);
     setError(null);
     try {
-      if (action === "recover") await rpc.computer.recover({ botId });
+      if (action === "recover") await computerUpdates.start(botId, "recover");
       else if (action === "reset") await rpc.computer.reset({ botId });
-      else await rpc.computer.update({ botId });
+      else await computerUpdates.start(botId);
       setConfirmReset(false);
-      await onChanged();
       setMenuOpen(false);
+      await onChanged();
     } catch (err) {
       setError(err instanceof Error ? err.message : t`Could not update computer`);
     } finally {

--- a/apps/web/src/components/ComputerUpdateProgress.tsx
+++ b/apps/web/src/components/ComputerUpdateProgress.tsx
@@ -1,7 +1,21 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { COMPUTER_UPDATE_STAGES, type ComputerUpdate } from "@rakazo/contracts";
 import { computerUpdateNeedsAttention, computerUpdateStages } from "@rakazo/core";
-import { Button, cn, Dialog, DialogContent, DialogTitle } from "@rakazo/ui-web";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@rakazo/ui-web";
 import { CheckCircle2, Circle, CircleAlert, LoaderCircle } from "lucide-react";
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { computerUpdates } from "../lib/computer-updates";
@@ -18,6 +32,7 @@ export function ComputerUpdateProgress({ onCompleted }: { onCompleted: () => voi
   completed.current = onCompleted;
   const [error, setError] = useState(false);
   const [recovering, setRecovering] = useState(false);
+  const [releaseId, setReleaseId] = useState<string | null>(null);
   useEffect(() => computerUpdates.watch(), []);
   useEffect(() => {
     if (
@@ -160,6 +175,11 @@ export function ComputerUpdateProgress({ onCompleted }: { onCompleted: () => voi
               </p>
             ) : null}
             <div className="flex justify-end gap-2 border-t border-border px-6 py-4">
+              {selected.status === "interrupted" && selected.canReleaseReservation ? (
+                <Button variant="outline" onClick={() => setReleaseId(selected.id)}>
+                  <Trans>Release computer</Trans>
+                </Button>
+              ) : null}
               {selected.status === "failed" ? (
                 <Button
                   variant="outline"
@@ -193,6 +213,49 @@ export function ComputerUpdateProgress({ onCompleted }: { onCompleted: () => voi
           </DialogContent>
         ) : null}
       </Dialog>
+      <AlertDialog
+        open={releaseId !== null}
+        onOpenChange={(open) => {
+          if (!open) setReleaseId(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              <Trans>Release interrupted computer?</Trans>
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              <Trans>
+                Stop all workers and confirm that provider operations have stopped before releasing
+                this computer.
+              </Trans>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              <Trans>Cancel</Trans>
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={recovering}
+              onClick={() => {
+                if (!releaseId) return;
+                setRecovering(true);
+                setError(false);
+                void computerUpdates
+                  .releaseInterrupted(releaseId)
+                  .then(() => setReleaseId(null))
+                  .catch(() => {
+                    setReleaseId(null);
+                    setError(true);
+                  })
+                  .finally(() => setRecovering(false));
+              }}
+            >
+              <Trans>Workers and operations are stopped</Trans>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/apps/web/src/components/ComputerUpdateProgress.tsx
+++ b/apps/web/src/components/ComputerUpdateProgress.tsx
@@ -1,0 +1,189 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import { COMPUTER_UPDATE_STAGES, type ComputerUpdate } from "@rakazo/contracts";
+import { computerUpdateStages } from "@rakazo/core";
+import { Button, cn, Dialog, DialogContent, DialogTitle } from "@rakazo/ui-web";
+import { CheckCircle2, Circle, CircleAlert, LoaderCircle } from "lucide-react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { computerUpdates } from "../lib/computer-updates";
+import { LoadingState } from "./ai/primitives";
+
+export function ComputerUpdateProgress({ onCompleted }: { onCompleted: () => void }) {
+  const { t } = useLingui();
+  const { updates, openId } = useSyncExternalStore(
+    computerUpdates.subscribe,
+    computerUpdates.getSnapshot,
+  );
+  const previous = useRef<ComputerUpdate[]>([]);
+  const completed = useRef(onCompleted);
+  completed.current = onCompleted;
+  const [error, setError] = useState(false);
+  const [recovering, setRecovering] = useState(false);
+  useEffect(() => computerUpdates.watch(), []);
+  useEffect(() => {
+    if (
+      previous.current.some(
+        (old) => old.status !== "failed" && !updates.some((item) => item.id === old.id),
+      )
+    )
+      completed.current();
+    previous.current = updates;
+  }, [updates]);
+  const labels = [
+    t`Getting ready`,
+    t`Saving your workspace`,
+    t`Recreating the computer`,
+    t`Restoring your workspace`,
+    t`Reconnecting`,
+  ];
+  const title = (update: ComputerUpdate) =>
+    update.status === "failed"
+      ? update.action === "recover"
+        ? t`Recovery failed`
+        : t`Update failed`
+      : update.action === "recover"
+        ? update.mode === "team"
+          ? t`Recovering Team Computer`
+          : t`Recovering ${update.name}’s Computer`
+        : update.mode === "team"
+          ? t`Updating Team Computer`
+          : t`Updating ${update.name}’s Computer`;
+  const selected = updates.find((update) => update.id === openId);
+  return (
+    <>
+      <div className="fixed top-3 left-1/2 z-50 flex -translate-x-1/2 flex-col gap-2">
+        {updates.map((update) => (
+          <Button
+            key={update.id}
+            variant="outline"
+            className="h-auto gap-3 rounded-xl bg-card px-4 py-2 shadow-sm"
+            onClick={() => {
+              setError(false);
+              computerUpdates.open(update.id);
+            }}
+          >
+            {update.status === "failed" ? (
+              <CircleAlert className="text-destructive" />
+            ) : (
+              <LoadingState
+                label={title(update)}
+                indicator={
+                  <LoaderCircle className="size-5 animate-spin motion-reduce:animate-none" />
+                }
+              />
+            )}
+            <span className="text-center">
+              <span className="block">{title(update)}</span>
+              <span className="block text-xs text-muted-foreground">
+                {labels[COMPUTER_UPDATE_STAGES.indexOf(update.stage)]}
+              </span>
+            </span>
+          </Button>
+        ))}
+      </div>
+      <Dialog
+        open={Boolean(selected)}
+        onOpenChange={(open) => {
+          if (!open) computerUpdates.open(null);
+        }}
+      >
+        {selected ? (
+          <DialogContent
+            showCloseButton={false}
+            className="gap-0 overflow-hidden rounded-3xl border border-border bg-card p-0 sm:max-w-xl"
+            aria-describedby={undefined}
+            data-testid="computer-update-dialog"
+          >
+            <div className="border-b border-border px-6 py-5">
+              <DialogTitle className="text-lg font-semibold">{title(selected)}</DialogTitle>
+            </div>
+            {selected.status !== "failed" ? (
+              <ol className="space-y-4 px-6 py-6" aria-label={t`Update progress`}>
+                {computerUpdateStages(selected.action).map((stage, index) => {
+                  const current = computerUpdateStages(selected.action).indexOf(selected.stage);
+                  const Icon =
+                    index < current
+                      ? CheckCircle2
+                      : index === current
+                        ? selected.status === "failed"
+                          ? CircleAlert
+                          : LoaderCircle
+                        : Circle;
+                  return (
+                    <li
+                      key={stage}
+                      aria-current={index === current ? "step" : undefined}
+                      className={cn(
+                        "flex items-center gap-3 text-base",
+                        index === current ? "text-foreground" : "text-muted-foreground",
+                      )}
+                    >
+                      <Icon
+                        aria-hidden
+                        className={cn(
+                          "size-5 shrink-0",
+                          index === current &&
+                            selected.status !== "failed" &&
+                            "animate-spin motion-reduce:animate-none",
+                          index === current && selected.status === "failed" && "text-destructive",
+                        )}
+                      />
+                      {labels[COMPUTER_UPDATE_STAGES.indexOf(stage)]}
+                    </li>
+                  );
+                })}
+              </ol>
+            ) : null}
+            {selected.status === "failed" ? (
+              <p
+                role="alert"
+                className="mx-6 my-6 rounded-xl bg-muted px-4 py-4 text-sm text-muted-foreground"
+              >
+                <Trans>Recovery restores the last saved workspace. Unsaved work may be lost.</Trans>
+              </p>
+            ) : (
+              <span role="status" className="sr-only">
+                {labels[COMPUTER_UPDATE_STAGES.indexOf(selected.stage)]}
+              </span>
+            )}
+            {error ? (
+              <p role="alert" className="px-6 pb-3 text-sm text-destructive">
+                <Trans>Could not complete action</Trans>
+              </p>
+            ) : null}
+            <div className="flex justify-end gap-2 border-t border-border px-6 py-4">
+              {selected.status === "failed" ? (
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    void computerUpdates.dismiss(selected.id).catch(() => setError(true))
+                  }
+                >
+                  <Trans>Dismiss</Trans>
+                </Button>
+              ) : (
+                <Button variant="outline" onClick={() => computerUpdates.open(null)}>
+                  <Trans>Continue in Background</Trans>
+                </Button>
+              )}
+              {selected.status === "failed" ? (
+                <Button
+                  disabled={recovering}
+                  onClick={() => {
+                    setRecovering(true);
+                    setError(false);
+                    void computerUpdates
+                      .start(selected.botId, "recover")
+                      .catch(() => setError(true))
+                      .finally(() => setRecovering(false));
+                  }}
+                >
+                  <Trans>Recover computer</Trans>
+                </Button>
+              ) : null}
+            </div>
+          </DialogContent>
+        ) : null}
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/ComputerUpdateProgress.tsx
+++ b/apps/web/src/components/ComputerUpdateProgress.tsx
@@ -1,6 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { COMPUTER_UPDATE_STAGES, type ComputerUpdate } from "@rakazo/contracts";
-import { computerUpdateStages } from "@rakazo/core";
+import { computerUpdateNeedsAttention, computerUpdateStages } from "@rakazo/core";
 import { Button, cn, Dialog, DialogContent, DialogTitle } from "@rakazo/ui-web";
 import { CheckCircle2, Circle, CircleAlert, LoaderCircle } from "lucide-react";
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
@@ -22,7 +22,10 @@ export function ComputerUpdateProgress({ onCompleted }: { onCompleted: () => voi
   useEffect(() => {
     if (
       previous.current.some(
-        (old) => old.status !== "failed" && !updates.some((item) => item.id === old.id),
+        (old) =>
+          old.status !== "failed" &&
+          (!updates.some((item) => item.id === old.id) ||
+            updates.some((item) => item.id === old.id && item.status === "failed")),
       )
     )
       completed.current();
@@ -36,7 +39,7 @@ export function ComputerUpdateProgress({ onCompleted }: { onCompleted: () => voi
     t`Reconnecting`,
   ];
   const title = (update: ComputerUpdate) =>
-    update.status === "failed"
+    computerUpdateNeedsAttention(update)
       ? update.action === "recover"
         ? t`Recovery failed`
         : t`Update failed`
@@ -61,7 +64,7 @@ export function ComputerUpdateProgress({ onCompleted }: { onCompleted: () => voi
               computerUpdates.open(update.id);
             }}
           >
-            {update.status === "failed" ? (
+            {computerUpdateNeedsAttention(update) ? (
               <CircleAlert className="text-destructive" />
             ) : (
               <LoadingState
@@ -96,7 +99,7 @@ export function ComputerUpdateProgress({ onCompleted }: { onCompleted: () => voi
             <div className="border-b border-border px-6 py-5">
               <DialogTitle className="text-lg font-semibold">{title(selected)}</DialogTitle>
             </div>
-            {selected.status !== "failed" ? (
+            {!computerUpdateNeedsAttention(selected) ? (
               <ol className="space-y-4 px-6 py-6" aria-label={t`Update progress`}>
                 {computerUpdateStages(selected.action).map((stage, index) => {
                   const current = computerUpdateStages(selected.action).indexOf(selected.stage);
@@ -122,7 +125,7 @@ export function ComputerUpdateProgress({ onCompleted }: { onCompleted: () => voi
                         className={cn(
                           "size-5 shrink-0",
                           index === current &&
-                            selected.status !== "failed" &&
+                            !computerUpdateNeedsAttention(selected) &&
                             "animate-spin motion-reduce:animate-none",
                           index === current && selected.status === "failed" && "text-destructive",
                         )}
@@ -133,12 +136,18 @@ export function ComputerUpdateProgress({ onCompleted }: { onCompleted: () => voi
                 })}
               </ol>
             ) : null}
-            {selected.status === "failed" ? (
+            {computerUpdateNeedsAttention(selected) ? (
               <p
                 role="alert"
                 className="mx-6 my-6 rounded-xl bg-muted px-4 py-4 text-sm text-muted-foreground"
               >
-                <Trans>Recovery restores the last saved workspace. Unsaved work may be lost.</Trans>
+                {selected.status === "interrupted" ? (
+                  <Trans>Recovery is unavailable until the previous operation has stopped.</Trans>
+                ) : (
+                  <Trans>
+                    Recovery restores the last saved workspace. Unsaved work may be lost.
+                  </Trans>
+                )}
               </p>
             ) : (
               <span role="status" className="sr-only">

--- a/apps/web/src/lib/computer-updates.ts
+++ b/apps/web/src/lib/computer-updates.ts
@@ -1,0 +1,7 @@
+import { createComputerUpdates } from "@rakazo/core";
+import { rpc } from "./rpc";
+export const computerUpdates = createComputerUpdates({
+  list: () => rpc.computer.updates(),
+  start: (botId, action) => rpc.computer[action]({ botId }),
+  dismiss: (id) => rpc.computer.dismissUpdate({ id }),
+});

--- a/apps/web/src/lib/computer-updates.ts
+++ b/apps/web/src/lib/computer-updates.ts
@@ -3,5 +3,6 @@ import { rpc } from "./rpc";
 export const computerUpdates = createComputerUpdates({
   list: () => rpc.computer.updates(),
   start: (botId, action) => rpc.computer[action]({ botId }),
+  releaseInterrupted: (id) => rpc.computer.releaseInterrupted({ id, workersStopped: true }),
   dismiss: (id) => rpc.computer.dismissUpdate({ id }),
 });

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -1500,7 +1500,7 @@ function computer(overrides: Partial<ComputerStatus> = {}): ComputerStatus {
     screenHeight: 800,
     homeRevision: null,
     busyBotName: null,
-    updateAvailable: true,
+    canUpdate: true,
     ...overrides,
   };
 }

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3400,3 +3400,7 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx:47
 msgid "Updating Team Computer"
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Recovery is unavailable until the previous operation has stopped."
+msgstr ""

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3404,3 +3404,19 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx
 msgid "Recovery is unavailable until the previous operation has stopped."
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release interrupted computer?"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Workers and operations are stopped"
+msgstr ""

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3346,3 +3346,57 @@ msgstr "Docker begrenzt für mehr Sicherheit den Zugriff auf deinen Computer. We
 #: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "Mit lokalem Zugriff können Bots ohne Rückfrage Befehle ausführen. Vermeide dies auf gemeinsam genutzten oder öffentlichen Servern."
+
+#: src/components/ComputerUpdateProgress.tsx:181
+msgid "Continue in Background"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:151
+msgid "Could not complete action"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:31
+msgid "Getting ready"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:45
+msgid "Recovering {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:44
+msgid "Recovering Team Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:40
+msgid "Recovery failed"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:33
+msgid "Recreating the computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:34
+msgid "Restoring your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:32
+msgid "Saving your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:139
+msgid "Recovery restores the last saved workspace. Unsaved work may be lost."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:101
+msgid "Update progress"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:48
+msgid "Updating {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:47
+msgid "Updating Team Computer"
+msgstr ""

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -3404,3 +3404,19 @@ msgstr "Updating Team Computer"
 #: src/components/ComputerUpdateProgress.tsx
 msgid "Recovery is unavailable until the previous operation has stopped."
 msgstr "Recovery is unavailable until the previous operation has stopped."
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release computer"
+msgstr "Release computer"
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release interrupted computer?"
+msgstr "Release interrupted computer?"
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
+msgstr "Stop all workers and confirm that provider operations have stopped before releasing this computer."
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Workers and operations are stopped"
+msgstr "Workers and operations are stopped"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -3346,3 +3346,57 @@ msgstr "Docker limits access to your computer for added security. Using {hostLab
 #: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "Local access lets bots run commands without asking. Avoid it on shared or public servers."
+
+#: src/components/ComputerUpdateProgress.tsx:181
+msgid "Continue in Background"
+msgstr "Continue in Background"
+
+#: src/components/ComputerUpdateProgress.tsx:151
+msgid "Could not complete action"
+msgstr "Could not complete action"
+
+#: src/components/ComputerUpdateProgress.tsx:31
+msgid "Getting ready"
+msgstr "Getting ready"
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:45
+msgid "Recovering {0}’s Computer"
+msgstr "Recovering {0}’s Computer"
+
+#: src/components/ComputerUpdateProgress.tsx:44
+msgid "Recovering Team Computer"
+msgstr "Recovering Team Computer"
+
+#: src/components/ComputerUpdateProgress.tsx:40
+msgid "Recovery failed"
+msgstr "Recovery failed"
+
+#: src/components/ComputerUpdateProgress.tsx:33
+msgid "Recreating the computer"
+msgstr "Recreating the computer"
+
+#: src/components/ComputerUpdateProgress.tsx:34
+msgid "Restoring your workspace"
+msgstr "Restoring your workspace"
+
+#: src/components/ComputerUpdateProgress.tsx:32
+msgid "Saving your workspace"
+msgstr "Saving your workspace"
+
+#: src/components/ComputerUpdateProgress.tsx:139
+msgid "Recovery restores the last saved workspace. Unsaved work may be lost."
+msgstr "Recovery restores the last saved workspace. Unsaved work may be lost."
+
+#: src/components/ComputerUpdateProgress.tsx:101
+msgid "Update progress"
+msgstr "Update progress"
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:48
+msgid "Updating {0}’s Computer"
+msgstr "Updating {0}’s Computer"
+
+#: src/components/ComputerUpdateProgress.tsx:47
+msgid "Updating Team Computer"
+msgstr "Updating Team Computer"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -3400,3 +3400,7 @@ msgstr "Updating {0}’s Computer"
 #: src/components/ComputerUpdateProgress.tsx:47
 msgid "Updating Team Computer"
 msgstr "Updating Team Computer"
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Recovery is unavailable until the previous operation has stopped."
+msgstr "Recovery is unavailable until the previous operation has stopped."

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -3364,3 +3364,19 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx
 msgid "Recovery is unavailable until the previous operation has stopped."
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release interrupted computer?"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Workers and operations are stopped"
+msgstr ""

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -3360,3 +3360,7 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx:47
 msgid "Updating Team Computer"
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Recovery is unavailable until the previous operation has stopped."
+msgstr ""

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -3306,3 +3306,57 @@ msgstr "Docker limita el acceso a tu computadora para mayor seguridad. Usar {hos
 #: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "El acceso local permite que los bots ejecuten comandos sin preguntar. Evítalo en servidores compartidos o públicos."
+
+#: src/components/ComputerUpdateProgress.tsx:181
+msgid "Continue in Background"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:151
+msgid "Could not complete action"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:31
+msgid "Getting ready"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:45
+msgid "Recovering {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:44
+msgid "Recovering Team Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:40
+msgid "Recovery failed"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:33
+msgid "Recreating the computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:34
+msgid "Restoring your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:32
+msgid "Saving your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:139
+msgid "Recovery restores the last saved workspace. Unsaved work may be lost."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:101
+msgid "Update progress"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:48
+msgid "Updating {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:47
+msgid "Updating Team Computer"
+msgstr ""

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3400,3 +3400,7 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx:47
 msgid "Updating Team Computer"
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Recovery is unavailable until the previous operation has stopped."
+msgstr ""

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3346,3 +3346,57 @@ msgstr "Docker अतिरिक्त सुरक्षा के लिए �
 #: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "स्थानीय पहुँच मिलने पर बॉट्स बिना पूछे कमांड चला सकते हैं। साझा या सार्वजनिक सर्वर पर इससे बचें।"
+
+#: src/components/ComputerUpdateProgress.tsx:181
+msgid "Continue in Background"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:151
+msgid "Could not complete action"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:31
+msgid "Getting ready"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:45
+msgid "Recovering {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:44
+msgid "Recovering Team Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:40
+msgid "Recovery failed"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:33
+msgid "Recreating the computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:34
+msgid "Restoring your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:32
+msgid "Saving your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:139
+msgid "Recovery restores the last saved workspace. Unsaved work may be lost."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:101
+msgid "Update progress"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:48
+msgid "Updating {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:47
+msgid "Updating Team Computer"
+msgstr ""

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3404,3 +3404,19 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx
 msgid "Recovery is unavailable until the previous operation has stopped."
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release interrupted computer?"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Workers and operations are stopped"
+msgstr ""

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3346,3 +3346,57 @@ msgstr "Docker는 보안을 위해 컴퓨터 접근을 제한합니다. {hostLab
 #: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "로컬 접근을 허용하면 Bot이 묻지 않고 명령을 실행할 수 있습니다. 공유 서버나 공개 서버에서는 허용하지 마세요."
+
+#: src/components/ComputerUpdateProgress.tsx:181
+msgid "Continue in Background"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:151
+msgid "Could not complete action"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:31
+msgid "Getting ready"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:45
+msgid "Recovering {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:44
+msgid "Recovering Team Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:40
+msgid "Recovery failed"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:33
+msgid "Recreating the computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:34
+msgid "Restoring your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:32
+msgid "Saving your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:139
+msgid "Recovery restores the last saved workspace. Unsaved work may be lost."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:101
+msgid "Update progress"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:48
+msgid "Updating {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:47
+msgid "Updating Team Computer"
+msgstr ""

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3400,3 +3400,7 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx:47
 msgid "Updating Team Computer"
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Recovery is unavailable until the previous operation has stopped."
+msgstr ""

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3404,3 +3404,19 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx
 msgid "Recovery is unavailable until the previous operation has stopped."
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release interrupted computer?"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Workers and operations are stopped"
+msgstr ""

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3400,3 +3400,7 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx:47
 msgid "Updating Team Computer"
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Recovery is unavailable until the previous operation has stopped."
+msgstr ""

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3346,3 +3346,57 @@ msgstr "O Docker limita o acesso ao seu computador para maior segurança. Usar {
 #: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "O acesso local permite que os bots executem comandos sem perguntar. Evite usá-lo em servidores compartilhados ou públicos."
+
+#: src/components/ComputerUpdateProgress.tsx:181
+msgid "Continue in Background"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:151
+msgid "Could not complete action"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:31
+msgid "Getting ready"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:45
+msgid "Recovering {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:44
+msgid "Recovering Team Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:40
+msgid "Recovery failed"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:33
+msgid "Recreating the computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:34
+msgid "Restoring your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:32
+msgid "Saving your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:139
+msgid "Recovery restores the last saved workspace. Unsaved work may be lost."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:101
+msgid "Update progress"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:48
+msgid "Updating {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:47
+msgid "Updating Team Computer"
+msgstr ""

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3404,3 +3404,19 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx
 msgid "Recovery is unavailable until the previous operation has stopped."
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release interrupted computer?"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Workers and operations are stopped"
+msgstr ""

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3400,3 +3400,7 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx:47
 msgid "Updating Team Computer"
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Recovery is unavailable until the previous operation has stopped."
+msgstr ""

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3404,3 +3404,19 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx
 msgid "Recovery is unavailable until the previous operation has stopped."
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release interrupted computer?"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Workers and operations are stopped"
+msgstr ""

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3346,3 +3346,57 @@ msgstr "Docker, ek güvenlik için bilgisayarına erişimi sınırlar. {hostLabe
 #: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "Yerel erişim, botların sormadan komut çalıştırmasına izin verir. Paylaşılan veya herkese açık sunucularda bunu kullanma."
+
+#: src/components/ComputerUpdateProgress.tsx:181
+msgid "Continue in Background"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:151
+msgid "Could not complete action"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:31
+msgid "Getting ready"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:45
+msgid "Recovering {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:44
+msgid "Recovering Team Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:40
+msgid "Recovery failed"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:33
+msgid "Recreating the computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:34
+msgid "Restoring your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:32
+msgid "Saving your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:139
+msgid "Recovery restores the last saved workspace. Unsaved work may be lost."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:101
+msgid "Update progress"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:48
+msgid "Updating {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:47
+msgid "Updating Team Computer"
+msgstr ""

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -3400,3 +3400,7 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx:47
 msgid "Updating Team Computer"
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Recovery is unavailable until the previous operation has stopped."
+msgstr ""

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -3404,3 +3404,19 @@ msgstr ""
 #: src/components/ComputerUpdateProgress.tsx
 msgid "Recovery is unavailable until the previous operation has stopped."
 msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Release interrupted computer?"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx
+msgid "Workers and operations are stopped"
+msgstr ""

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -3346,3 +3346,57 @@ msgstr "Docker 限制对你电脑的访问，以提高安全性。使用{hostLab
 #: src/pages/HostComputerPrompt.tsx:69
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "本地访问权限允许 Bot 无需询问就执行命令。请勿在共享或公开服务器上启用。"
+
+#: src/components/ComputerUpdateProgress.tsx:181
+msgid "Continue in Background"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:151
+msgid "Could not complete action"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:31
+msgid "Getting ready"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:45
+msgid "Recovering {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:44
+msgid "Recovering Team Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:40
+msgid "Recovery failed"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:33
+msgid "Recreating the computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:34
+msgid "Restoring your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:32
+msgid "Saving your workspace"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:139
+msgid "Recovery restores the last saved workspace. Unsaved work may be lost."
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:101
+msgid "Update progress"
+msgstr ""
+
+#. placeholder {0}: update.name
+#: src/components/ComputerUpdateProgress.tsx:48
+msgid "Updating {0}’s Computer"
+msgstr ""
+
+#: src/components/ComputerUpdateProgress.tsx:47
+msgid "Updating Team Computer"
+msgstr ""

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -129,6 +129,7 @@ import {
   ComputersUnavailableHint,
   computersAreUnavailable,
 } from "../components/ComputersUnavailableHint";
+import { ComputerUpdateProgress } from "../components/ComputerUpdateProgress";
 import { MessageHoverMetadata } from "../components/MessageHoverMetadata";
 import { SkillDraftCard } from "../components/teach/SkillDraftCard";
 import { TeachCaptureOverlay } from "../components/teach/TeachCaptureOverlay";
@@ -2390,6 +2391,11 @@ export function ShellPage() {
       data-ready={shellReady}
       className="relative flex h-full min-w-0 overflow-hidden bg-background text-foreground/90"
     >
+      <ComputerUpdateProgress
+        onCompleted={() => {
+          if (active) void refreshThread(active.id);
+        }}
+      />
       {bootstrapMe !== undefined ? (
         <HostComputerPrompt initialMe={bootstrapMe ?? undefined} />
       ) : null}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -36,6 +36,7 @@ import {
   PostgresRealtimeFanout,
   pipedreamConfigFromEnv,
   reconcileCloudAgents,
+  reconcileComputerUpdates,
   resolveDeploymentModel,
   resolvePiSessionRoot,
   resolveSandboxProvider,
@@ -202,6 +203,7 @@ async function main() {
     events,
     leadership: createPostgresReconciliationLeadership(pool),
     reconcileCloudAgents: () => reconcileCloudAgents({ prisma, jobs, cloudAgent }),
+    reconcileComputerUpdates: () => reconcileComputerUpdates({ prisma, jobs }),
   });
   reconciler.start();
 

--- a/docs/computer-runtime.md
+++ b/docs/computer-runtime.md
@@ -83,3 +83,24 @@ It starts the full API, provisions a real E2B desktop, serves a deterministic pa
 ### Docker desktop lifecycle regression
 
 Build the computer image, then run `VERIFY_DOCKER_TEAM_SCREENS=1 pnpm exec vitest run infra/sandboxes/supervisor/src/team-desktops.docker.test.ts`. Set `RAKAZO_COMPUTER_IMAGE` to select a prebuilt image. The test uses an isolated Docker container with networking disabled and fake browser state; it verifies parallel Chrome desktops visiting local fixture sites, independent cookies, profile persistence after release, transport teardown, and rejection of old view/control tokens after slot reuse. It runs both Docker supervision and the command path used by remote providers. Default unit tests exercise profile persistence, allocation, and lease fencing offline without Docker.
+
+## Computer maintenance
+
+Update and recovery run as durable background jobs. A computer-wide reservation
+excludes new execution leases, stop, takeover, idle suspension, and computer-mode
+changes while the operation saves and replaces the workspace. Progress is stored
+separately from the computer's provisioning fence. Web and Electron show a dialog
+or compact background pill; mobile uses a native sheet. Reopening the app restores
+active operations and failures from the API.
+
+Update explicitly rebuilds with the configured provider/image; `canUpdate` means
+the computer supports that action, not that a newer image was detected. Provider
+migration and image-version discovery are not part of this UI. Updates checkpoint
+live work before teardown. Recovery can fall back to the last saved workspace,
+so its failure action warns that unsaved work may be lost.
+
+The reconciler republishes queued operations after a missed enqueue. Jobs already
+claimed are never destructively replayed. A worker that stops heartbeating for ten
+minutes leaves a visible failure requiring explicit recovery. Progress reports
+actual lifecycle stages rather than estimated percentages; workspace files and
+browser profiles are portable, while system packages outside the workspace are not.

--- a/docs/computer-runtime.md
+++ b/docs/computer-runtime.md
@@ -104,6 +104,11 @@ claimed are never destructively replayed. A worker that stops heartbeating for t
 minutes is marked interrupted and remains reserved until its provider calls settle.
 Only then is recovery available. If a worker has permanently disappeared, an operator
 must stop the affected workers and verify that provider operations have stopped before
-clearing the reservation; a stale heartbeat alone never authorizes takeover. Progress reports
+using the server-owner-only **Release computer** action in the interrupted dialog.
+Its confirmation requires an explicit assertion that workers and provider operations
+have stopped, then makes normal recovery available. The corresponding RPC is
+`computer/releaseInterrupted` with `{ id, workersStopped: true }`; it accepts only
+interrupted operations in the owner’s current workspace. A stale heartbeat alone
+never authorizes takeover. Progress reports
 actual lifecycle stages rather than estimated percentages; workspace files and
 browser profiles are portable, while system packages outside the workspace are not.

--- a/docs/computer-runtime.md
+++ b/docs/computer-runtime.md
@@ -101,6 +101,9 @@ so its failure action warns that unsaved work may be lost.
 
 The reconciler republishes queued operations after a missed enqueue. Jobs already
 claimed are never destructively replayed. A worker that stops heartbeating for ten
-minutes leaves a visible failure requiring explicit recovery. Progress reports
+minutes is marked interrupted and remains reserved until its provider calls settle.
+Only then is recovery available. If a worker has permanently disappeared, an operator
+must stop the affected workers and verify that provider operations have stopped before
+clearing the reservation; a stale heartbeat alone never authorizes takeover. Progress reports
 actual lifecycle stages rather than estimated percentages; workspace files and
 browser profiles are portable, while system packages outside the workspace are not.

--- a/packages/adapter-kit/src/background-jobs.test.ts
+++ b/packages/adapter-kit/src/background-jobs.test.ts
@@ -12,6 +12,7 @@ function handlers(): BackgroundJobHandlers {
   return {
     "run.continue": vi.fn(async () => undefined),
     "routine.wakeup": vi.fn(async () => undefined),
+    "computer.update": vi.fn(async () => undefined),
     "computer.sleep": vi.fn(async () => undefined),
     "computer.control-expire": vi.fn(async () => undefined),
     "skill.teaching-expire": vi.fn(async () => undefined),

--- a/packages/adapter-kit/src/background-jobs.ts
+++ b/packages/adapter-kit/src/background-jobs.ts
@@ -12,6 +12,7 @@ const payloadSchemas = {
     routineId: z.string().min(1),
     scheduledFor: z.string().datetime({ offset: true }),
   }),
+  "computer.update": z.object({ updateId: z.string().min(1) }),
   "computer.sleep": z.object({ computerId: z.string().min(1) }),
   "computer.control-expire": z.object({
     computerId: z.string().min(1),

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -459,6 +459,7 @@ export interface BackgroundJobPayloads {
   "run.continue": { runId: string };
   "routine.wakeup": { routineId: string; scheduledFor: string };
   "computer.sleep": { computerId: string };
+  "computer.update": { updateId: string };
   "computer.control-expire": { computerId: string; leaseId: string };
   "skill.teaching-expire": { skillId: string };
   "history.compact": { threadId: string };

--- a/packages/adapters/src/background-job-handlers.ts
+++ b/packages/adapters/src/background-job-handlers.ts
@@ -12,6 +12,7 @@ import { getLogger } from "@rakazo/logging";
 import { pollCloudAgent } from "./cloud-agent-poll.js";
 import { expireComputerControl } from "./computer-control.js";
 import { scheduleComputerSleep, sleepComputerIfIdle } from "./computer-idle.js";
+import { performComputerUpdate } from "./computer-update.js";
 import type { createRunExecutor } from "./executor.js";
 import { compactHistory } from "./history-compaction.js";
 import type { MemoryProviderResolver } from "./memory-provider-factory.js";
@@ -70,6 +71,9 @@ export function createBackgroundJobHandlers(deps: {
     },
     "routine.wakeup": async (payload) => {
       await deps.executor.wakeRoutine(payload.routineId, payload.scheduledFor);
+    },
+    "computer.update": async ({ updateId }) => {
+      await performComputerUpdate(deps, updateId);
     },
     "computer.sleep": async (payload) => {
       await sleepComputerIfIdle(deps, payload.computerId);

--- a/packages/adapters/src/computer-idle.ts
+++ b/packages/adapters/src/computer-idle.ts
@@ -229,6 +229,7 @@ export async function sleepComputerIfIdle(
     where: {
       id: computerId,
       state: "running",
+      maintenanceId: null,
       providerRef: computer.providerRef,
       updatedAt: computer.updatedAt,
       executionRunId: null,

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -102,6 +102,7 @@ describe("computer provisioning", () => {
         2,
         expect.objectContaining({
           where: {
+            maintenanceId: null,
             id: "computer-1",
             state: "booting",
             updatedAt: expect.any(Date),
@@ -686,6 +687,7 @@ describe("computer provisioning", () => {
         expect(sandbox.stop).not.toHaveBeenCalled();
         expect(prisma.computer.updateMany).toHaveBeenLastCalledWith({
           where: {
+            maintenanceId: null,
             id: "computer-1",
             state: "booting",
             providerRef: "provider-1",
@@ -827,6 +829,7 @@ describe("computer provisioning", () => {
         expect(await sandbox.readFile(ref, "notes/keep.txt", context)).toEqual(saved);
         expect(prisma.computer.updateMany).toHaveBeenLastCalledWith({
           where: {
+            maintenanceId: null,
             id: "computer-1",
             state: "booting",
             providerRef: "provider-1",
@@ -1022,6 +1025,7 @@ describe("computer provisioning", () => {
       });
       expect(updateMany).toHaveBeenLastCalledWith({
         where: {
+          maintenanceId: null,
           id: "computer-1",
           state: "booting",
           providerRef: null,
@@ -2366,7 +2370,7 @@ describe("computer replacement", () => {
       ).rejects.toThrow("ECONNRESET");
       expect(destroy).not.toHaveBeenCalled();
       expect(updateMany).toHaveBeenLastCalledWith({
-        where: { id: "computer-1" },
+        where: { id: "computer-1", maintenanceId: null },
         data: { state: "error" },
       });
     } finally {

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -6,6 +6,7 @@ import type {
   JobPublisher,
   SandboxProvider,
 } from "@rakazo/adapter-kit";
+import type { ComputerUpdate } from "@rakazo/contracts";
 import { ACTIVE_RUN_STATUSES, parseScreenLeaseId, screenLeaseId } from "@rakazo/core";
 import {
   expireComputerExecutionLeases,
@@ -25,6 +26,10 @@ import {
   restoreComputerWorkspace,
 } from "./computer-workspace.js";
 import { resolveAgentHomePath } from "./home.js";
+
+type ComputerUpdateProgress = (
+  stage: Exclude<ComputerUpdate["stage"], "preparing">,
+) => Promise<void>;
 
 const EXECUTION_LEASE_MS = 5 * 60_000;
 const BOOT_WAIT_ATTEMPTS = 40;
@@ -133,8 +138,11 @@ export async function provisionComputer(
   computerId: string,
   context: AdapterContext,
   controlHolder: "bot" | "none" = "none",
+  onProgress?: ComputerUpdateProgress,
 ): Promise<ComputerRef> {
   let existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
+  if (existing.maintenanceId && existing.maintenanceId !== context.operationId)
+    throw new ComputerBusyError();
   if (existing.controlLeaseId && !hasActiveComputerControl(existing)) {
     await expireComputerControl(deps, existing.id, existing.controlLeaseId);
     existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
@@ -229,6 +237,7 @@ export async function provisionComputer(
     where: {
       id: computerId,
       ...claimWhere,
+      maintenanceId: existing.maintenanceId ?? null,
       ...(context.botId ? { bots: { some: { id: context.botId, archivedAt: null } } } : {}),
     },
     data: { state: "booting", updatedAt: claimStamp },
@@ -236,6 +245,7 @@ export async function provisionComputer(
   if (claimed.count !== 1) throw new ComputerBusyError();
   let provisioned: ComputerRef | undefined;
   try {
+    await onProgress?.("recreating");
     const ref = await deps.sandbox.provision(
       {
         botId: existing.homeKey,
@@ -253,8 +263,10 @@ export async function provisionComputer(
       existing.providerRef !== ref.providerRef ||
       existing.kind !== ref.kind;
     if (replacement) {
+      await onProgress?.("restoring");
       await restoreComputerWorkspace(deps.home, deps.sandbox, existing.homeKey, ref, context);
     }
+    await onProgress?.("reconnecting");
     await ensureComputerWorkspaceLayout(
       deps.sandbox,
       ref,
@@ -269,6 +281,7 @@ export async function provisionComputer(
         state: "booting",
         updatedAt: claimStamp,
         ...previousRef,
+        maintenanceId: existing.maintenanceId ?? null,
         ...(context.botId ? { bots: { some: { id: context.botId, archivedAt: null } } } : {}),
       },
       data: {
@@ -307,6 +320,7 @@ export async function provisionComputer(
           state: "booting",
           updatedAt: claimStamp,
           ...previousRef,
+          maintenanceId: existing.maintenanceId ?? null,
         },
         data: {
           state: reconnecting ? "running" : "error",
@@ -398,6 +412,8 @@ export async function acquireComputerExecutionLease(
   },
 ): Promise<ComputerExecutionLease | null> {
   const computer = await prisma.computer.findUniqueOrThrow({ where: { id: input.computerId } });
+  if (computer.maintenanceId && computer.maintenanceId !== input.runId)
+    throw new ComputerBusyError();
   if (computer.scope !== "team") return null;
   if (computer.state === "suspending") throw new ComputerBusyError();
   const now = new Date();
@@ -452,9 +468,13 @@ async function validateAcquiredComputerLease(
 ): Promise<ComputerExecutionLease> {
   const computer = await prisma.computer.findUniqueOrThrow({
     where: { id: lease.computerId },
-    select: { state: true },
+    select: { state: true, maintenanceId: true },
   });
-  if (computer.state !== "suspending") return lease;
+  if (
+    computer.state !== "suspending" &&
+    (!computer.maintenanceId || computer.maintenanceId === lease.runId)
+  )
+    return lease;
   await releaseComputerExecutionLease(prisma, lease);
   throw new ComputerBusyError();
 }
@@ -536,8 +556,11 @@ export async function replaceComputer(
   mode: ComputerReplaceMode,
   context: AdapterContext,
   controlHolder: "bot" | "none" = "none",
+  onProgress?: ComputerUpdateProgress,
 ): Promise<ComputerRef> {
   let existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
+  if (existing.maintenanceId && existing.maintenanceId !== context.operationId)
+    throw new ComputerBusyError();
   if (existing.controlLeaseId && !hasActiveComputerControl(existing)) {
     const expired = await expireComputerControl(deps, existing.id, existing.controlLeaseId);
     existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
@@ -595,6 +618,7 @@ export async function replaceComputer(
     where: {
       id: computerId,
       state: previousState,
+      maintenanceId: existing.maintenanceId ?? null,
       // CAS the booting stamp so a concurrent live claim cannot be overwritten by Reset.
       ...(previousState === "booting" ? { updatedAt: existing.updatedAt } : {}),
       executionLeases: { none: { botId: { not: botId }, expiresAt: { gt: now } } },
@@ -629,11 +653,13 @@ export async function replaceComputer(
     // Retry the checkpoint even after an earlier update left the row in error.
     if (oldRef && (mode === "update" || (existing.state === "running" && mode === "recover"))) {
       try {
+        await onProgress?.("saving");
         await checkpointAndRecordComputerWorkspace(deps, existing, oldRef, context);
       } catch (error) {
         if (mode !== "recover") throw error;
       }
     }
+    await onProgress?.("recreating");
     if (oldRef) {
       await deps.sandbox.releaseScreen?.(oldRef, context).catch(() => undefined);
       try {
@@ -642,8 +668,8 @@ export async function replaceComputer(
         if (mode !== "recover") throw error;
       }
     }
-    await deps.prisma.computer.update({
-      where: { id: computerId },
+    const stopped = await deps.prisma.computer.updateMany({
+      where: { id: computerId, state: "suspending", maintenanceId: existing.maintenanceId ?? null },
       data: {
         state: "stopped",
         providerRef: null,
@@ -654,11 +680,12 @@ export async function replaceComputer(
         controlRunId: null,
       },
     });
-    return provisionComputer(deps, computerId, context, controlHolder);
+    if (stopped.count !== 1) throw new ComputerBusyError();
+    return provisionComputer(deps, computerId, context, controlHolder, onProgress);
   } catch (error) {
     await deps.prisma.computer
       .updateMany({
-        where: { id: computerId },
+        where: { id: computerId, maintenanceId: existing.maintenanceId ?? null },
         data: { state: "error" },
       })
       .catch(() => undefined);

--- a/packages/adapters/src/computer-recovery.test.ts
+++ b/packages/adapters/src/computer-recovery.test.ts
@@ -44,6 +44,7 @@ async function fixture(provider: "fake" | "desktop" = "fake") {
     kind: first.kind,
     controlHolder: "none",
     controlLeaseId: null,
+    maintenanceId: null as string | null,
     homeRevision: "saved",
     updatedAt: new Date("2024-01-01T00:00:00.000Z"),
   };
@@ -78,6 +79,23 @@ async function fixture(provider: "fake" | "desktop" = "fake") {
 }
 
 describe("computer recovery preserves live work", () => {
+  it("blocks competing maintenance and boots while an update owns the computer", async () => {
+    const { deps, row } = await fixture();
+    row.maintenanceId = "other-update";
+    const destroy = vi.spyOn(deps.sandbox, "destroy");
+    const provision = vi.spyOn(deps.sandbox, "provision");
+    await expect(provisionComputer(deps, row.id, context)).rejects.toBeInstanceOf(
+      ComputerBusyError,
+    );
+    for (const mode of ["update", "recover", "reset"] as const) {
+      await expect(replaceComputer(deps, row.id, mode, context)).rejects.toBeInstanceOf(
+        ComputerBusyError,
+      );
+    }
+    expect(destroy).not.toHaveBeenCalled();
+    expect(provision).not.toHaveBeenCalled();
+  });
+
   it("claims a running computer before concurrent workers can create competing replacements", async () => {
     const { deps, row, computer, first } = await fixture();
     await deps.sandbox.destroy(first, context);

--- a/packages/adapters/src/computer-update.test.ts
+++ b/packages/adapters/src/computer-update.test.ts
@@ -54,6 +54,7 @@ function fixture(status = "queued") {
     }),
   };
   const prisma = {
+    $queryRaw: vi.fn(async () => []),
     computer,
     bot: { findFirst: vi.fn(async () => ({ userId: "user" })) },
     computerUpdate,

--- a/packages/adapters/src/computer-update.test.ts
+++ b/packages/adapters/src/computer-update.test.ts
@@ -42,7 +42,13 @@ function fixture(status = "queued") {
     findUniqueOrThrow: vi.fn(async () => row),
     findMany: vi.fn(async () => [row]),
     updateMany: vi.fn(async ({ where, data }) => {
-      if (where.status && where.status !== row.status) return { count: 0 };
+      if (
+        where.status &&
+        (typeof where.status === "string"
+          ? where.status !== row.status
+          : !where.status.in.includes(row.status))
+      )
+        return { count: 0 };
       Object.assign(row, data);
       return { count: 1 };
     }),
@@ -91,16 +97,35 @@ describe("background computer maintenance", () => {
     expect(jobs.enqueue).toHaveBeenCalledTimes(2);
     expect(replacement).not.toHaveBeenCalled();
   });
-  it("marks an abandoned worker as failed instead of repeating a destructive step", async () => {
+  it("keeps an interrupted worker reserved instead of repeating a destructive step", async () => {
     const { row, deps, computer } = fixture("running");
     await reconcileComputerUpdates(deps);
-    expect(row.status).toBe("failed");
-    expect(computer.updateMany).toHaveBeenCalledWith({
-      where: { id: row.computerId, maintenanceId: row.id },
-      data: { maintenanceId: null, state: "error" },
-    });
+    expect(row.status).toBe("interrupted");
+    expect(computer.updateMany).not.toHaveBeenCalled();
     expect(replacement).not.toHaveBeenCalled();
   });
+  it("releases an interrupted reservation only after the worker has settled", async () => {
+    const { row, deps, computer } = fixture();
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    replacement.mockImplementationOnce(async (_deps, _id, _mode, _ctx, _holder, progress) => {
+      await pending;
+      await progress?.("recreating");
+      return {} as Awaited<ReturnType<typeof replaceComputer>>;
+    });
+    const work = performComputerUpdate(deps, row.id);
+    await vi.waitFor(() => expect(replacement).toHaveBeenCalled());
+    await reconcileComputerUpdates(deps);
+    expect(row.status).toBe("interrupted");
+    expect(computer.updateMany).not.toHaveBeenCalled();
+    release();
+    await work;
+    expect(row.status).toBe("failed");
+    expect(computer.updateMany).toHaveBeenCalledOnce();
+  });
+
   it("rejects a busy computer before publishing an operation", async () => {
     const { row, deps, computer, jobs } = fixture();
     computer.updateMany.mockResolvedValueOnce({ count: 0 });

--- a/packages/adapters/src/computer-update.test.ts
+++ b/packages/adapters/src/computer-update.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { replaceComputer } from "./computer-lifecycle.js";
+import {
+  performComputerUpdate,
+  queueComputerUpdate,
+  reconcileComputerUpdates,
+} from "./computer-update.js";
+
+vi.mock("./computer-lifecycle.js", async (original) => ({
+  ...(await original<typeof import("./computer-lifecycle.js")>()),
+  replaceComputer: vi.fn(),
+}));
+const replacement = vi.mocked(replaceComputer);
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+function fixture(status = "queued") {
+  const row = {
+    id: "update-1",
+    computerId: "computer-1",
+    botId: "bot-1",
+    action: "update",
+    status,
+    stage: "preparing",
+    updatedAt: new Date(0),
+    computer: {
+      id: "computer-1",
+      kind: "fake",
+      scope: "team",
+      spaceId: "space",
+      userId: "user",
+      bots: [{ id: "bot-1", name: "Writer" }],
+    },
+  };
+  const computer = {
+    updateMany: vi.fn(async () => ({ count: 1 })),
+    findUniqueOrThrow: vi.fn(async () => row.computer),
+  };
+  const computerUpdate = {
+    create: vi.fn(async () => row),
+    findUniqueOrThrow: vi.fn(async () => row),
+    findMany: vi.fn(async () => [row]),
+    updateMany: vi.fn(async ({ where, data }) => {
+      if (where.status && where.status !== row.status) return { count: 0 };
+      Object.assign(row, data);
+      return { count: 1 };
+    }),
+  };
+  const prisma = {
+    computer,
+    bot: { findFirst: vi.fn(async () => ({ userId: "user" })) },
+    computerUpdate,
+    $transaction: vi.fn(async (fn) => fn(prisma)),
+  };
+  const jobs = { enqueue: vi.fn(async () => {}) };
+  const deps = { prisma, jobs } as unknown as Parameters<typeof performComputerUpdate>[0];
+  return { row, computer, computerUpdate, deps, jobs };
+}
+describe("background computer maintenance", () => {
+  it("persists stages and releases its reservation only after completion; redelivery is harmless", async () => {
+    const { row, computer, deps } = fixture();
+    replacement.mockImplementationOnce(async (_deps, _id, _mode, _ctx, _holder, progress) => {
+      for (const stage of ["saving", "recreating", "restoring", "reconnecting"] as const)
+        await progress?.(stage);
+      return {} as Awaited<ReturnType<typeof replaceComputer>>;
+    });
+    await performComputerUpdate(deps, row.id);
+    expect(row).toMatchObject({ status: "completed", stage: "reconnecting" });
+    expect(computer.updateMany).toHaveBeenCalledWith({
+      where: { id: row.computerId, maintenanceId: row.id },
+      data: { maintenanceId: null },
+    });
+    await performComputerUpdate(deps, row.id);
+    expect(replacement).toHaveBeenCalledOnce();
+  });
+  it("records a failure without exposing the provider error or replaying replacement", async () => {
+    const { row, deps } = fixture();
+    replacement.mockRejectedValueOnce(new Error("provider-private-detail"));
+    await performComputerUpdate(deps, row.id);
+    expect(row.status).toBe("failed");
+    expect(JSON.stringify(row)).not.toContain("provider-private-detail");
+    await performComputerUpdate(deps, row.id);
+    expect(replacement).toHaveBeenCalledOnce();
+  });
+  it("republishes queued intent after an enqueue failure", async () => {
+    const { row, deps, jobs } = fixture();
+    jobs.enqueue.mockRejectedValueOnce(new Error("offline"));
+    await queueComputerUpdate(deps, row.computerId, row.botId);
+    await reconcileComputerUpdates(deps);
+    expect(jobs.enqueue).toHaveBeenCalledTimes(2);
+    expect(replacement).not.toHaveBeenCalled();
+  });
+  it("marks an abandoned worker as failed instead of repeating a destructive step", async () => {
+    const { row, deps, computer } = fixture("running");
+    await reconcileComputerUpdates(deps);
+    expect(row.status).toBe("failed");
+    expect(computer.updateMany).toHaveBeenCalledWith({
+      where: { id: row.computerId, maintenanceId: row.id },
+      data: { maintenanceId: null, state: "error" },
+    });
+    expect(replacement).not.toHaveBeenCalled();
+  });
+  it("rejects a busy computer before publishing an operation", async () => {
+    const { row, deps, computer, jobs } = fixture();
+    computer.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(queueComputerUpdate(deps, row.computerId, row.botId)).rejects.toThrow(
+      "Computer is busy",
+    );
+    expect(jobs.enqueue).not.toHaveBeenCalled();
+  });
+});

--- a/packages/adapters/src/computer-update.ts
+++ b/packages/adapters/src/computer-update.ts
@@ -1,0 +1,195 @@
+import { type ComputerUpdate, ComputerUpdateSchema } from "@rakazo/contracts";
+import { ACTIVE_RUN_STATUSES } from "@rakazo/core";
+import type { PrismaClient } from "@rakazo/db";
+import { scheduleComputerSleep } from "./computer-idle.js";
+import {
+  ComputerBusyError,
+  computerSupportsUpdate,
+  replaceComputer,
+} from "./computer-lifecycle.js";
+
+type Deps = Parameters<typeof replaceComputer>[0];
+const STALE_MS = 10 * 60_000;
+
+export function computerUpdateView(row: {
+  action: string;
+  id: string;
+  botId: string;
+  status: string;
+  stage: string;
+  computer: { scope: string; bots: { id: string; name: string }[] };
+}): ComputerUpdate {
+  return ComputerUpdateSchema.parse({
+    action: row.action,
+    id: row.id,
+    botId: row.computer.bots.some((bot) => bot.id === row.botId)
+      ? row.botId
+      : (row.computer.bots[0]?.id ?? row.botId),
+    name: row.computer.bots.find((bot) => bot.id === row.botId)?.name ?? "",
+    mode: row.computer.scope === "team" ? "team" : "dedicated",
+    status: row.status,
+    stage: row.stage,
+  });
+}
+
+export async function queueComputerUpdate(
+  deps: Pick<Deps, "prisma" | "jobs">,
+  computerId: string,
+  botId: string,
+  action: "update" | "recover" = "update",
+) {
+  const update = await deps.prisma.$transaction(async (tx) => {
+    const computer = await tx.computer.findUniqueOrThrow({ where: { id: computerId } });
+    if (action === "update" && !computerSupportsUpdate(computer.kind))
+      throw new Error("Computer update is not available on this device");
+    const update = await tx.computerUpdate.create({ data: { computerId, botId, action } });
+    const claimed = await tx.computer.updateMany({
+      where: {
+        id: computerId,
+        maintenanceId: null,
+        state: { notIn: ["booting", "suspending"] },
+        controlHolder: { not: "user" },
+        executionLeases: { none: { expiresAt: { gt: new Date() } } },
+        bots: {
+          none: {
+            OR: [
+              { computerSwitching: true },
+              { runs: { some: { status: { in: [...ACTIVE_RUN_STATUSES] } } } },
+            ],
+          },
+        },
+      },
+      data: { maintenanceId: update.id },
+    });
+    if (claimed.count !== 1) throw new ComputerBusyError();
+    await tx.computerUpdate.updateMany({
+      where: { computerId, status: "failed" },
+      data: { status: "dismissed" },
+    });
+    return tx.computerUpdate.findUniqueOrThrow({
+      where: { id: update.id },
+      include: {
+        computer: { include: { bots: { where: { id: botId }, select: { id: true, name: true } } } },
+      },
+    });
+  });
+  // The reconciler republishes durable queued intent if publishing fails.
+  await deps.jobs
+    .enqueue({
+      name: "computer.update",
+      payload: { updateId: update.id },
+      replaceKey: `computer.update:${update.id}`,
+    })
+    .catch(() => undefined);
+  return computerUpdateView(update);
+}
+
+export async function performComputerUpdate(deps: Deps, updateId: string) {
+  const claimed = await deps.prisma.computerUpdate.updateMany({
+    where: { id: updateId, status: "queued" },
+    data: { status: "running" },
+  });
+  if (claimed.count !== 1) return; // Never replay a destructive operation on job redelivery.
+  const update = await deps.prisma.computerUpdate.findUniqueOrThrow({
+    where: { id: updateId },
+    include: { computer: true },
+  });
+  const controller = new AbortController();
+  const heartbeat = setInterval(() => {
+    void deps.prisma.computerUpdate
+      .updateMany({ where: { id: updateId, status: "running" }, data: { updatedAt: new Date() } })
+      .then((result) => {
+        if (result.count !== 1) controller.abort();
+      })
+      .catch(() => controller.abort());
+  }, 30_000);
+  try {
+    const bot = await deps.prisma.bot.findFirst({
+      where: { id: update.botId, computerId: update.computerId, archivedAt: null },
+      select: { userId: true },
+    });
+    if (!bot) throw new Error("Computer update target is unavailable");
+    await replaceComputer(
+      deps,
+      update.computerId,
+      update.action === "recover" ? "recover" : "update",
+      {
+        operationId: updateId,
+        traceId: updateId,
+        botId: update.botId,
+        spaceId: update.computer.spaceId,
+        userId: bot.userId,
+        signal: controller.signal,
+      },
+      "none",
+      async (stage) => {
+        controller.signal.throwIfAborted();
+        const result = await deps.prisma.computerUpdate.updateMany({
+          where: { id: updateId, status: "running" },
+          data: { stage: update.action === "recover" && stage === "saving" ? "preparing" : stage },
+        });
+        if (result.count !== 1) throw new Error("Computer update interrupted");
+      },
+    );
+    await finishUpdate(deps.prisma, updateId, update.computerId, "completed");
+    scheduleComputerSleep(deps.jobs, update.computerId);
+  } catch {
+    // Provider errors may contain credentials or private URLs. Expose only the failed stage.
+    await finishUpdate(deps.prisma, updateId, update.computerId, "failed");
+  } finally {
+    clearInterval(heartbeat);
+  }
+}
+
+async function finishUpdate(
+  prisma: PrismaClient,
+  id: string,
+  computerId: string,
+  status: "completed" | "failed",
+) {
+  await prisma.$transaction(async (tx) => {
+    const finished = await tx.computerUpdate.updateMany({
+      where: { id, status: "running" },
+      data: { status },
+    });
+    if (finished.count !== 1) return;
+    await tx.computer.updateMany({
+      where: { id: computerId, maintenanceId: id },
+      data: { maintenanceId: null },
+    });
+  });
+}
+
+export async function reconcileComputerUpdates(deps: Pick<Deps, "prisma" | "jobs">) {
+  const updates = await deps.prisma.computerUpdate.findMany({
+    where: {
+      OR: [
+        { status: "queued" },
+        { status: "running", updatedAt: { lt: new Date(Date.now() - STALE_MS) } },
+      ],
+    },
+    take: 100,
+    orderBy: { updatedAt: "asc" },
+  });
+  for (const update of updates) {
+    if (update.status === "queued") {
+      await deps.jobs.enqueue({
+        name: "computer.update",
+        payload: { updateId: update.id },
+        replaceKey: `computer.update:${update.id}`,
+      });
+    } else {
+      await deps.prisma.$transaction(async (tx) => {
+        const stale = await tx.computerUpdate.updateMany({
+          where: { id: update.id, status: "running", updatedAt: update.updatedAt },
+          data: { status: "failed" },
+        });
+        if (stale.count !== 1) return;
+        await tx.computer.updateMany({
+          where: { id: update.computerId, maintenanceId: update.id },
+          data: { maintenanceId: null, state: "error" },
+        });
+      });
+    }
+  }
+}

--- a/packages/adapters/src/computer-update.ts
+++ b/packages/adapters/src/computer-update.ts
@@ -1,6 +1,7 @@
 import { type ComputerUpdate, ComputerUpdateSchema } from "@rakazo/contracts";
 import { ACTIVE_RUN_STATUSES } from "@rakazo/core";
 import type { PrismaClient } from "@rakazo/db";
+import { getLogger } from "@rakazo/logging";
 import { scheduleComputerSleep } from "./computer-idle.js";
 import {
   ComputerBusyError,
@@ -11,15 +12,19 @@ import {
 type Deps = Parameters<typeof replaceComputer>[0];
 const STALE_MS = 10 * 60_000;
 
-export function computerUpdateView(row: {
-  action: string;
-  id: string;
-  botId: string;
-  status: string;
-  stage: string;
-  computer: { scope: string; bots: { id: string; name: string }[] };
-}): ComputerUpdate {
+export function computerUpdateView(
+  row: {
+    action: string;
+    id: string;
+    botId: string;
+    status: string;
+    stage: string;
+    computer: { scope: string; bots: { id: string; name: string }[] };
+  },
+  isDeploymentOwner = false,
+): ComputerUpdate {
   return ComputerUpdateSchema.parse({
+    canReleaseReservation: isDeploymentOwner && row.status === "interrupted",
     action: row.action,
     id: row.id,
     botId: row.computer.bots.some((bot) => bot.id === row.botId)
@@ -39,6 +44,9 @@ export async function queueComputerUpdate(
   action: "update" | "recover" = "update",
 ) {
   const update = await deps.prisma.$transaction(async (tx) => {
+    // Mode switches lock this same row before marking a bot as switching.
+    // The following statement then observes their committed reservation.
+    await tx.$queryRaw`SELECT id FROM computers WHERE id = ${computerId} FOR UPDATE`;
     const computer = await tx.computer.findUniqueOrThrow({ where: { id: computerId } });
     if (action === "update" && !computerSupportsUpdate(computer.kind))
       throw new Error("Computer update is not available on this device");
@@ -51,6 +59,7 @@ export async function queueComputerUpdate(
         controlHolder: { not: "user" },
         executionLeases: { none: { expiresAt: { gt: new Date() } } },
         bots: {
+          some: { id: botId, archivedAt: null },
           none: {
             OR: [
               { computerSwitching: true },
@@ -133,7 +142,8 @@ export async function performComputerUpdate(deps: Deps, updateId: string) {
     );
     await finishUpdate(deps.prisma, updateId, update.computerId, "completed");
     scheduleComputerSleep(deps.jobs, update.computerId);
-  } catch {
+  } catch (error) {
+    getLogger().error("computer update failed", error, { updateId, computerId: update.computerId });
     // Provider errors may contain credentials or private URLs. Expose only the failed stage.
     await finishUpdate(deps.prisma, updateId, update.computerId, "failed");
   } finally {

--- a/packages/adapters/src/computer-update.ts
+++ b/packages/adapters/src/computer-update.ts
@@ -149,7 +149,7 @@ async function finishUpdate(
 ) {
   await prisma.$transaction(async (tx) => {
     const finished = await tx.computerUpdate.updateMany({
-      where: { id, status: "running" },
+      where: { id, status: { in: ["running", "interrupted"] } },
       data: { status },
     });
     if (finished.count !== 1) return;
@@ -182,13 +182,11 @@ export async function reconcileComputerUpdates(deps: Pick<Deps, "prisma" | "jobs
       await deps.prisma.$transaction(async (tx) => {
         const stale = await tx.computerUpdate.updateMany({
           where: { id: update.id, status: "running", updatedAt: update.updatedAt },
-          data: { status: "failed" },
+          data: { status: "interrupted" },
         });
+        // A stale heartbeat is not proof that provider calls have stopped. Only
+        // the worker's settled path can release this reservation.
         if (stale.count !== 1) return;
-        await tx.computer.updateMany({
-          where: { id: update.computerId, maintenanceId: update.id },
-          data: { maintenanceId: null, state: "error" },
-        });
       });
     }
   }

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -31,6 +31,7 @@ export * from "./computer-lifecycle.js";
 export * from "./computer-screens.js";
 export * from "./computer-support.js";
 export * from "./computer-tools.js";
+export * from "./computer-update.js";
 export * from "./computer-workspace.js";
 export * from "./cursor-cloud-agent.js";
 export * from "./daytona-emulator.js";

--- a/packages/adapters/src/job-reconciler.test.ts
+++ b/packages/adapters/src/job-reconciler.test.ts
@@ -40,6 +40,29 @@ function fakePrisma(
 }
 
 describe("createJobReconciler", () => {
+  it("continues the main scans when an auxiliary reconciler fails", async () => {
+    const prisma = fakePrisma();
+    const { jobs } = publisher();
+    const reconcileCloudAgents = vi.fn(async () => {
+      throw new Error("cloud unavailable");
+    });
+    const reconcileComputerUpdates = vi.fn(() => {
+      throw new Error("queue unavailable");
+    });
+    await createJobReconciler({
+      prisma,
+      jobs,
+      reconcileCloudAgents,
+      reconcileComputerUpdates,
+    }).reconcileOnce();
+    expect(reconcileCloudAgents).toHaveBeenCalledOnce();
+    expect(reconcileComputerUpdates).toHaveBeenCalledOnce();
+    expect(prisma.run.findMany).toHaveBeenCalled();
+    expect(prisma.routine.findMany).toHaveBeenCalled();
+    expect(prisma.computer.findMany).toHaveBeenCalled();
+    expect(prisma.messagingOutbound.findFirst).toHaveBeenCalled();
+  });
+
   it("restores a due pending messaging outbox drain", async () => {
     const prisma = fakePrisma();
     vi.mocked(prisma.messagingOutbound.findFirst).mockResolvedValue({ id: "outbound-1" } as never);

--- a/packages/adapters/src/job-reconciler.ts
+++ b/packages/adapters/src/job-reconciler.ts
@@ -104,6 +104,7 @@ export function createJobReconciler(
     jobs: JobPublisher;
     events?: ThreadEvents;
     leadership?: ReconciliationLeadership;
+    reconcileComputerUpdates?: () => Promise<void>;
     reconcileCloudAgents?: () => Promise<void>;
   },
   options: { intervalMs?: number; batchSize?: number } = {},
@@ -122,7 +123,7 @@ export function createJobReconciler(
     reconciling = (async () => {
       if (deps.leadership && !(await deps.leadership.tryAcquire())) return;
 
-      await deps.reconcileCloudAgents?.();
+      await Promise.all([deps.reconcileCloudAgents?.(), deps.reconcileComputerUpdates?.()]);
 
       const now = new Date();
       controlScanDeadline ??= new Date(now.getTime() + CONTROL_LOOKAHEAD_MS);

--- a/packages/adapters/src/job-reconciler.ts
+++ b/packages/adapters/src/job-reconciler.ts
@@ -123,7 +123,15 @@ export function createJobReconciler(
     reconciling = (async () => {
       if (deps.leadership && !(await deps.leadership.tryAcquire())) return;
 
-      await Promise.all([deps.reconcileCloudAgents?.(), deps.reconcileComputerUpdates?.()]);
+      const auxiliary = await Promise.allSettled(
+        [deps.reconcileCloudAgents, deps.reconcileComputerUpdates].map(async (reconcile) =>
+          reconcile?.(),
+        ),
+      );
+      for (const result of auxiliary) {
+        if (result.status === "rejected")
+          getLogger().error("auxiliary reconciliation", result.reason);
+      }
 
       const now = new Date();
       controlScanDeadline ??= new Date(now.getTime() + CONTROL_LOOKAHEAD_MS);

--- a/packages/adapters/src/wakeup.postgres.test.ts
+++ b/packages/adapters/src/wakeup.postgres.test.ts
@@ -10,6 +10,7 @@ function handlers(overrides: Partial<BackgroundJobHandlers> = {}): BackgroundJob
   return {
     "run.continue": vi.fn(async () => undefined),
     "routine.wakeup": vi.fn(async () => undefined),
+    "computer.update": vi.fn(async () => undefined),
     "computer.sleep": vi.fn(async () => undefined),
     "computer.control-expire": vi.fn(async () => undefined),
     "skill.teaching-expire": vi.fn(async () => undefined),

--- a/packages/adapters/src/wakeup.test.ts
+++ b/packages/adapters/src/wakeup.test.ts
@@ -6,6 +6,7 @@ function handlers(): BackgroundJobHandlers {
   return {
     "run.continue": vi.fn(async () => undefined),
     "routine.wakeup": vi.fn(async () => undefined),
+    "computer.update": vi.fn(async () => undefined),
     "computer.sleep": vi.fn(async () => undefined),
     "computer.control-expire": vi.fn(async () => undefined),
     "skill.teaching-expire": vi.fn(async () => undefined),

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -721,6 +721,24 @@ export const UsageRecordSchema = z.object({
   createdAt: z.string(),
 });
 
+export const COMPUTER_UPDATE_STAGES = [
+  "preparing",
+  "saving",
+  "recreating",
+  "restoring",
+  "reconnecting",
+] as const;
+export const ComputerUpdateSchema = z.object({
+  action: z.enum(["update", "recover"]),
+  id: Id,
+  botId: Id,
+  name: z.string(),
+  mode: ComputerModeSchema,
+  status: z.enum(["queued", "running", "completed", "failed"]),
+  stage: z.enum(COMPUTER_UPDATE_STAGES),
+});
+export type ComputerUpdate = z.infer<typeof ComputerUpdateSchema>;
+
 export const ComputerStatusSchema = z.object({
   botId: Id,
   mode: ComputerModeSchema,
@@ -734,7 +752,7 @@ export const ComputerStatusSchema = z.object({
   screenHeight: z.number().int().positive(),
   homeRevision: z.string().nullable(),
   busyBotName: z.string().nullable(),
-  updateAvailable: z.boolean(),
+  canUpdate: z.boolean(),
 });
 export type ComputerStatus = z.infer<typeof ComputerStatusSchema>;
 

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -729,6 +729,7 @@ export const COMPUTER_UPDATE_STAGES = [
   "reconnecting",
 ] as const;
 export const ComputerUpdateSchema = z.object({
+  canReleaseReservation: z.boolean().optional(),
   action: z.enum(["update", "recover"]),
   id: Id,
   botId: Id,

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -734,7 +734,7 @@ export const ComputerUpdateSchema = z.object({
   botId: Id,
   name: z.string(),
   mode: ComputerModeSchema,
-  status: z.enum(["queued", "running", "completed", "failed"]),
+  status: z.enum(["queued", "running", "interrupted", "completed", "failed"]),
   stage: z.enum(COMPUTER_UPDATE_STAGES),
 });
 export type ComputerUpdate = z.infer<typeof ComputerUpdateSchema>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -19,6 +19,7 @@ import {
   ComputerModeSchema,
   ComputerReleaseReasonSchema,
   ComputerStatusSchema,
+  ComputerUpdateSchema,
   ConnectionCatalogItemSchema,
   ConnectionSchema,
   CreateAgentSkillInput,
@@ -307,9 +308,11 @@ export const appContract = {
     status: oc.input(botId).output(ComputerStatusSchema),
     boot: oc.input(botId).output(ComputerStatusSchema),
     stop: oc.input(botId).output(ComputerStatusSchema),
-    recover: oc.input(botId).output(ComputerStatusSchema),
+    recover: oc.input(botId).output(ComputerUpdateSchema),
     reset: oc.input(botId).output(ComputerStatusSchema),
-    update: oc.input(botId).output(ComputerStatusSchema),
+    update: oc.input(botId).output(ComputerUpdateSchema),
+    updates: oc.output(z.array(ComputerUpdateSchema)),
+    dismissUpdate: oc.input(z.object({ id: Id })).output(z.object({ ok: z.literal(true) })),
     takeover: oc.input(botId).output(z.object({ leaseId: Id, expiresAt: z.string() })),
     release: oc
       .input(

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -312,6 +312,9 @@ export const appContract = {
     reset: oc.input(botId).output(ComputerStatusSchema),
     update: oc.input(botId).output(ComputerUpdateSchema),
     updates: oc.output(z.array(ComputerUpdateSchema)),
+    releaseInterrupted: oc
+      .input(z.object({ id: Id, workersStopped: z.literal(true) }))
+      .output(z.object({ ok: z.literal(true) })),
     dismissUpdate: oc.input(z.object({ id: Id })).output(z.object({ ok: z.literal(true) })),
     takeover: oc.input(botId).output(z.object({ leaseId: Id, expiresAt: z.string() })),
     release: oc

--- a/packages/core/src/computer-updates.test.ts
+++ b/packages/core/src/computer-updates.test.ts
@@ -1,0 +1,61 @@
+import type { ComputerUpdate } from "@rakazo/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createComputerUpdates } from "./computer-updates.js";
+
+const update: ComputerUpdate = {
+  id: "update-1",
+  botId: "bot-1",
+  name: "Writer",
+  mode: "team",
+  action: "update",
+  status: "running",
+  stage: "saving",
+};
+afterEach(() => vi.useRealTimers());
+describe("computer update presentation", () => {
+  it("keeps a newly started update when an older poll returns, and closing does not stop polling", async () => {
+    vi.useFakeTimers();
+    let resolve!: (rows: ComputerUpdate[]) => void;
+    const list = vi.fn(
+      () =>
+        new Promise<ComputerUpdate[]>((done) => {
+          resolve = done;
+        }),
+    );
+    const store = createComputerUpdates({
+      list,
+      start: async () => update,
+      dismiss: async () => {},
+    });
+    const stop = store.watch();
+    await store.start("bot-1");
+    resolve([]);
+    await Promise.resolve();
+    expect(store.getSnapshot()).toEqual({ updates: [update], openId: update.id });
+    store.open(null);
+    await vi.advanceTimersByTimeAsync(1500);
+    resolve([{ ...update, stage: "restoring" }]);
+    await Promise.resolve();
+    expect(store.getSnapshot()).toEqual({
+      updates: [{ ...update, stage: "restoring" }],
+      openId: null,
+    });
+    stop();
+  });
+  it("restores background progress on a new mount and ignores responses after disposal", async () => {
+    vi.useFakeTimers();
+    const store = createComputerUpdates({
+      list: async () => [update],
+      start: async () => update,
+      dismiss: async () => {},
+    });
+    let stop = store.watch();
+    await Promise.resolve();
+    expect(store.getSnapshot().updates).toEqual([update]);
+    stop();
+    stop = store.watch();
+    stop();
+    await Promise.resolve();
+    expect(store.getSnapshot().updates).toEqual([]);
+  });
+});

--- a/packages/core/src/computer-updates.test.ts
+++ b/packages/core/src/computer-updates.test.ts
@@ -26,6 +26,7 @@ describe("computer update presentation", () => {
       list,
       start: async () => update,
       dismiss: async () => {},
+      releaseInterrupted: async () => {},
     });
     const stop = store.watch();
     await store.start("bot-1");
@@ -48,6 +49,7 @@ describe("computer update presentation", () => {
       list: async () => [update],
       start: async () => update,
       dismiss: async () => {},
+      releaseInterrupted: async () => {},
     });
     let stop = store.watch();
     await Promise.resolve();

--- a/packages/core/src/computer-updates.ts
+++ b/packages/core/src/computer-updates.ts
@@ -1,0 +1,91 @@
+import { COMPUTER_UPDATE_STAGES, type ComputerUpdate } from "@rakazo/contracts";
+
+/** Shared polling and local presentation state; the server owns operation lifetime. */
+export function createComputerUpdates(client: {
+  list: () => Promise<ComputerUpdate[]>;
+  start: (botId: string, action: "update" | "recover") => Promise<ComputerUpdate>;
+  dismiss: (id: string) => Promise<unknown>;
+}) {
+  let state: { updates: ComputerUpdate[]; openId: string | null } = { updates: [], openId: null };
+  const listeners = new Set<() => void>();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let generation = 0;
+  let revision = 0;
+  const emit = () => {
+    for (const listener of listeners) listener();
+  };
+  const poll = async (epoch: number) => {
+    const stamp = revision;
+    try {
+      const updates = await client.list();
+      if (epoch !== generation || stamp !== revision) return;
+      if (JSON.stringify(state.updates) === JSON.stringify(updates)) return;
+      state = {
+        updates,
+        openId: updates.some((item) => item.id === state.openId) ? state.openId : null,
+      };
+      emit();
+    } catch {
+      /* Keep the last known operation through transient connection failures. */
+    } finally {
+      if (epoch === generation) {
+        clearTimeout(timer);
+        timer = setTimeout(() => void poll(epoch), state.updates.length ? 1500 : 15000);
+      }
+    }
+  };
+  return {
+    getSnapshot: () => state,
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    watch() {
+      const epoch = ++generation;
+      void poll(epoch);
+      return () => {
+        generation++;
+        clearTimeout(timer);
+        state = { updates: [], openId: null };
+      };
+    },
+    open(id: string | null) {
+      state = { ...state, openId: id };
+      emit();
+    },
+    async start(botId: string, action: "update" | "recover" = "update") {
+      const epoch = generation;
+      const update = await client.start(botId, action);
+      if (epoch !== generation) return;
+      revision++;
+      state = {
+        updates: [update, ...state.updates.filter((item) => item.id !== update.id)],
+        openId: update.id,
+      };
+      emit();
+      clearTimeout(timer);
+      timer = setTimeout(() => void poll(epoch), 1500);
+    },
+    async dismiss(id: string) {
+      const epoch = generation;
+      await client.dismiss(id);
+      if (epoch !== generation) return;
+      revision++;
+      state = {
+        updates: state.updates.filter((item) => item.id !== id),
+        openId: state.openId === id ? null : state.openId,
+      };
+      emit();
+    },
+  };
+}
+
+export function computerUpdateStages(
+  action: ComputerUpdate["action"],
+): readonly ComputerUpdate["stage"][] {
+  return action === "recover"
+    ? COMPUTER_UPDATE_STAGES.filter((stage) => stage !== "saving")
+    : COMPUTER_UPDATE_STAGES;
+}

--- a/packages/core/src/computer-updates.ts
+++ b/packages/core/src/computer-updates.ts
@@ -5,6 +5,7 @@ export function createComputerUpdates(client: {
   list: () => Promise<ComputerUpdate[]>;
   start: (botId: string, action: "update" | "recover") => Promise<ComputerUpdate>;
   dismiss: (id: string) => Promise<unknown>;
+  releaseInterrupted: (id: string) => Promise<unknown>;
 }) {
   let state: { updates: ComputerUpdate[]; openId: string | null } = { updates: [], openId: null };
   const listeners = new Set<() => void>();
@@ -67,6 +68,13 @@ export function createComputerUpdates(client: {
       emit();
       clearTimeout(timer);
       timer = setTimeout(() => void poll(epoch), 1500);
+    },
+    async releaseInterrupted(id: string) {
+      const epoch = generation;
+      await client.releaseInterrupted(id);
+      if (epoch !== generation) return;
+      revision++;
+      await poll(epoch);
     },
     async dismiss(id: string) {
       const epoch = generation;

--- a/packages/core/src/computer-updates.ts
+++ b/packages/core/src/computer-updates.ts
@@ -89,3 +89,7 @@ export function computerUpdateStages(
     ? COMPUTER_UPDATE_STAGES.filter((stage) => stage !== "saving")
     : COMPUTER_UPDATE_STAGES;
 }
+
+export function computerUpdateNeedsAttention(update: ComputerUpdate): boolean {
+  return update.status === "failed" || update.status === "interrupted";
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from "./compose-update.js";
 export * from "./composer-mention-picker.js";
 export * from "./composer-mentions.js";
 export * from "./composer-slash.js";
+export * from "./computer-updates.js";
 export * from "./cron.js";
 export * from "./events.js";
 export * from "./featured-connectors.js";

--- a/packages/db/prisma/migrations/20260908010000_computer_updates/migration.sql
+++ b/packages/db/prisma/migrations/20260908010000_computer_updates/migration.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "computers" ADD COLUMN "maintenanceId" TEXT;
+CREATE TABLE "computer_updates" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "computerId" TEXT NOT NULL REFERENCES "computers"("id") ON DELETE CASCADE,
+  "botId" TEXT NOT NULL,
+  "action" TEXT NOT NULL DEFAULT 'update',
+  "status" TEXT NOT NULL DEFAULT 'queued',
+  "stage" TEXT NOT NULL DEFAULT 'preparing',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL
+);
+CREATE INDEX "computer_updates_computerId_createdAt_idx" ON "computer_updates"("computerId", "createdAt");
+CREATE INDEX "computer_updates_status_updatedAt_idx" ON "computer_updates"("status", "updatedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -865,6 +865,22 @@ model BrowserProfile {
   @@map("browser_profiles")
 }
 
+model ComputerUpdate {
+  action     String   @default("update")
+  id         String   @id @default(cuid())
+  computerId String
+  computer   Computer @relation(fields: [computerId], references: [id], onDelete: Cascade)
+  botId      String
+  status     String   @default("queued")
+  stage      String   @default("preparing")
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@index([computerId, createdAt])
+  @@index([status, updatedAt])
+  @@map("computer_updates")
+}
+
 model Computer {
   id                      String                   @id @default(cuid())
   spaceId                 String
@@ -892,6 +908,8 @@ model Computer {
   updatedAt               DateTime                 @updatedAt
   bots                    Bot[]
   executionLeases         ComputerExecutionLease[]
+  maintenanceId           String?
+  updates                 ComputerUpdate[]
 
   @@index([spaceId, scope])
   @@map("computers")

--- a/packages/testkit/src/computer-use.e2e.test.ts
+++ b/packages/testkit/src/computer-use.e2e.test.ts
@@ -178,7 +178,17 @@ describeLive("real model and sandbox computer journey", () => {
     await handles.sandbox.destroy(computer, testContext(bot.id));
     // Simulate loss outside the app: the stored state still says running, so use
     // recovery to replace the missing sandbox and restore its checkpoint.
-    await rpc(handles.app, cookie, "computer/recover", { botId: bot.id });
+    const recovery = await rpc<{ id: string }>(handles.app, cookie, "computer/recover", {
+      botId: bot.id,
+    });
+    await expect
+      .poll(
+        async () =>
+          (await handles.prisma.computerUpdate.findUniqueOrThrow({ where: { id: recovery.id } }))
+            .status,
+        { timeout: 120_000 },
+      )
+      .toBe("completed");
     const replacementBot = await handles.prisma.bot.findUniqueOrThrow({
       where: { id: bot.id },
       include: { computer: true },

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -202,6 +202,12 @@ describeJourneys("required product journeys", () => {
         body: JSON.stringify({ json: { botId: bot.id } }),
       });
       expect(stopped.status).toBe(409);
+      const switched = await app.request("/rpc/bots/setComputer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: cookie },
+        body: JSON.stringify({ json: { botId: bot.id, mode: "dedicated" } }),
+      });
+      expect(switched.status).toBe(409);
       release();
       await waitForDatabase(
         async () =>

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -8,15 +8,16 @@ import {
   FakeSandboxProvider,
   handoffToGroupBot,
   ManagedSandboxEmulator,
+  toComputerRef,
 } from "@rakazo/adapters";
-import { ONCE_ROUTINE_CRON } from "@rakazo/core";
+import { ACTIVE_RUN_STATUSES, ONCE_ROUTINE_CRON } from "@rakazo/core";
 import {
   appendEvent,
   createThreadEvents,
   createThreadMessage,
   RunHistoryWriteError,
 } from "@rakazo/db";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { sessionCookieHeader } from "./index.js";
 
 type App = { request: (input: string, init?: RequestInit) => Promise<Response> };
@@ -134,6 +135,97 @@ describeJourneys("required product journeys", () => {
 
   afterAll(async () => {
     await stop?.();
+  });
+
+  it("computer updates preserve the workspace and reserve the shared computer until completion", async () => {
+    const cookie = await signup(app, `maintenance-${stamp}@rakazo.test`, "Maintenance");
+    const outsider = await signup(app, `maintenance-other-${stamp}@rakazo.test`, "Other workspace");
+    const bot = await rpc<Bot>(app, cookie, "bots/create", {
+      name: "Writer",
+      title: "Writer",
+      description: "Writes files",
+      instructions: "Write files.",
+    });
+    await waitForDatabase(
+      async () =>
+        (await prisma.run.count({
+          where: { botId: bot.id, status: { in: [...ACTIVE_RUN_STATUSES] } },
+        })) === 0,
+    );
+    await rpc(app, cookie, "computer/boot", { botId: bot.id });
+    const original = await prisma.bot.findUniqueOrThrow({
+      where: { id: bot.id },
+      include: { computer: true },
+    });
+    const ctx = {
+      operationId: "fixture",
+      traceId: "fixture",
+      spaceId: original.spaceId,
+      userId: original.userId,
+      botId: bot.id,
+      signal: new AbortController().signal,
+    };
+    await sandbox.writeFile(
+      toComputerRef(original.computer!),
+      { path: "notes.txt", content: new TextEncoder().encode("durable work") },
+      ctx,
+    );
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const destroyed = vi.spyOn(sandbox, "destroy");
+    const exportWorkspace = sandbox.exportWorkspace.bind(sandbox);
+    const spy = vi
+      .spyOn(sandbox, "exportWorkspace")
+      .mockImplementation(async function* (ref, context) {
+        await gate;
+        yield* exportWorkspace(ref, context);
+      });
+    try {
+      const update = await rpc<{ id: string }>(app, cookie, "computer/update", { botId: bot.id });
+      await waitForDatabase(
+        async () =>
+          (await prisma.computerUpdate.findUniqueOrThrow({ where: { id: update.id } })).stage ===
+          "saving",
+      );
+      expect(await rpc(app, outsider, "computer/updates")).toEqual([]);
+      const duplicate = await app.request("/rpc/computer/update", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: cookie },
+        body: JSON.stringify({ json: { botId: bot.id } }),
+      });
+      expect(duplicate.status).toBe(409);
+      const stopped = await app.request("/rpc/computer/stop", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: cookie },
+        body: JSON.stringify({ json: { botId: bot.id } }),
+      });
+      expect(stopped.status).toBe(409);
+      release();
+      await waitForDatabase(
+        async () =>
+          (await prisma.computerUpdate.findUniqueOrThrow({ where: { id: update.id } })).status ===
+          "completed",
+      );
+      const replacement = await prisma.computer.findUniqueOrThrow({
+        where: { id: original.computerId! },
+      });
+      expect(replacement.maintenanceId).toBeNull();
+      expect(destroyed).toHaveBeenCalledWith(
+        expect.objectContaining({ providerRef: original.computer!.providerRef }),
+        expect.anything(),
+      );
+      expect(
+        new TextDecoder().decode(
+          await sandbox.readFile(toComputerRef(replacement), "notes.txt", ctx),
+        ),
+      ).toBe("durable work");
+    } finally {
+      release();
+      spy.mockRestore();
+      destroyed.mockRestore();
+    }
   });
 
   it("1+2: users are isolated and workspace bots share the Team Computer", async () => {


### PR DESCRIPTION
Computer updates previously kept a request open with only an “Updating…” label. Users could not follow replacement progress or return to it after leaving the screen, and failures offered no direct recovery flow.

This adds a stage dialog and compact background pill on web/Electron, a native mobile sheet, and a failure dialog with recovery. Update and recovery run through durable background jobs with saved progress, shared-computer reservations, heartbeat reconciliation, and protection against destructive job replay. Update still rebuilds using the configured provider/image; `canUpdate` describes support for that action. Provider switching and newer-image detection are outside this change. An interrupted worker keeps its reservation until provider calls settle; permanent worker loss has a server-owner-only release action that requires an explicit confirmation that workers and provider operations have stopped.

Validation: the full offline unit suite passed, as did project typecheck, lint, and the PostgreSQL journeys. The new browser test passed and captures update progress, background progress, failure, and recovery; it also verifies restoration after reload. The database journey verifies workspace preservation and rejection of concurrent update/stop requests. Local verification did not run the Electron E2E suite; CI runs it. The mobile sheet is native-only and cannot be captured by web CI.

User-facing copy is shown only while maintenance is relevant: “Updating Team Computer”, “Updating {name}’s Computer”, “Recovering Team Computer”, “Recovering {name}’s Computer”, “Getting ready”, “Saving your workspace”, “Recreating the computer”, “Restoring your workspace”, “Reconnecting”, “Continue in Background”, “Update failed”, “Recovery failed”, “Dismiss”, “Recover computer”, “Could not complete action”, “Recovery is unavailable until the previous operation has stopped.”, and “Recovery restores the last saved workspace. Unsaved work may be lost.” The accessible list name is “Update progress”. Titles identify the affected computer, stages explain the current operation, controls let users leave or recover, and the failure-only warning explains the possible loss of unsaved work before recovery. Removing these labels would make progress and recovery ambiguous; they are already disclosed only during the operation or its failure. No estimated percentage is shown. Only the server owner sees “Release computer” for an interrupted operation. “Release interrupted computer?”, “Stop all workers and confirm that provider operations have stopped before releasing this computer.”, and “Workers and operations are stopped” make this attended recovery requirement explicit; removing that confirmation would permit unsafe overlap. Tests cover owner authorization, required confirmation, and cancellation.

[CI update screenshot](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34162162983-1/screenshots/images/123-computer-update-progress.png) · [CI failure screenshot](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34162162983-1/screenshots/images/121-computer-update-failed.png) · [Full CI screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/791/index.html).

Operational limit: attended release relies on the trusted server owner actually stopping the old workers and provider operations externally. The API cannot independently prove that shutdown; it enforces authorization and reservation state. Automatic reconciliation never uses this escape hatch.
