### PR TITLE
Fix desktop server switching at the welcome screen

### DIFF
--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -285,53 +285,68 @@ test("a session-pending shell skeleton is not accepted as a ready app", async ()
   }
 });
 
-test("a post-session ready app mount is accepted", async () => {
-  const readyHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title>
-<script>performance.mark("rk:renderer:session-committed");performance.mark("rk:renderer:shell-ready");</script>
+for (const { name, surface } of [
+  {
+    name: "bootstrapped workspace",
+    surface: '<div data-testid="shell-root" data-ready="true">Workspace</div>',
+  },
+  {
+    name: "logged-out welcome",
+    surface: '<div data-rakazo-surface="welcome"><button>Sign up</button></div>',
+  },
+  {
+    name: "translated logged-out welcome",
+    surface: '<div data-rakazo-surface="welcome"><button>Créer un compte</button></div>',
+  },
+]) {
+  test(`a post-session ${name} mount is accepted`, async () => {
+    const readyHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title>
 </head>
-<body><div id="root"><div data-rakazo-app-state="ready"><div data-testid="shell-root" data-ready="true">Workspace</div></div></div></body></html>`;
-  const ready = createServer((request, response) => {
-    if (request.url === "/rpc/health" && request.method === "POST") {
-      response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
-      response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
-      return;
-    }
-    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
-    response.end(readyHtml);
-  });
-  await new Promise<void>((resolve) => ready.listen(0, "127.0.0.1", resolve));
-  const address = ready.address();
-  if (address === null || typeof address === "string") throw new Error("ready server has no port");
-
-  try {
-    app = await launch();
-    const setup = await app.firstWindow();
-    await setup.getByRole("radio", { name: /Existing instance/ }).check();
-    await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
-    const appWindow = await Promise.all([
-      app.waitForEvent("window"),
-      setup.getByRole("button", { name: "Continue" }).click(),
-    ]).then(([window]) => window);
-
-    await expect(appWindow.getByTestId("shell-root")).toBeVisible();
-    await expect
-      .poll(async () => {
-        try {
-          return JSON.parse(await readFile(path.join(userData, "setup.json"), "utf8"));
-        } catch {
-          return null;
-        }
-      })
-      .toEqual({
-        mode: "existing",
-        serverUrl: `http://127.0.0.1:${address.port}`,
-      });
-  } finally {
-    await new Promise<void>((resolve, reject) => {
-      ready.close((error) => (error ? reject(error) : resolve()));
+<body><div id="root"><div data-rakazo-app-state="ready">${surface}</div></div></body></html>`;
+    const ready = createServer((request, response) => {
+      if (request.url === "/rpc/health" && request.method === "POST") {
+        response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+        response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
+        return;
+      }
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      response.end(readyHtml);
     });
-  }
-});
+    await new Promise<void>((resolve) => ready.listen(0, "127.0.0.1", resolve));
+    const address = ready.address();
+    if (address === null || typeof address === "string")
+      throw new Error("ready server has no port");
+
+    try {
+      app = await launch();
+      const setup = await app.firstWindow();
+      await setup.getByRole("radio", { name: /Existing instance/ }).check();
+      await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
+      const appWindow = await Promise.all([
+        app.waitForEvent("window"),
+        setup.getByRole("button", { name: "Continue" }).click(),
+      ]).then(([window]) => window);
+
+      await expect(appWindow.locator('[data-rakazo-app-state="ready"]')).toBeVisible();
+      await expect
+        .poll(async () => {
+          try {
+            return JSON.parse(await readFile(path.join(userData, "setup.json"), "utf8"));
+          } catch {
+            return null;
+          }
+        })
+        .toEqual({
+          mode: "existing",
+          serverUrl: `http://127.0.0.1:${address.port}`,
+        });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        ready.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+}
 
 test("a shell mount before workspace bootstrap is not accepted", async () => {
   const preBootstrapHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title></head>

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -456,9 +456,10 @@ async function waitForMountedAppDocument(contents: Electron.WebContents) {
           performance.getEntriesByName("rk:renderer:shell-ready").length > 0,
       );
       const authOrWelcomeSurface = Boolean(
-        document.querySelector(
-          'form input[type="email"], form input[name="email"], form input#email',
-        ) ||
+        document.querySelector('[data-rakazo-surface="welcome"]') ||
+          document.querySelector(
+            'form input[type="email"], form input[name="email"], form input#email',
+          ) ||
           Array.from(document.querySelectorAll("button")).some((button) =>
             /sign\\s*in/i.test((button.textContent || "").trim()),
           ) ||

--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -57,6 +57,7 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   await page.getByRole("button", { name: "Log out" }).click();
   await expect(page.getByRole("heading", { name: "Sign in to Rakazo" })).toBeVisible();
   await page.goto("/");
+  await expect(page.locator('[data-rakazo-surface="welcome"]')).toBeVisible();
   await expect(page.getByText(/Your team of always-on agents/)).toBeVisible();
   await page.getByRole("button", { name: /Sign up/ }).click();
   await expect(page).toHaveURL(/\/sign-up$/);

--- a/apps/web/src/pages/Welcome.tsx
+++ b/apps/web/src/pages/Welcome.tsx
@@ -5,7 +5,7 @@ import { WindowChrome } from "./WindowChrome";
 export function WelcomePage() {
   const navigate = useNavigate();
   return (
-    <div className="flex min-h-full flex-col bg-background">
+    <div className="flex min-h-full flex-col bg-background" data-rakazo-surface="welcome">
       <div className="app-drag flex gap-2 px-5 py-[18px]">
         <WindowChrome />
       </div>


### PR DESCRIPTION
A healthy server could fail to open in desktop setup with “The server page did not become ready.” The readiness check did not recognize the logged-out welcome screen, whose action is “Sign up.” This affects connecting to a server, including switching to This computer.

Add an explicit welcome-surface marker to the shared web renderer and accept it only after session readiness. Loading screens and unbootstrapped workspaces still fail the readiness check. No visible UI or copy changes.

Validation: all 295 desktop unit tests and desktop TypeScript checks passed, along with formatting checks. Added desktop E2E coverage for English and translated welcome screens, and a web E2E assertion for the marker. Electron E2E runs in CI to avoid opening native windows during local verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved app startup handling so logged-out welcome screens are recognized as ready and usable.
  - Fixed readiness detection across both English and French welcome experiences.
  - Improved logout and sign-in flows so the expected welcome screen appears reliably before authentication state is restored.

- **Tests**
  - Expanded coverage for bootstrapped workspace and localized welcome-screen startup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->