### PR TITLE
Add local server settings to the desktop app menu

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -83,6 +83,7 @@ import { MarkdownMemoryStore } from "@rakazo/memory";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { type AppEnv, loadEnv } from "./env.js";
+import { mountLocalSettings } from "./local-settings.js";
 import {
   createMessagingInboundHandler,
   teamChatSenderCanWakeMessageRoutines,
@@ -472,6 +473,7 @@ export async function createApp(
     }
     return auth.handler(c.req.raw);
   });
+  mountLocalSettings(app, { token: env.desktopStackToken, prisma, rpc });
   app.use("/rpc/*", async (c, next) => {
     const session = await auth.api.getSession({ headers: sessionHeaders(c.req.raw) });
     const requestedSpaceId = c.req.header("x-rakazo-space-id");

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -14,6 +14,7 @@ export { resolveCloudAgentProvider, resolveSandboxProvider } from "@rakazo/adapt
 
 export interface AppEnv {
   nodeEnv: string;
+  desktopStackToken?: string;
   databaseUrl: string;
   realtimeDatabaseUrl: string;
   authSecret: string;
@@ -102,6 +103,7 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     nodeEnv: source.NODE_ENV ?? "",
     databaseUrl: required(source, "DATABASE_URL"),
     realtimeDatabaseUrl: source.REALTIME_DATABASE_URL ?? required(source, "DATABASE_URL"),
+    desktopStackToken: optional(source.RAKAZO_DESKTOP_STACK_TOKEN),
     authSecret,
     authUrl: source.BETTER_AUTH_URL ?? source.WEB_ORIGIN ?? "http://127.0.0.1:5173",
     webOrigin: source.WEB_ORIGIN ?? "http://127.0.0.1:5173",

--- a/apps/api/src/local-settings.test.ts
+++ b/apps/api/src/local-settings.test.ts
@@ -1,0 +1,101 @@
+import { LOCAL_SETTINGS_RPC, LOCAL_SETTINGS_TOKEN_HEADER } from "@rakazo/contracts";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { mountLocalSettings, validLocalSettingsToken } from "./local-settings.js";
+
+const token = "ab".repeat(32);
+function fixture(
+  configuredToken: string | undefined = token,
+  ownerUserId: string | null = "owner",
+) {
+  const findUnique = vi.fn(async () => ({ ownerUserId }));
+  const findFirst = vi.fn(async () => ({
+    userId: "owner",
+    spaceId: "owner-default",
+    member: { user: { email: "owner@example.test" } },
+  }));
+  const handle = vi.fn(async () => ({
+    matched: true,
+    response: new Response('{"json":{"ok":true}}'),
+  }));
+  const app = new Hono();
+  mountLocalSettings(app, {
+    token: configuredToken,
+    prisma: { deploymentSettings: { findUnique }, spaceMember: { findFirst } } as never,
+    rpc: { handle } as never,
+  });
+  function request(procedure: string, supplied: string | null = token, method = "POST") {
+    return app.request(`${LOCAL_SETTINGS_RPC}/${procedure}`, {
+      method,
+      headers: {
+        ...(supplied === null ? {} : { [LOCAL_SETTINGS_TOKEN_HEADER]: supplied }),
+        "x-rakazo-space-id": "someone-elses-space",
+        cookie: "session=fake",
+      },
+    });
+  }
+  return { request, findUnique, findFirst, handle };
+}
+
+describe("local settings authority", () => {
+  it("requires a configured, exact capability, not a cookie", async () => {
+    const f = fixture();
+    for (const supplied of [null, "", "cd".repeat(32), `${token}x`]) {
+      expect((await f.request("models/list", supplied)).status).toBe(401);
+    }
+    expect(f.findUnique).not.toHaveBeenCalled();
+    expect(validLocalSettingsToken(undefined, token)).toBe(false);
+    expect(validLocalSettingsToken("", "")).toBe(false);
+    expect(validLocalSettingsToken(token, token)).toBe(true);
+  });
+
+  it("denies general app access and noncanonical paths even with the capability", async () => {
+    const f = fixture();
+    for (const procedure of [
+      "bots/list",
+      "spaces/list",
+      "models/list/",
+      "models%2Flist",
+      "integrationSetup/save/extra",
+    ]) {
+      expect((await f.request(procedure)).status).toBe(403);
+    }
+    expect((await f.request("models/list", token, "GET")).status).toBe(403);
+    expect(f.handle).not.toHaveBeenCalled();
+    expect(f.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("uses the deployment owner's default space and ignores client space selection", async () => {
+    const f = fixture();
+    for (const procedure of [
+      "models/connect",
+      "models/setDefault",
+      "integrationSetup/get",
+      "integrationSetup/save",
+    ]) {
+      expect((await f.request(procedure)).status).toBe(200);
+    }
+    expect(f.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: "owner" } }),
+    );
+    expect(f.handle).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        prefix: LOCAL_SETTINGS_RPC,
+        context: expect.objectContaining({
+          actor: expect.objectContaining({
+            userId: "owner",
+            spaceId: "owner-default",
+            isDeploymentOwner: true,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("requires an existing owner account", async () => {
+    const f = fixture(token, null);
+    expect((await f.request("models/list")).status).toBe(409);
+    expect(f.handle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/local-settings.ts
+++ b/apps/api/src/local-settings.ts
@@ -1,0 +1,59 @@
+import { timingSafeEqual } from "node:crypto";
+import type { RPCHandler } from "@orpc/server/fetch";
+import type { Actor } from "@rakazo/contracts";
+import {
+  isLocalSettingsProcedure,
+  LOCAL_SETTINGS_RPC,
+  LOCAL_SETTINGS_TOKEN_HEADER,
+} from "@rakazo/contracts";
+import { type PrismaClient, requireMembership } from "@rakazo/db";
+import type { Hono } from "hono";
+
+export function validLocalSettingsToken(
+  expected: string | undefined,
+  supplied: string | undefined,
+): boolean {
+  return Boolean(
+    expected &&
+      supplied &&
+      /^[a-f0-9]{64}$/.test(expected) &&
+      /^[a-f0-9]{64}$/.test(supplied) &&
+      timingSafeEqual(Buffer.from(expected), Buffer.from(supplied)),
+  );
+}
+
+/** Separate, allowlisted RPC surface; ordinary session authentication is unchanged. */
+export function mountLocalSettings(
+  app: Hono,
+  deps: {
+    token?: string;
+    prisma: PrismaClient;
+    rpc: RPCHandler<{ actor: Actor | null; signal?: AbortSignal }>;
+  },
+) {
+  app.use(`${LOCAL_SETTINGS_RPC}/*`, async (c) => {
+    c.header("cache-control", "no-store");
+    if (!validLocalSettingsToken(deps.token, c.req.header(LOCAL_SETTINGS_TOKEN_HEADER))) {
+      return c.json({ error: "Local settings are unavailable" }, 401);
+    }
+    if (c.req.method !== "POST" || !isLocalSettingsProcedure(new URL(c.req.url).pathname)) {
+      return c.json({ error: "Not available in local settings" }, 403);
+    }
+    const owner = await deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } });
+    const actor = owner?.ownerUserId
+      ? await requireMembership(deps.prisma, owner.ownerUserId).catch(() => null)
+      : null;
+    if (!actor?.isDeploymentOwner) {
+      return c.json(
+        { error: "Create the server owner account before configuring local settings" },
+        409,
+      );
+    }
+    const { matched, response } = await deps.rpc.handle(c.req.raw, {
+      prefix: LOCAL_SETTINGS_RPC,
+      context: { actor, signal: c.req.raw.signal },
+    });
+    if (!matched) return c.notFound();
+    return c.newResponse(response.body, response);
+  });
+}

--- a/apps/api/src/request-body-limit.ts
+++ b/apps/api/src/request-body-limit.ts
@@ -1,3 +1,4 @@
+import { LOCAL_SETTINGS_RPC } from "@rakazo/contracts";
 import type { Hono, MiddlewareHandler } from "hono";
 import { cancelBody } from "./http-body.js";
 
@@ -57,5 +58,6 @@ export function requestBodyLimit(maxSize: number): MiddlewareHandler {
 /** Install limits only on framework-parsed JSON surfaces with known payload contracts. */
 export function mountApiRequestBodyLimits(app: Hono): void {
   app.use("/api/auth/*", requestBodyLimit(MAX_AUTH_REQUEST_BYTES));
+  app.use(`${LOCAL_SETTINGS_RPC}/*`, requestBodyLimit(MAX_RPC_REQUEST_BYTES));
   app.use("/rpc/*", requestBodyLimit(MAX_RPC_REQUEST_BYTES));
 }

--- a/apps/desktop/e2e/local-stack.spec.ts
+++ b/apps/desktop/e2e/local-stack.spec.ts
@@ -40,6 +40,19 @@ test.beforeAll(async () => {
       response.end(JSON.stringify({ ok: true, imageTag: IMAGE_TAG }));
       return;
     }
+    if (request.url === "/api/desktop-settings/rpc/integrationSetup/get") {
+      const expected = await readFile(path.join(userData, "stack", ".desktop-stack-token"), "utf8");
+      if (
+        request.headers["x-rakazo-local-settings-token"] !== expected.trim() ||
+        request.headers.cookie
+      ) {
+        response.writeHead(401).end();
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ json: { canConfigure: true } }));
+      return;
+    }
     if (request.url === "/rpc/health" && request.method === "POST") {
       response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
       response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
@@ -455,4 +468,48 @@ test("repeated port conflicts stop with a retry action", async () => {
   await setup.screenshot({
     path: path.join(import.meta.dirname, "screenshots", "10-setup-ports-unavailable.png"),
   });
+});
+
+test("the native settings menu opens an isolated logged-out settings capability", async () => {
+  app = await launch("ok");
+  const setup = await app.firstWindow();
+  const nextWindow = app.waitForEvent("window");
+  await setup.getByRole("button", { name: "Continue", exact: true }).click();
+  const main = await nextWindow;
+  await expect(main.getByText(APP_MARKER)).toBeVisible();
+  await expect.poll(savedSetup).toEqual({ mode: "new", serverUrl });
+  const denied = await main.evaluate(async () => {
+    try {
+      await window.rakazoDesktop?.localSettings?.request(
+        "/api/desktop-settings/rpc/integrationSetup/get",
+        "{}",
+      );
+      return false;
+    } catch {
+      return true;
+    }
+  });
+  expect(denied).toBe(true);
+  const settingsOpened = app.waitForEvent("window");
+  await app.evaluate(({ Menu }) => {
+    const item = Menu.getApplicationMenu()?.getMenuItemById("local-server-settings");
+    if (!item) throw new Error("Missing settings menu");
+    item.click();
+  });
+  const settings = await settingsOpened;
+  await expect(settings).toHaveURL(`${serverUrl}/desktop-settings`);
+  const result = await settings.evaluate(() =>
+    window.rakazoDesktop?.localSettings?.request(
+      "/api/desktop-settings/rpc/integrationSetup/get",
+      "{}",
+    ),
+  );
+  expect(result?.status).toBe(200);
+  expect(JSON.parse(result!.body)).toEqual({ json: { canConfigure: true } });
+  await app.evaluate(({ Menu }) =>
+    Menu.getApplicationMenu()?.getMenuItemById("local-server-settings")?.click(),
+  );
+  expect(app.windows()).toHaveLength(2);
+  await settings.close();
+  await expect(main.getByText(APP_MARKER)).toBeVisible();
 });

--- a/apps/desktop/e2e/smoke.spec.ts
+++ b/apps/desktop/e2e/smoke.spec.ts
@@ -41,7 +41,7 @@ test("launches with a narrow preload bridge and an isolated renderer", async () 
       };
     });
 
-    expect(renderer.bridgeKeys).toEqual(["oauth", "platform", "update", "window"]);
+    expect(renderer.bridgeKeys).toEqual(["localSettings", "oauth", "platform", "update", "window"]);
     expect(renderer.windowKeys).toEqual(["close", "minimize", "state", "toggleMaximize"]);
     expect(renderer.updateKeys).toEqual(["check", "download", "install", "state"]);
     expect(renderer.platform).toBe(process.platform);

--- a/apps/desktop/src/local-settings.test.ts
+++ b/apps/desktop/src/local-settings.test.ts
@@ -1,0 +1,45 @@
+import { LOCAL_SETTINGS_RPC, LOCAL_SETTINGS_TOKEN_HEADER } from "@rakazo/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { requestLocalSettings } from "./local-settings.js";
+
+const target = { origin: "http://127.0.0.1:5173", token: "ab".repeat(32) };
+const pathname = `${LOCAL_SETTINGS_RPC}/models/connect`;
+describe("local settings transport", () => {
+  it("sends only the scoped capability, without cookies or following redirects", async () => {
+    const fetcher = vi.fn(async () => new Response('{"json":{"ok":true}}'));
+    expect(await requestLocalSettings(target, pathname, '{"json":{}}', fetcher)).toEqual({
+      status: 200,
+      body: '{"json":{"ok":true}}',
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      target.origin + pathname,
+      expect.objectContaining({
+        method: "POST",
+        credentials: "omit",
+        redirect: "error",
+        headers: {
+          "content-type": "application/json",
+          [LOCAL_SETTINGS_TOKEN_HEADER]: target.token,
+        },
+      }),
+    );
+  });
+  it("rejects remote targets, arbitrary procedures, and oversized payloads before sending", async () => {
+    const fetcher = vi.fn();
+    for (const path of [
+      "/rpc/bots/list",
+      `${LOCAL_SETTINGS_RPC}/bots/list`,
+      `${pathname}?redirect=1`,
+      "https://example.test",
+    ]) {
+      await expect(requestLocalSettings(target, path, "{}", fetcher)).rejects.toThrow();
+    }
+    await expect(
+      requestLocalSettings({ ...target, origin: "https://example.test" }, pathname, "{}", fetcher),
+    ).rejects.toThrow();
+    await expect(
+      requestLocalSettings(target, pathname, "x".repeat(1024 * 1024 + 1), fetcher),
+    ).rejects.toThrow();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/local-settings.test.ts
+++ b/apps/desktop/src/local-settings.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { LOCAL_SETTINGS_RPC, LOCAL_SETTINGS_TOKEN_HEADER } from "@rakazo/contracts";
 import { describe, expect, it, vi } from "vitest";
 import { requestLocalSettings } from "./local-settings.js";
@@ -5,6 +6,20 @@ import { requestLocalSettings } from "./local-settings.js";
 const target = { origin: "http://127.0.0.1:5173", token: "ab".repeat(32) };
 const pathname = `${LOCAL_SETTINGS_RPC}/models/connect`;
 describe("local settings transport", () => {
+  it("loads shared settings contracts in native Node without a TypeScript loader", () => {
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        [
+          "--no-experimental-strip-types",
+          "--input-type=module",
+          "-e",
+          'import { LOCAL_SETTINGS_PAGE, isLocalSettingsProcedure } from "@rakazo/contracts/local-settings"; if (LOCAL_SETTINGS_PAGE !== "/desktop-settings" || !isLocalSettingsProcedure("/api/desktop-settings/rpc/me")) throw new Error("Invalid runtime contract");',
+        ],
+        { cwd: import.meta.dirname, env: { ...process.env, NODE_OPTIONS: "" }, stdio: "pipe" },
+      ),
+    ).not.toThrow();
+  });
   it("sends only the scoped capability, without cookies or following redirects", async () => {
     const fetcher = vi.fn(async () => new Response('{"json":{"ok":true}}'));
     expect(await requestLocalSettings(target, pathname, '{"json":{}}', fetcher)).toEqual({

--- a/apps/desktop/src/local-settings.ts
+++ b/apps/desktop/src/local-settings.ts
@@ -1,4 +1,7 @@
-import { isLocalSettingsProcedure, LOCAL_SETTINGS_TOKEN_HEADER } from "@rakazo/contracts";
+import {
+  isLocalSettingsProcedure,
+  LOCAL_SETTINGS_TOKEN_HEADER,
+} from "@rakazo/contracts/local-settings";
 import { isLoopbackHost } from "./setup-config.js";
 
 /** Only a fixed local target and known settings procedures can receive host authority. */

--- a/apps/desktop/src/local-settings.ts
+++ b/apps/desktop/src/local-settings.ts
@@ -1,0 +1,32 @@
+import { isLocalSettingsProcedure, LOCAL_SETTINGS_TOKEN_HEADER } from "@rakazo/contracts";
+import { isLoopbackHost } from "./setup-config.js";
+
+/** Only a fixed local target and known settings procedures can receive host authority. */
+export async function requestLocalSettings(
+  target: { origin: string; token: string },
+  pathname: unknown,
+  body: unknown,
+  request: typeof fetch,
+): Promise<{ status: number; body: string }> {
+  const url = new URL(target.origin);
+  if (
+    url.origin !== target.origin ||
+    !["http:", "https:"].includes(url.protocol) ||
+    !isLoopbackHost(url.hostname) ||
+    typeof pathname !== "string" ||
+    !isLocalSettingsProcedure(pathname) ||
+    typeof body !== "string" ||
+    body.length > 1024 * 1024
+  ) {
+    throw new Error("Invalid local settings request");
+  }
+  const response = await request(`${target.origin}${pathname}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", [LOCAL_SETTINGS_TOKEN_HEADER]: target.token },
+    body,
+    credentials: "omit",
+    redirect: "error",
+    signal: AbortSignal.timeout(120_000),
+  });
+  return { status: response.status, body: await response.text() };
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { DesktopReachability, DesktopSetup } from "@rakazo/contracts";
-import { LOCAL_SETTINGS_PAGE } from "@rakazo/contracts";
+import { LOCAL_SETTINGS_PAGE } from "@rakazo/contracts/local-settings";
 import {
   app,
   BrowserWindow,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3,7 +3,18 @@ import { existsSync } from "node:fs";
 import { readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { DesktopReachability, DesktopSetup } from "@rakazo/contracts";
-import { app, BrowserWindow, ipcMain, Menu, net, type Session, session, shell } from "electron";
+import { LOCAL_SETTINGS_PAGE } from "@rakazo/contracts";
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  Menu,
+  net,
+  type Session,
+  session,
+  shell,
+} from "electron";
 import {
   DesktopUpdateController,
   type ElectronAutoUpdater,
@@ -11,8 +22,10 @@ import {
 } from "./auto-update.js";
 import { openBrowserAuth } from "./browser-auth.js";
 import { DOCKER_INSTALL_LINKS, isDesktopSetupLink, runDocker } from "./docker-cli.js";
+import { requestLocalSettings } from "./local-settings.js";
 import {
   LocalStackController,
+  readStackToken,
   readStackWebUrl,
   resolveImageTag,
   stackDir,
@@ -60,6 +73,10 @@ const DESKTOP_STACK_TOKEN_HEADER = "x-rakazo-desktop-stack-token";
 let mainWindow: BrowserWindow | null = null;
 const appWindowTargets = new WeakMap<BrowserWindow, string>();
 let setupWindow: BrowserWindow | null = null;
+let settingsWindow: BrowserWindow | null = null;
+let openingSettings = false;
+let settingsCleanup: Promise<void> = Promise.resolve();
+let settingsTarget: { origin: string; token: string } | null = null;
 const bundledRendererInstallations = new Set<string>();
 let currentSetup: DesktopSetup | null = null;
 let currentTargetUrl: string | null = null;
@@ -607,7 +624,89 @@ function restoreAppWindowAfterSetup() {
   mainWindow.focus();
 }
 
+async function showLocalSettings() {
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
+    settingsWindow.show();
+    settingsWindow.focus();
+    return;
+  }
+  if (openingSettings) return;
+  openingSettings = true;
+  try {
+    const url = localStack.webUrl();
+    const token = await readStackToken(stackDir(app.getPath("userData")));
+    if (!token || !(await localStack.matchesDesiredStack(url))) {
+      await dialog.showMessageBox({
+        message: "Start the local server before opening its settings.",
+        type: "info",
+      });
+      return;
+    }
+    await settingsCleanup;
+    const partition = "local-server-settings";
+    const targetSession = session.fromPartition(partition);
+    installSessionPermissions(targetSession, () => null);
+    await installBundledRenderer(url, targetSession, partition);
+    const win = new BrowserWindow({
+      ...browserWindowOptions(process.platform),
+      title: "Local Server Settings",
+      frame: true,
+      titleBarStyle: "default",
+      trafficLightPosition: undefined,
+      webPreferences: {
+        preload: path.join(import.meta.dirname, "preload.cjs"),
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
+        partition,
+      },
+    });
+    settingsWindow = win;
+    const origin = new URL(url).origin;
+    settingsTarget = { origin, token };
+    win.webContents.setWindowOpenHandler(({ url: externalUrl }) => {
+      const external = safeExternalUrl(externalUrl);
+      if (external) void shell.openExternal(external);
+      return { action: "deny" };
+    });
+    const preventNavigation = (event: Electron.Event, target: string) => {
+      if (target === `${origin}${LOCAL_SETTINGS_PAGE}`) return;
+      event.preventDefault();
+    };
+    win.webContents.on("will-navigate", preventNavigation);
+    win.webContents.on("will-redirect", preventNavigation);
+    win.once("closed", () => {
+      if (settingsWindow === win) {
+        settingsWindow = null;
+        settingsTarget = null;
+      }
+      const protocol = new URL(url).protocol;
+      if (bundledRendererInstallations.delete(`${partition}:${protocol}`)) {
+        targetSession.protocol.unhandle(protocol.slice(0, -1));
+      }
+      settingsCleanup = targetSession.clearStorageData().catch(() => undefined);
+    });
+    await win.loadURL(`${origin}${LOCAL_SETTINGS_PAGE}`);
+  } catch {
+    settingsWindow?.close();
+    await dialog.showMessageBox({
+      message: "Could not open local server settings. Try again.",
+      type: "error",
+    });
+  } finally {
+    openingSettings = false;
+  }
+}
+
 function installApplicationMenu() {
+  const localSettings: Electron.MenuItemConstructorOptions = {
+    id: "local-server-settings",
+    label: "Local Server Settings…",
+    accelerator: "CmdOrCtrl+,",
+    click: () => {
+      void showLocalSettings();
+    },
+  };
   const changeServer: Electron.MenuItemConstructorOptions = {
     id: "change-rakazo-server",
     label: "Change Rakazo Server…",
@@ -630,6 +729,7 @@ function installApplicationMenu() {
             submenu: [
               { role: "about" },
               { type: "separator" },
+              localSettings,
               changeServer,
               stopStack,
               { type: "separator" },
@@ -646,7 +746,13 @@ function installApplicationMenu() {
       : [
           {
             label: "File",
-            submenu: [changeServer, stopStack, { type: "separator" }, { role: "quit" }],
+            submenu: [
+              localSettings,
+              changeServer,
+              stopStack,
+              { type: "separator" },
+              { role: "quit" },
+            ],
           },
           { role: "editMenu" },
           { role: "windowMenu" },
@@ -951,7 +1057,8 @@ app.whenReady().then(async () => {
   app.on("before-quit", cancelBrowserAuth);
   ipcMain.handle("desktop.oauth.open", async (event, url: unknown) => {
     if (
-      !fromMainWindow(event) ||
+      (!fromMainWindow(event) &&
+        !(settingsWindow !== null && windowFrom(event) === settingsWindow)) ||
       event.senderFrame !== event.sender.mainFrame ||
       typeof url !== "string" ||
       url.length > 16_384
@@ -993,13 +1100,34 @@ app.whenReady().then(async () => {
   });
   ipcMain.handle("desktop.oauth.cancel", (event, url: unknown) => {
     if (
-      !fromMainWindow(event) ||
+      (!fromMainWindow(event) &&
+        !(settingsWindow !== null && windowFrom(event) === settingsWindow)) ||
       event.senderFrame !== event.sender.mainFrame ||
       typeof url !== "string"
     )
       return;
     browserAuthAttempts.get(url)?.abort();
   });
+  ipcMain.handle(
+    "desktop.localSettings.request",
+    async (event, pathname: unknown, body: unknown) => {
+      if (
+        !settingsWindow ||
+        windowFrom(event) !== settingsWindow ||
+        event.senderFrame !== event.sender.mainFrame ||
+        !settingsTarget ||
+        event.senderFrame.url !== `${settingsTarget.origin}${LOCAL_SETTINGS_PAGE}`
+      ) {
+        throw new Error("Local settings are not active");
+      }
+      return requestLocalSettings(settingsTarget, pathname, body, (input, init) =>
+        net.fetch(input instanceof URL ? input.href : input, {
+          ...init,
+          bypassCustomProtocolHandlers: true,
+        }),
+      );
+    },
+  );
   ipcMain.handle("desktop.platform", () => process.platform);
   ipcMain.handle("desktop.window.close", (event) => {
     windowFrom(event)?.close();

--- a/apps/desktop/src/preload.cjs
+++ b/apps/desktop/src/preload.cjs
@@ -2,6 +2,10 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("rakazoDesktop", {
   platform: process.platform,
+  localSettings: {
+    request: (pathname, body) =>
+      ipcRenderer.invoke("desktop.localSettings.request", pathname, body),
+  },
   window: {
     close: () => ipcRenderer.invoke("desktop.window.close"),
     minimize: () => ipcRenderer.invoke("desktop.window.minimize"),

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -24,14 +24,20 @@ function runPreload(file: string, ipc: { invoke?: unknown; on?: unknown; off?: u
 }
 
 describe("desktop preload bridge", () => {
-  it("exposes only the platform, the four window operations, the updater, and the OAuth bridge", async () => {
+  it("exposes the scoped desktop bridges", async () => {
     const { invoke, exposeInMainWorld } = runPreload("preload.cjs");
 
     expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
     const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoDesktop];
     expect(globalName).toBe("rakazoDesktop");
     expect(bridge.platform).toBe("linux");
-    expect(Object.keys(bridge).sort()).toEqual(["oauth", "platform", "update", "window"]);
+    expect(Object.keys(bridge).sort()).toEqual([
+      "localSettings",
+      "oauth",
+      "platform",
+      "update",
+      "window",
+    ]);
     expect(Object.keys(bridge.window).sort()).toEqual([
       "close",
       "minimize",
@@ -67,7 +73,13 @@ describe("desktop preload bridge", () => {
   it("keeps setup off the app bridge so a connected server cannot re-point the app", () => {
     const { exposeInMainWorld } = runPreload("preload.cjs");
     const [, bridge] = exposeInMainWorld.mock.calls[0] as [string, Record<string, unknown>];
-    expect(Object.keys(bridge).sort()).toEqual(["oauth", "platform", "update", "window"]);
+    expect(Object.keys(bridge).sort()).toEqual([
+      "localSettings",
+      "oauth",
+      "platform",
+      "update",
+      "window",
+    ]);
   });
 
   it("forwards captured codes without leaking the IPC event to the renderer", () => {

--- a/apps/web/e2e/local-settings.spec.ts
+++ b/apps/web/e2e/local-settings.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot } from "./helpers";
+
+test("local settings open and save integrations without an app session", async ({
+  page,
+}, testInfo) => {
+  await page.addInitScript(() => {
+    let connected = false;
+    window.rakazoDesktop = {
+      platform: "darwin",
+      localSettings: {
+        request: async (pathname: string, body: string) => {
+          const procedure = pathname.split("/rpc/")[1];
+          let json: unknown;
+          if (procedure === "integrationSetup/get") {
+            json = {
+              canConfigure: true,
+              needsSetup: !connected,
+              providers: [{ id: "composio", configured: connected }],
+              webUrl: "https://example.test/integrations/setup",
+            };
+          } else if (procedure === "integrationSetup/save") {
+            const input = JSON.parse(body).json;
+            if (input.provider !== "composio" || input.apiKey !== "fake-integration-key")
+              throw new Error("Unexpected input");
+            connected = true;
+            json = { ok: true };
+          } else if (procedure === "models/list") {
+            json = [
+              {
+                provider: "openai-compatible",
+                providerName: "OpenAI-compatible",
+                id: "custom",
+                label: "Custom model",
+                billing: "",
+                placeholder: true,
+                auth: "api-key",
+              },
+            ];
+          } else if (procedure === "models/credentials") {
+            json = [];
+          } else if (procedure === "me") {
+            json = {
+              userId: "owner",
+              spaceId: "default",
+              email: "owner@example.test",
+              name: "Owner",
+              isDeploymentOwner: true,
+              needsModel: true,
+              defaultProvider: "openai-compatible",
+              defaultModel: "custom",
+              computerHost: "local",
+              canChooseHostComputer: true,
+              sandboxProvider: "docker",
+              avatarStyle: "robot",
+            };
+          } else throw new Error(`Unexpected procedure: ${procedure}`);
+          return { status: 200, body: JSON.stringify({ json }) };
+        },
+      },
+    } as typeof window.rakazoDesktop;
+  });
+  await page.goto("/desktop-settings");
+  await page.getByRole("button", { name: "Server integrations", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Direct MCP", exact: true })).toBeHidden();
+  await page.getByLabel("API key", { exact: true }).fill("fake-integration-key");
+  await page.getByRole("button", { name: "Connect", exact: true }).click();
+  await expect(page.getByText("Connected", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("API key", { exact: true })).toHaveValue("");
+  await captureScreenshot(page, testInfo, "local-server-integrations-logged-out");
+  await page.getByRole("button", { name: "Models", exact: true }).click();
+  await expect(page.getByText("Models for the server owner’s default space.")).toBeVisible();
+  await expect(page.getByLabel("OpenAI-compatible server URL")).toBeVisible();
+  await captureScreenshot(page, testInfo, "local-server-models-logged-out");
+});
+
+test("ordinary browsers cannot use local settings", async ({ page }) => {
+  await page.goto("/desktop-settings");
+  await expect(page.getByRole("alert")).toContainText("Could not open local settings");
+  await expect(page.getByRole("button", { name: "Models", exact: true })).toBeHidden();
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import { LOCAL_SETTINGS_PAGE } from "@rakazo/contracts";
 import { Button, Skeleton } from "@rakazo/ui-web";
 import { lazy, Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Navigate, Route, Routes, useSearchParams } from "react-router-dom";
@@ -12,6 +13,7 @@ import {
   showSessionUnavailable,
 } from "./lib/session-gate";
 import { IntegrationSetupPage } from "./pages/IntegrationSetup";
+import { LocalSettingsPage } from "./pages/LocalSettings";
 import { McpOAuthCallbackPage } from "./pages/McpOAuthCallback";
 import { ShellPage } from "./pages/Shell";
 
@@ -29,6 +31,11 @@ const WelcomePage = lazy(() =>
 );
 
 export function App() {
+  if (window.location.pathname === LOCAL_SETTINGS_PAGE) return <LocalSettingsPage />;
+  return <SessionApp />;
+}
+
+function SessionApp() {
   const [searchParams] = useSearchParams();
   const signInDestination =
     searchParams.get("next") === "/integrations/setup" ? "/integrations/setup" : "/app";

--- a/apps/web/src/components/integrations/IntegrationSetup.tsx
+++ b/apps/web/src/components/integrations/IntegrationSetup.tsx
@@ -11,12 +11,15 @@ type Choice = "direct" | "composio" | "pipedream" | "executor";
 export function IntegrationSetup({
   onDone,
   serverSetup = false,
+  managedOnly = false,
   initialState,
   botId,
   onServerConnected,
 }: {
   onDone?: () => void;
   serverSetup?: boolean;
+  /** Local host settings can configure providers, but cannot access account MCP servers. */
+  managedOnly?: boolean;
   initialState?: IntegrationSetupState | null;
   botId?: string;
   onServerConnected?: (id: string) => void;
@@ -24,7 +27,7 @@ export function IntegrationSetup({
   const { t } = useLingui();
   const fieldId = useId();
   const [state, setState] = useState<IntegrationSetupState | null>(initialState ?? null);
-  const [selectedChoice, setChoice] = useState<Choice>("direct");
+  const [selectedChoice, setChoice] = useState<Choice>(managedOnly ? "composio" : "direct");
   const choice = serverSetup ? selectedChoice : "direct";
   const [apiKey, setApiKey] = useState("");
   const [clientId, setClientId] = useState("");
@@ -133,23 +136,25 @@ export function IntegrationSetup({
           aria-label={t`Integration options`}
           className="overflow-hidden rounded-xl border border-border"
         >
-          {choices.map(({ id, label }) => (
-            <button
-              key={id}
-              type="button"
-              aria-pressed={choice === id}
-              disabled={busy}
-              onClick={() => {
-                setChoice(id);
-                setApiKey("");
-                setError(null);
-              }}
-              className={`flex min-h-11 w-full items-center justify-between border-b border-border px-3.5 py-2.5 text-left last:border-0 ${choice === id ? "bg-muted" : "hover:bg-accent"}`}
-            >
-              <span>{label}</span>
-              {choice === id ? <Check className="size-4" aria-hidden /> : null}
-            </button>
-          ))}
+          {choices
+            .filter(({ id }) => !managedOnly || id === "composio" || id === "pipedream")
+            .map(({ id, label }) => (
+              <button
+                key={id}
+                type="button"
+                aria-pressed={choice === id}
+                disabled={busy}
+                onClick={() => {
+                  setChoice(id);
+                  setApiKey("");
+                  setError(null);
+                }}
+                className={`flex min-h-11 w-full items-center justify-between border-b border-border px-3.5 py-2.5 text-left last:border-0 ${choice === id ? "bg-muted" : "hover:bg-accent"}`}
+              >
+                <span>{label}</span>
+                {choice === id ? <Check className="size-4" aria-hidden /> : null}
+              </button>
+            ))}
         </fieldset>
       ) : null}
       {choice === "composio" || choice === "pipedream" ? (
@@ -209,7 +214,11 @@ export function IntegrationSetup({
                 <Trans>Get credentials</Trans>
               </a>
               {!onDone ? (
-                <Button disabled={busy || !credentialsReady} onClick={() => void saveProvider()}>
+                <Button
+                  className="ml-3"
+                  disabled={busy || !credentialsReady}
+                  onClick={() => void saveProvider()}
+                >
                   {busy ? t`Connecting…` : t`Connect`}
                 </Button>
               ) : null}

--- a/apps/web/src/lib/rpc.ts
+++ b/apps/web/src/lib/rpc.ts
@@ -2,6 +2,8 @@ import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import type { ContractRouterClient } from "@orpc/contract";
 import type { AppContract } from "@rakazo/contracts";
+import { LOCAL_SETTINGS_PAGE, LOCAL_SETTINGS_RPC } from "@rakazo/contracts";
+import { desktopBridge } from "./desktop";
 
 const SPACE_STORAGE_KEY = "rakazo:space-id";
 
@@ -51,9 +53,20 @@ export function withSpaceHeaders(
 
 const link = new RPCLink<RpcClientContext>({
   url: () =>
-    typeof window === "undefined" ? "http://127.0.0.1:5173/rpc" : `${window.location.origin}/rpc`,
-  fetch: (input, init, options) => {
+    typeof window === "undefined"
+      ? "http://127.0.0.1:5173/rpc"
+      : `${window.location.origin}${window.location.pathname === LOCAL_SETTINGS_PAGE ? LOCAL_SETTINGS_RPC : "/rpc"}`,
+  fetch: async (input, init, options) => {
     const request = new Request(input, init);
+    if (typeof window !== "undefined" && window.location.pathname === LOCAL_SETTINGS_PAGE) {
+      const bridge = desktopBridge()?.localSettings;
+      if (!bridge) throw new Error("Local settings require the desktop app");
+      const result = await bridge.request(new URL(request.url).pathname, await request.text());
+      return new Response(result.body, {
+        status: result.status,
+        headers: { "content-type": "application/json" },
+      });
+    }
     const spaceId =
       options.context.spaceId === undefined ? selectedSpaceId() : options.context.spaceId;
     return fetch(request, {

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -13,22 +13,22 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2720
+#: src/pages/Shell.tsx:2730
 msgid " (unread)"
 msgstr " (ungelesen)"
 
 #. placeholder {0}: group.entries.length
-#: src/pages/ModelSettingsOverlay.tsx:382
+#: src/pages/ModelSettingsOverlay.tsx:386
 msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# Modell} other {# Modelle}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1822
+#: src/pages/Shell.tsx:1832
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (maximal {ATTACHMENT_MAX_COUNT} Anhänge)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1826
+#: src/pages/Shell.tsx:1836
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (über 10 MiB)"
 
@@ -80,11 +80,11 @@ msgid "{0} will still respond to direct mentions."
 msgstr ""
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3245
+#: src/pages/Shell.tsx:3255
 msgid "{0}'s screen"
 msgstr "{0}s Bildschirm"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "{botName}’s computer"
 msgstr "Computer von {botName}"
 
@@ -132,12 +132,12 @@ msgstr "{title}, {label}"
 msgid "{toolCount, plural, one {# tool} other {# tools}}"
 msgstr ""
 
-#: src/pages/Shell.tsx:4072
+#: src/pages/Shell.tsx:4086
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} arbeitet"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4711
+#: src/pages/Shell.tsx:4725
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "About spaces"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:301
+#: src/components/integrations/IntegrationSetup.tsx:310
 msgid "Access token"
 msgstr ""
 
@@ -188,7 +188,7 @@ msgstr "Aktionsbestätigungen"
 msgid "Actions for {0}"
 msgstr "Aktionen für {0}"
 
-#: src/pages/Shell.tsx:3619
+#: src/pages/Shell.tsx:3629
 msgid "Actions for space"
 msgstr ""
 
@@ -196,12 +196,12 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:337
+#: src/pages/ModelSettingsOverlay.tsx:341
 msgid "Active model"
 msgstr "Aktives Modell"
 
-#: src/pages/Shell.tsx:2440
-#: src/pages/Shell.tsx:2442
+#: src/pages/Shell.tsx:2450
+#: src/pages/Shell.tsx:2452
 msgid "Activity"
 msgstr "Aktivität"
 
@@ -215,11 +215,11 @@ msgstr "Hinzufügen"
 msgid "Add a model in Settings to use this."
 msgstr ""
 
-#: src/pages/Shell.tsx:3407
+#: src/pages/Shell.tsx:3417
 msgid "Add a run time for this one-shot."
 msgstr ""
 
-#: src/pages/Shell.tsx:3385
+#: src/pages/Shell.tsx:3395
 msgid "Add a schedule, webhook, GitHub, or message trigger"
 msgstr ""
 
@@ -259,7 +259,7 @@ msgstr "GraphQL-Endpunkt hinzufügen"
 msgid "Add item"
 msgstr "Element hinzufügen"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/PluginsOverlay.tsx:951
 msgid "Add MCP server"
 msgstr "MCP-Server hinzufügen"
@@ -277,12 +277,12 @@ msgstr "Remote-MCP-Server hinzufügen"
 msgid "Add server"
 msgstr "Server hinzufügen"
 
-#: src/components/integrations/IntegrationSetup.tsx:269
+#: src/components/integrations/IntegrationSetup.tsx:278
 msgid "Add server URL"
 msgstr ""
 
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Add thumbs-up"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr "Wird hinzugefügt…"
 
 #: src/pages/AccountSettingsOverlay.tsx:166
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/ModelSettingsOverlay.tsx:502
+#: src/pages/ModelSettingsOverlay.tsx:506
 #: src/pages/Onboarding.tsx:461
 #: src/pages/PluginsOverlay.tsx:836
 #: src/pages/RoutineSchedule.tsx:43
@@ -323,7 +323,7 @@ msgstr "Erweitert"
 msgid "Advanced..."
 msgstr ""
 
-#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3039
 msgid "Agent computer"
 msgstr "Agent-Computer"
 
@@ -405,15 +405,15 @@ msgid "API is back, but the update did not finish. Check the host logs."
 msgstr ""
 
 #: src/components/AskCard.tsx:44
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 #: src/lib/localized-provider-hint.ts:9
-#: src/pages/ModelSettingsOverlay.tsx:644
-#: src/pages/ModelSettingsOverlay.tsx:647
-#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:648
+#: src/pages/ModelSettingsOverlay.tsx:651
+#: src/pages/ModelSettingsOverlay.tsx:670
 #: src/pages/Onboarding.tsx:563
 #: src/pages/Onboarding.tsx:566
 #: src/pages/Onboarding.tsx:580
-#: src/pages/VoiceSettingsOverlay.tsx:219
+#: src/pages/VoiceSettingsOverlay.tsx:223
 msgid "API key"
 msgstr "API-Schlüssel"
 
@@ -444,15 +444,15 @@ msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
 msgid "Archive"
 msgstr "Archivieren"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5431
 msgid "archived"
 msgstr "archiviert"
 
-#: src/pages/Shell.tsx:2789
+#: src/pages/Shell.tsx:2799
 msgid "Archived"
 msgstr "Archiviert"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5442
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archiviert. Chat, Erinnerungen und Dateien bleiben erhalten."
 
@@ -491,7 +491,7 @@ msgstr "Vor Käufen nachfragen"
 msgid "Ask before sending external email"
 msgstr "Vor dem Senden externer E-Mails nachfragen"
 
-#: src/components/integrations/IntegrationSetup.tsx:219
+#: src/components/integrations/IntegrationSetup.tsx:228
 msgid "Ask the server owner to configure this provider."
 msgstr ""
 
@@ -506,15 +506,15 @@ msgstr "um {0}"
 msgid "at {timeSelect}"
 msgstr "um {timeSelect}"
 
-#: src/pages/Shell.tsx:4791
+#: src/pages/Shell.tsx:4805
 msgid "Attach file"
 msgstr "Datei anhängen"
 
-#: src/pages/Shell.tsx:5023
+#: src/pages/Shell.tsx:5037
 msgid "Attachment"
 msgstr "Anhang"
 
-#: src/pages/ModelSettingsOverlay.tsx:577
+#: src/pages/ModelSettingsOverlay.tsx:581
 #: src/pages/Onboarding.tsx:512
 msgid "Authorization code or callback URL"
 msgstr "Autorisierungscode oder Callback-URL"
@@ -567,23 +567,23 @@ msgstr "Basis-URL"
 msgid "Bearer token"
 msgstr "Bearer-Token"
 
-#: src/pages/Shell.tsx:5644
+#: src/pages/Shell.tsx:5658
 msgid "Booting live desktop…"
 msgstr "Live-Desktop wird gestartet…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3877
 msgid "Booting up {0}’s computer"
 msgstr "Computer von {0} wird gestartet"
 
-#: src/pages/Shell.tsx:5292
-#: src/pages/Shell.tsx:5293
-#: src/pages/Shell.tsx:5421
+#: src/pages/Shell.tsx:5306
+#: src/pages/Shell.tsx:5307
+#: src/pages/Shell.tsx:5435
 msgid "bot"
 msgstr "Bot"
 
 #: src/pages/IntegrationSetup.tsx:51
-#: src/pages/Shell.tsx:1617
+#: src/pages/Shell.tsx:1627
 msgid "Bot"
 msgstr "Bot"
 
@@ -592,11 +592,11 @@ msgstr "Bot"
 msgid "Bot"
 msgstr ""
 
-#: src/pages/Shell.tsx:3971
+#: src/pages/Shell.tsx:3985
 msgid "Bot screen"
 msgstr "Bot-Bildschirm"
 
-#: src/pages/Shell.tsx:3208
+#: src/pages/Shell.tsx:3218
 msgid "Bot screen preview"
 msgstr "Bot-Bildschirmvorschau"
 
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first."
 msgstr "Bots handeln standardmäßig ohne Nachfrage. Füge nur dann eine Ausnahme hinzu, wenn du eine Aktionsart zuerst prüfen möchtest."
 
-#: src/pages/Shell.tsx:4073
+#: src/pages/Shell.tsx:4087
 msgid "Bots are working"
 msgstr "Bots arbeiten"
 
@@ -620,7 +620,7 @@ msgstr ""
 msgid "Call"
 msgstr "Anrufen"
 
-#: src/App.tsx:152
+#: src/App.tsx:159
 msgid "Can't reach the server."
 msgstr "Server nicht erreichbar."
 
@@ -648,7 +648,7 @@ msgstr "Neuen Bot abbrechen"
 msgid "Cancel new group"
 msgstr "Neue Gruppe abbrechen"
 
-#: src/pages/Shell.tsx:4649
+#: src/pages/Shell.tsx:4663
 msgid "Cancel reply"
 msgstr "Antwort abbrechen"
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Chat apps, group channels, and agent connections."
 msgstr ""
 
-#: src/pages/Shell.tsx:4966
+#: src/pages/Shell.tsx:4980
 msgid "Chat Settings"
 msgstr "Chat-Einstellungen"
 
@@ -699,8 +699,8 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: src/pages/Shell.tsx:3420
-#: src/pages/Shell.tsx:3432
+#: src/pages/Shell.tsx:3430
+#: src/pages/Shell.tsx:3442
 msgid "Check in."
 msgstr "Melde dich."
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Choose a new password"
 msgstr "Wähle ein neues Passwort"
 
-#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:312
 msgid "Choose which connected model Rakazo uses."
 msgstr "Wähle das verbundene Modell aus, das Rakazo verwendet."
 
@@ -747,11 +747,11 @@ msgstr "Unterhaltung leeren"
 msgid "Clearing…"
 msgstr "Wird geleert…"
 
-#: src/components/integrations/IntegrationSetup.tsx:167
+#: src/components/integrations/IntegrationSetup.tsx:172
 msgid "Client ID"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 msgid "Client secret"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr "Schließen"
 msgid "Close chart"
 msgstr "Diagramm schließen"
 
-#: src/pages/Shell.tsx:3950
+#: src/pages/Shell.tsx:3964
 msgid "Close computer"
 msgstr "Computer schließen"
 
@@ -784,7 +784,7 @@ msgstr "Integrationen schließen"
 msgid "Close MCP servers"
 msgstr "MCP-Server schließen"
 
-#: src/pages/MemorySettingsOverlay.tsx:164
+#: src/pages/MemorySettingsOverlay.tsx:168
 #: src/pages/SettingsOverlay.tsx:109
 msgid "Close memory settings"
 msgstr "Erinnerungseinstellungen schließen"
@@ -793,16 +793,16 @@ msgstr "Erinnerungseinstellungen schließen"
 msgid "Close messaging settings"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:324
+#: src/pages/ModelSettingsOverlay.tsx:328
 #: src/pages/SettingsOverlay.tsx:107
 msgid "Close model settings"
 msgstr "Modelleinstellungen schließen"
 
-#: src/pages/Shell.tsx:2418
+#: src/pages/Shell.tsx:2428
 msgid "Close navigation"
 msgstr "Navigation schließen"
 
-#: src/pages/Shell.tsx:3186
+#: src/pages/Shell.tsx:3196
 msgid "Close panel"
 msgstr "Panel schließen"
 
@@ -815,7 +815,7 @@ msgid "Close user settings"
 msgstr "Benutzereinstellungen schließen"
 
 #: src/pages/SettingsOverlay.tsx:111
-#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:158
 msgid "Close voice settings"
 msgstr "Stimmeinstellungen schließen"
 
@@ -828,7 +828,7 @@ msgid "Code"
 msgstr "Code"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2590
+#: src/pages/Shell.tsx:2600
 msgid "Collapse {0}"
 msgstr ""
 
@@ -855,24 +855,24 @@ msgid "Complete"
 msgstr "Abschließen"
 
 #: src/pages/SettingsOverlay.tsx:97
-#: src/pages/Shell.tsx:5578
+#: src/pages/Shell.tsx:5592
 #: src/pages/shell/bot-panel.tsx:57
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5647
+#: src/pages/Shell.tsx:5661
 msgid "Computer failed to boot"
 msgstr "Computer konnte nicht gestartet werden"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4008
 msgid "Computer is asleep"
 msgstr "Computer ist im Ruhezustand"
 
-#: src/pages/Shell.tsx:5646
+#: src/pages/Shell.tsx:5660
 msgid "Computer is asleep. Open it to wake."
 msgstr ""
 
-#: src/pages/Shell.tsx:5648
+#: src/pages/Shell.tsx:5662
 msgid "Computer is stopped"
 msgstr "Computer ist gestoppt"
 
@@ -884,7 +884,7 @@ msgstr "Computer"
 msgid "Computers are off. Set SANDBOX_PROVIDER=docker with SANDBOX_SUPERVISOR_TOKEN, or set SANDBOX_PROVIDER to e2b, daytona, or box with its API key. Recreate the stack after changing .env."
 msgstr "Computer sind aus. Setze SANDBOX_PROVIDER=docker mit SANDBOX_SUPERVISOR_TOKEN, oder setze SANDBOX_PROVIDER auf e2b, daytona oder box mit dem passenden API-Key. Stack nach der Änderung von .env neu erstellen."
 
-#: src/pages/ModelSettingsOverlay.tsx:344
+#: src/pages/ModelSettingsOverlay.tsx:348
 msgid "Configured by deployment"
 msgstr "Durch die Bereitstellung konfiguriert"
 
@@ -902,12 +902,12 @@ msgstr "Löschen bestätigen"
 msgid "Confirm password"
 msgstr "Passwort bestätigen"
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:258
-#: src/components/integrations/IntegrationSetup.tsx:282
-#: src/components/integrations/IntegrationSetup.tsx:315
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:267
+#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:324
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
-#: src/pages/VoiceSettingsOverlay.tsx:241
+#: src/pages/VoiceSettingsOverlay.tsx:245
 msgid "Connect"
 msgstr "Verbinden"
 
@@ -915,7 +915,7 @@ msgstr "Verbinden"
 msgid "Connect a model"
 msgstr "Modell verbinden"
 
-#: src/pages/ModelSettingsOverlay.tsx:697
+#: src/pages/ModelSettingsOverlay.tsx:701
 msgid "Connect API key"
 msgstr "API-Schlüssel verbinden"
 
@@ -931,7 +931,7 @@ msgstr "MCP-Server „{name}“ verbinden"
 msgid "Connect OAuth"
 msgstr "OAuth verbinden"
 
-#: src/pages/ModelSettingsOverlay.tsx:547
+#: src/pages/ModelSettingsOverlay.tsx:551
 msgid "Connect this provider to use it as your personal model."
 msgstr "Verbinde diesen Anbieter, um ihn als persönliches Modell zu verwenden."
 
@@ -939,30 +939,30 @@ msgstr "Verbinde diesen Anbieter, um ihn als persönliches Modell zu verwenden."
 msgid "Connect Treg"
 msgstr "Treg verbinden"
 
-#: src/components/integrations/IntegrationSetup.tsx:159
-#: src/components/integrations/IntegrationSetup.tsx:258
+#: src/components/integrations/IntegrationSetup.tsx:164
+#: src/components/integrations/IntegrationSetup.tsx:267
 #: src/pages/McpOAuthCallback.tsx:54
-#: src/pages/MemorySettingsOverlay.tsx:187
-#: src/pages/ModelSettingsOverlay.tsx:389
+#: src/pages/MemorySettingsOverlay.tsx:191
+#: src/pages/ModelSettingsOverlay.tsx:393
 #: src/pages/shell/message-cards.tsx:187
-#: src/pages/VoiceSettingsOverlay.tsx:198
+#: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Verbunden"
 
 #. placeholder {0}: credential.label
-#: src/pages/ModelSettingsOverlay.tsx:538
+#: src/pages/ModelSettingsOverlay.tsx:542
 msgid "Connected · {0}"
 msgstr "Verbunden · {0}"
 
 #. placeholder {0}: selected.name
-#: src/pages/VoiceSettingsOverlay.tsx:102
+#: src/pages/VoiceSettingsOverlay.tsx:106
 msgid "Connected {0}."
 msgstr "{0} verbunden."
 
 #. placeholder {0}: selected.label
 #. placeholder {0}: selectedLabelRef.current ?? "this model"
-#: src/pages/ModelSettingsOverlay.tsx:82
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:84
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Connected and using {0}."
 msgstr "Verbunden, {0} wird verwendet."
 
@@ -970,12 +970,12 @@ msgstr "Verbunden, {0} wird verwendet."
 msgid "Connected. Its tools are available from your next message."
 msgstr "Verbunden. Die Tools sind ab deiner nächsten Nachricht verfügbar."
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/McpServersOverlay.tsx:38
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
 #: src/pages/shell/message-cards.tsx:360
-#: src/pages/VoiceSettingsOverlay.tsx:237
+#: src/pages/VoiceSettingsOverlay.tsx:241
 msgid "Connecting…"
 msgstr "Verbindung wird hergestellt…"
 
@@ -984,7 +984,7 @@ msgstr "Verbindung wird hergestellt…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "Die Verbindung zu {0} steht noch aus. Du kannst dieses Fenster schließen und später erneut nachsehen."
 
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/Onboarding.tsx:604
 #: src/pages/Onboarding.tsx:667
 msgid "Continue"
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Continue with email"
 msgstr "Mit E-Mail fortfahren"
 
-#: src/pages/Shell.tsx:5109
+#: src/pages/Shell.tsx:5123
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -1022,7 +1022,7 @@ msgstr "App konnte nicht autorisiert werden"
 msgid "Could not change password"
 msgstr "Passwort konnte nicht geändert werden"
 
-#: src/pages/ModelSettingsOverlay.tsx:245
+#: src/pages/ModelSettingsOverlay.tsx:247
 msgid "Could not change the default model"
 msgstr "Standardmodell konnte nicht geändert werden"
 
@@ -1046,30 +1046,30 @@ msgstr "OAuth konnte nicht abgeschlossen werden"
 msgid "Could not complete the update. Try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:76
+#: src/components/integrations/IntegrationSetup.tsx:79
 #: src/pages/PluginsOverlay.tsx:264
 msgid "Could not connect"
 msgstr "Verbindung fehlgeschlagen"
 
 #. placeholder {0}: registration.name
-#: src/pages/MemorySettingsOverlay.tsx:115
+#: src/pages/MemorySettingsOverlay.tsx:119
 msgid "Could not connect {0}"
 msgstr "Verbindung mit {0} fehlgeschlagen"
 
-#: src/pages/ModelSettingsOverlay.tsx:284
+#: src/pages/ModelSettingsOverlay.tsx:286
 msgid "Could not connect this provider"
 msgstr "Anbieter konnte nicht verbunden werden"
 
-#: src/pages/VoiceSettingsOverlay.tsx:104
+#: src/pages/VoiceSettingsOverlay.tsx:108
 msgid "Could not connect this voice provider"
 msgstr "Stimmanbieter konnte nicht verbunden werden"
 
-#: src/pages/Shell.tsx:875
+#: src/pages/Shell.tsx:885
 msgid "Could not connect to the computer screen"
 msgstr ""
 
 #: src/pages/Auth.tsx:99
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2368
 msgid "Could not continue"
 msgstr "Fortfahren fehlgeschlagen"
 
@@ -1117,7 +1117,7 @@ msgstr "Skill konnte nicht gelöscht werden"
 msgid "Could not delete space"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:129
+#: src/pages/MemorySettingsOverlay.tsx:133
 msgid "Could not disconnect memory provider"
 msgstr "Erinnerungsanbieter konnte nicht getrennt werden"
 
@@ -1158,7 +1158,7 @@ msgstr "Bestätigungsregeln konnten nicht geladen werden"
 msgid "Could not load bots. Reload to try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:67
+#: src/components/integrations/IntegrationSetup.tsx:70
 #: src/pages/PluginsOverlay.tsx:143
 #: src/pages/PluginsOverlay.tsx:719
 msgid "Could not load integrations"
@@ -1168,7 +1168,7 @@ msgstr "Integrationen konnten nicht geladen werden"
 msgid "Could not load MCP servers"
 msgstr "MCP-Server konnten nicht geladen werden"
 
-#: src/pages/ModelSettingsOverlay.tsx:129
+#: src/pages/ModelSettingsOverlay.tsx:131
 msgid "Could not load model settings"
 msgstr "Modelleinstellungen konnten nicht geladen werden"
 
@@ -1188,11 +1188,15 @@ msgstr "Datei konnte nicht geladen werden."
 msgid "Could not load update status"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:77
+#: src/pages/VoiceSettingsOverlay.tsx:81
 msgid "Could not load voice settings"
 msgstr "Stimmeinstellungen konnten nicht geladen werden"
 
-#: src/pages/VoiceSettingsOverlay.tsx:138
+#: src/pages/LocalSettings.tsx:26
+msgid "Could not open local settings. Start the local server and create its owner account, then try again."
+msgstr ""
+
+#: src/pages/VoiceSettingsOverlay.tsx:142
 msgid "Could not play a test clip"
 msgstr "Testclip konnte nicht abgespielt werden"
 
@@ -1202,7 +1206,7 @@ msgstr "Testclip konnte nicht abgespielt werden"
 msgid "Could not reach the server"
 msgstr "Server konnte nicht erreicht werden"
 
-#: src/pages/ModelSettingsOverlay.tsx:229
+#: src/pages/ModelSettingsOverlay.tsx:231
 #: src/pages/Onboarding.tsx:191
 msgid "Could not reach this model server"
 msgstr "Modellserver konnte nicht erreicht werden"
@@ -1240,7 +1244,7 @@ msgstr "Passwort konnte nicht zurückgesetzt werden"
 msgid "Could not revoke connection"
 msgstr "Verbindung konnte nicht widerrufen werden"
 
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3496
 msgid "Could not run routine"
 msgstr ""
 
@@ -1262,7 +1266,7 @@ msgstr "Gruppe konnte nicht gespeichert werden"
 msgid "Could not save model"
 msgstr "Modell konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:3457
+#: src/pages/Shell.tsx:3467
 msgid "Could not save routine"
 msgstr "Routine konnte nicht gespeichert werden"
 
@@ -1278,7 +1282,7 @@ msgstr "Skill konnte nicht gespeichert werden"
 msgid "Could not save that choice"
 msgstr "Auswahl konnte nicht gespeichert werden"
 
-#: src/pages/VoiceSettingsOverlay.tsx:119
+#: src/pages/VoiceSettingsOverlay.tsx:123
 msgid "Could not save that voice"
 msgstr "Stimme konnte nicht gespeichert werden"
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Could not submit this answer"
 msgstr "Antwort konnte nicht gesendet werden"
 
-#: src/pages/Shell.tsx:2212
+#: src/pages/Shell.tsx:2222
 msgid "Could not take control"
 msgstr "Kontrolle konnte nicht übernommen werden"
 
@@ -1326,11 +1330,11 @@ msgstr "Agent-Zugriff konnte nicht aktualisiert werden"
 msgid "Could not update computer"
 msgstr ""
 
-#: src/pages/Shell.tsx:1808
+#: src/pages/Shell.tsx:1818
 msgid "Could not update reaction"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:143
+#: src/pages/MemorySettingsOverlay.tsx:147
 msgid "Could not update the default memory scope"
 msgstr "Standardbereich für Erinnerungen konnte nicht aktualisiert werden"
 
@@ -1346,7 +1350,7 @@ msgstr ""
 msgid "Couldn't update messaging settings"
 msgstr ""
 
-#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2481
 #: src/pages/shell/bot-panel.tsx:184
 #: src/pages/shell/dialogs.tsx:208
 msgid "Create"
@@ -1460,8 +1464,8 @@ msgstr "Standardbereich"
 #: src/pages/KnowledgeSection.tsx:449
 #: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:301
-#: src/pages/Shell.tsx:2825
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2835
+#: src/pages/Shell.tsx:2866
 #: src/pages/shell/dialogs.tsx:351
 #: src/pages/shell/dialogs.tsx:412
 msgid "Delete"
@@ -1469,8 +1473,8 @@ msgstr "Löschen"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2822
-#: src/pages/Shell.tsx:2853
+#: src/pages/Shell.tsx:2832
+#: src/pages/Shell.tsx:2863
 msgid "Delete {0}"
 msgstr "{0} löschen"
 
@@ -1489,11 +1493,11 @@ msgstr "Gruppe löschen"
 msgid "Delete memories too"
 msgstr "Erinnerungen ebenfalls löschen"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3643
 msgid "Delete space"
 msgstr ""
 
-#: src/pages/Shell.tsx:5419
+#: src/pages/Shell.tsx:5433
 msgid "deleted"
 msgstr "gelöscht"
 
@@ -1511,7 +1515,7 @@ msgstr "Abgelehnt"
 msgid "Deny"
 msgstr "Ablehnen"
 
-#: src/pages/ModelSettingsOverlay.tsx:340
+#: src/pages/ModelSettingsOverlay.tsx:344
 msgid "Deployment default"
 msgstr "Bereitstellungsstandard"
 
@@ -1534,16 +1538,16 @@ msgstr ""
 msgid "Desktop update"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:40
+#: src/components/integrations/IntegrationSetup.tsx:43
 msgid "Direct MCP"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:493
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnect"
 msgstr "Trennen"
 
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnecting…"
 msgstr "Verbindung wird getrennt…"
 
@@ -1553,7 +1557,7 @@ msgstr "Verbindung wird getrennt…"
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/Shell.tsx:4629
+#: src/pages/Shell.tsx:4643
 msgid "Dismiss error"
 msgstr ""
 
@@ -1601,7 +1605,7 @@ msgstr "{name} herunterladen"
 msgid "Download as markdown"
 msgstr "Als Markdown herunterladen"
 
-#: src/components/integrations/IntegrationSetup.tsx:327
+#: src/components/integrations/IntegrationSetup.tsx:336
 msgid "Download Executor"
 msgstr ""
 
@@ -1617,7 +1621,7 @@ msgstr "Skill-Entwurf"
 msgid "Duplicate"
 msgstr "Duplizieren"
 
-#: src/pages/Shell.tsx:5245
+#: src/pages/Shell.tsx:5259
 msgid "Earlier message"
 msgstr "Frühere Nachricht"
 
@@ -1638,7 +1642,7 @@ msgid "Engage when... Ignore..."
 msgstr ""
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
-#: src/pages/ModelSettingsOverlay.tsx:600
+#: src/pages/ModelSettingsOverlay.tsx:604
 #: src/pages/Onboarding.tsx:531
 msgid "Enter this code at <0>{0}</0>"
 msgstr "Gib diesen Code unter <0>{0}</0> ein"
@@ -1687,7 +1691,7 @@ msgid "Expand"
 msgstr "Erweitern"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2589
+#: src/pages/Shell.tsx:2599
 msgid "Expand {0}"
 msgstr ""
 
@@ -1716,14 +1720,14 @@ msgstr "fehlgeschlagen"
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: src/pages/Shell.tsx:1981
-#: src/pages/Shell.tsx:1983
-#: src/pages/Shell.tsx:1985
+#: src/pages/Shell.tsx:1991
+#: src/pages/Shell.tsx:1993
+#: src/pages/Shell.tsx:1995
 msgid "Failed to send message"
 msgstr "Nachricht konnte nicht gesendet werden"
 
-#: src/pages/Shell.tsx:2018
-#: src/pages/Shell.tsx:2037
+#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2047
 msgid "Failed to stop"
 msgstr "Stoppen fehlgeschlagen"
 
@@ -1736,18 +1740,18 @@ msgstr "Fehlgeschlagen."
 msgid "Failure handling"
 msgstr "Fehlerbehandlung"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Find models"
 msgstr "Modelle suchen"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Finding…"
 msgstr "Suche läuft…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
-#: src/pages/ModelSettingsOverlay.tsx:560
+#: src/pages/ModelSettingsOverlay.tsx:564
 #: src/pages/Onboarding.tsx:495
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "Schließe die Anmeldung unter <0>{0}</0> ab. Die letzte Seite wird möglicherweise nicht geladen; füge ihre URL oder den Code hier ein."
@@ -1773,7 +1777,7 @@ msgstr ""
 msgid "Forgot password?"
 msgstr "Passwort vergessen?"
 
-#: src/pages/ModelSettingsOverlay.tsx:1071
+#: src/pages/ModelSettingsOverlay.tsx:1075
 msgid "Free"
 msgstr "Kostenlos"
 
@@ -1786,7 +1790,7 @@ msgstr "Vollbild"
 msgid "General"
 msgstr "Allgemein"
 
-#: src/components/integrations/IntegrationSetup.tsx:209
+#: src/components/integrations/IntegrationSetup.tsx:214
 msgid "Get credentials"
 msgstr ""
 
@@ -1801,8 +1805,8 @@ msgid "Git event"
 msgstr ""
 
 #: src/pages/MessagingSettingsOverlay.tsx:204
-#: src/pages/Shell.tsx:3019
-#: src/pages/Shell.tsx:3156
+#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3166
 msgid "Group"
 msgstr "Gruppe"
 
@@ -1844,15 +1848,15 @@ msgstr "Header-Name"
 msgid "Header value"
 msgstr "Header-Wert"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Hear a sample"
 msgstr "Beispiel anhören"
 
-#: src/pages/VoiceSettingsOverlay.tsx:131
+#: src/pages/VoiceSettingsOverlay.tsx:135
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hallo, so klinge ich, wenn ich Antworten vorlese."
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Hide bots"
 msgstr ""
 
@@ -1881,11 +1885,11 @@ msgstr "Wie oft"
 msgid "How to check"
 msgstr "So wird geprüft"
 
-#: src/pages/Shell.tsx:5174
+#: src/pages/Shell.tsx:5188
 msgid "I’m done"
 msgstr "Ich bin fertig"
 
-#: src/pages/VoiceSettingsOverlay.tsx:136
+#: src/pages/VoiceSettingsOverlay.tsx:140
 msgid "If you heard that, voice is ready."
 msgstr "Wenn du das gehört hast, ist die Stimme einsatzbereit."
 
@@ -1917,12 +1921,12 @@ msgstr "Anweisung"
 msgid "Integration domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:133
+#: src/components/integrations/IntegrationSetup.tsx:136
 msgid "Integration options"
 msgstr ""
 
 #: src/pages/PluginsOverlay.tsx:679
-#: src/pages/Shell.tsx:2874
+#: src/pages/Shell.tsx:2884
 msgid "Integrations"
 msgstr "Integrationen"
 
@@ -1952,11 +1956,11 @@ msgstr "Isoliert"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Seine Unterhaltung, Dateien und Routinen werden dauerhaft gelöscht. Von ihm erstellte Bots bleiben in deiner Liste."
 
-#: src/pages/Shell.tsx:4289
+#: src/pages/Shell.tsx:4303
 msgid "Jump to latest"
 msgstr "Zur neuesten Nachricht springen"
 
-#: src/pages/Shell.tsx:5240
+#: src/pages/Shell.tsx:5254
 msgid "Jump to replied message"
 msgstr "Zur beantworteten Nachricht springen"
 
@@ -2014,7 +2018,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "Hört zu…"
 
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Load earlier messages"
 msgstr "Frühere Nachrichten laden"
 
@@ -2026,12 +2030,12 @@ msgstr "Aktivität wird geladen…"
 msgid "Loading integrations…"
 msgstr "Integrationen werden geladen…"
 
-#: src/pages/MemorySettingsOverlay.tsx:182
+#: src/pages/MemorySettingsOverlay.tsx:186
 msgid "Loading memory settings…"
 msgstr "Erinnerungseinstellungen werden geladen…"
 
-#: src/pages/ModelSettingsOverlay.tsx:306
-#: src/pages/ModelSettingsOverlay.tsx:733
+#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:737
 msgid "Loading model catalog…"
 msgstr "Modellkatalog wird geladen…"
 
@@ -2047,15 +2051,15 @@ msgstr "Regeln werden geladen…"
 msgid "Loading tools…"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:210
+#: src/pages/VoiceSettingsOverlay.tsx:214
 msgid "Loading voice providers…"
 msgstr "Stimmanbieter werden geladen…"
 
-#: src/App.tsx:58
+#: src/App.tsx:65
 #: src/pages/IntegrationSetup.tsx:72
 #: src/pages/Onboarding.tsx:282
 #: src/pages/PeerMessagesOverlay.tsx:98
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Loading…"
 msgstr "Wird geladen…"
 
@@ -2067,7 +2071,11 @@ msgstr "Lokal"
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "Mit lokalem Zugriff können Bots ohne Rückfrage Befehle ausführen. Vermeide dies auf gemeinsam genutzten oder öffentlichen Servern."
 
-#: src/pages/Shell.tsx:2932
+#: src/pages/LocalSettings.tsx:22
+msgid "Local Server Settings"
+msgstr ""
+
+#: src/pages/Shell.tsx:2942
 msgid "Log out"
 msgstr "Abmelden"
 
@@ -2083,8 +2091,8 @@ msgstr "MCP-Server verwalten"
 msgid "Manage messaging settings"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:159
-#: src/pages/MemorySettingsOverlay.tsx:173
+#: src/pages/MemorySettingsOverlay.tsx:163
+#: src/pages/MemorySettingsOverlay.tsx:177
 msgid "Manage the Space semantic memory provider."
 msgstr "Verwalte den Anbieter für semantische Erinnerungen des Arbeitsbereichs."
 
@@ -2125,7 +2133,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Mitglieder ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} auswählen)"
 
 #: src/pages/KnowledgeSection.tsx:39
-#: src/pages/MemorySettingsOverlay.tsx:155
+#: src/pages/MemorySettingsOverlay.tsx:159
 #: src/pages/SettingsOverlay.tsx:94
 msgid "Memory"
 msgstr "Erinnerungen"
@@ -2134,7 +2142,7 @@ msgstr "Erinnerungen"
 msgid "Memory scope"
 msgstr "Erinnerungsbereich"
 
-#: src/pages/Shell.tsx:4697
+#: src/pages/Shell.tsx:4711
 msgid "Mentions"
 msgstr ""
 
@@ -2142,8 +2150,8 @@ msgstr ""
 msgid "Mentions only"
 msgstr ""
 
-#: src/pages/Shell.tsx:4898
-#: src/pages/Shell.tsx:5025
+#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:5039
 msgid "Message"
 msgstr "Nachricht"
 
@@ -2152,12 +2160,12 @@ msgstr "Nachricht"
 msgid "Message"
 msgstr "Nachricht"
 
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4898
+#: src/pages/Shell.tsx:4908
+#: src/pages/Shell.tsx:4912
 msgid "Message {activeName}"
 msgstr "Nachricht an {activeName}"
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4623
 msgid "Message composer"
 msgstr ""
 
@@ -2166,15 +2174,15 @@ msgstr ""
 msgid "Message event"
 msgstr ""
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Message from {peer}"
 msgstr "Nachricht von {peer}"
 
-#: src/pages/Shell.tsx:4895
+#: src/pages/Shell.tsx:4909
 msgid "Message…"
 msgstr "Nachricht…"
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Messaged {peer}"
 msgstr "Nachricht an {peer} gesendet"
 
@@ -2195,8 +2203,8 @@ msgstr "Minimal"
 msgid "Minimize"
 msgstr "Minimieren"
 
-#: src/pages/Shell.tsx:2461
-#: src/pages/Shell.tsx:2462
+#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2472
 msgid "Minimize bots"
 msgstr ""
 
@@ -2208,9 +2216,9 @@ msgstr "Minute"
 msgid "minutes"
 msgstr "Minuten"
 
-#: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/ModelSettingsOverlay.tsx:509
-#: src/pages/ModelSettingsOverlay.tsx:959
+#: src/pages/ModelSettingsOverlay.tsx:448
+#: src/pages/ModelSettingsOverlay.tsx:513
+#: src/pages/ModelSettingsOverlay.tsx:963
 #: src/pages/Onboarding.tsx:420
 #: src/pages/Onboarding.tsx:468
 #: src/pages/Onboarding.tsx:476
@@ -2218,12 +2226,12 @@ msgstr "Minuten"
 msgid "Model"
 msgstr "Modell"
 
-#: src/pages/ModelSettingsOverlay.tsx:478
+#: src/pages/ModelSettingsOverlay.tsx:482
 #: src/pages/Onboarding.tsx:442
 msgid "Model id"
 msgstr "Modell-ID"
 
-#: src/pages/ModelSettingsOverlay.tsx:995
+#: src/pages/ModelSettingsOverlay.tsx:999
 msgid "Model options"
 msgstr "Modelloptionen"
 
@@ -2235,16 +2243,21 @@ msgstr ""
 msgid "Model spend uses your provider keys."
 msgstr "Modellkosten werden über deine Anbieterschlüssel abgerechnet."
 
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Model updated."
 msgstr "Modell aktualisiert."
 
-#: src/pages/ModelSettingsOverlay.tsx:317
+#: src/pages/LocalSettings.tsx:36
+#: src/pages/ModelSettingsOverlay.tsx:321
 #: src/pages/SettingsOverlay.tsx:93
 msgid "Models"
 msgstr "Modelle"
 
-#: src/pages/ModelSettingsOverlay.tsx:457
+#: src/pages/ModelSettingsOverlay.tsx:310
+msgid "Models for the server owner’s default space."
+msgstr ""
+
+#: src/pages/ModelSettingsOverlay.tsx:461
 #: src/pages/Onboarding.tsx:426
 msgid "Models from server"
 msgstr "Modelle vom Server"
@@ -2253,7 +2266,7 @@ msgstr "Modelle vom Server"
 msgid "Monthly"
 msgstr "Monatlich"
 
-#: src/pages/Shell.tsx:5082
+#: src/pages/Shell.tsx:5096
 msgid "More"
 msgstr ""
 
@@ -2303,7 +2316,7 @@ msgstr "Eingabe erforderlich"
 msgid "Needs takeover"
 msgstr "Übernahme erforderlich"
 
-#: src/pages/Shell.tsx:3897
+#: src/pages/Shell.tsx:3911
 msgid "Needs you"
 msgstr ""
 
@@ -2381,7 +2394,7 @@ msgstr "Nicht mehr aktiv"
 msgid "No managed app catalog is configured on this deployment."
 msgstr "Für diese Bereitstellung ist kein verwalteter App-Katalog konfiguriert."
 
-#: src/pages/ModelSettingsOverlay.tsx:1023
+#: src/pages/ModelSettingsOverlay.tsx:1027
 msgid "No matching models"
 msgstr "Keine passenden Modelle"
 
@@ -2397,7 +2410,7 @@ msgstr "Noch keine MCP-Server."
 msgid "No messages with {peerBotName} yet."
 msgstr "Noch keine Nachrichten mit {peerBotName}."
 
-#: src/pages/ModelSettingsOverlay.tsx:737
+#: src/pages/ModelSettingsOverlay.tsx:741
 msgid "No model catalog is available."
 msgstr "Kein Modellkatalog verfügbar."
 
@@ -2405,11 +2418,11 @@ msgstr "Kein Modellkatalog verfügbar."
 msgid "No providers found"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:397
+#: src/pages/ModelSettingsOverlay.tsx:401
 msgid "No providers found."
 msgstr "Keine Anbieter gefunden."
 
-#: src/components/integrations/IntegrationSetup.tsx:264
+#: src/components/integrations/IntegrationSetup.tsx:273
 msgid "No remote MCP servers found"
 msgstr ""
 
@@ -2442,7 +2455,7 @@ msgstr ""
 msgid "None yet"
 msgstr "Noch keine"
 
-#: src/pages/ModelSettingsOverlay.tsx:540
+#: src/pages/ModelSettingsOverlay.tsx:544
 msgid "Not connected"
 msgstr "Nicht verbunden"
 
@@ -2463,7 +2476,7 @@ msgid "Now"
 msgstr "Jetzt"
 
 #. placeholder {0}: selected.label
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Now using {0}."
 msgstr "Jetzt wird {0} verwendet."
 
@@ -2496,26 +2509,26 @@ msgstr "am 1. um {0}"
 msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
 msgstr ""
 
-#: src/pages/Shell.tsx:3671
+#: src/pages/Shell.tsx:3681
 msgid "Only empty spaces can be deleted. Delete its bots and groups first."
 msgstr ""
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3234
-#: src/pages/Shell.tsx:3239
+#: src/pages/Shell.tsx:3244
+#: src/pages/Shell.tsx:3249
 msgid "Open"
 msgstr "Öffnen"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2597
 msgid "Open {0}"
 msgstr ""
 
-#: src/pages/Shell.tsx:3202
+#: src/pages/Shell.tsx:3212
 msgid "Open in full window"
 msgstr "In vollständigem Fenster öffnen"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3001
 msgid "Open navigation"
 msgstr "Navigation öffnen"
 
@@ -2523,20 +2536,20 @@ msgstr "Navigation öffnen"
 msgid "Open work"
 msgstr "Offene Arbeit"
 
-#: src/pages/ModelSettingsOverlay.tsx:417
+#: src/pages/ModelSettingsOverlay.tsx:421
 #: src/pages/Onboarding.tsx:395
 msgid "OpenAI-compatible server URL"
 msgstr "URL eines OpenAI-kompatiblen Servers"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5444
 msgid "Opened its thread."
 msgstr "Thread geöffnet."
 
-#: src/App.tsx:195
+#: src/App.tsx:202
 msgid "Opening your Space…"
 msgstr "Dein Arbeitsbereich wird geöffnet…"
 
-#: src/pages/ModelSettingsOverlay.tsx:650
+#: src/pages/ModelSettingsOverlay.tsx:654
 #: src/pages/Onboarding.tsx:569
 msgid "Optional"
 msgstr "Optional"
@@ -2549,7 +2562,7 @@ msgstr "Optionale Einstellungen, die die meisten nie benötigen"
 msgid "Optional header value"
 msgstr "Optionaler Header-Wert"
 
-#: src/pages/ModelSettingsOverlay.tsx:664
+#: src/pages/ModelSettingsOverlay.tsx:668
 msgid "Or connect an API key"
 msgstr "Oder einen API-Schlüssel verbinden"
 
@@ -2565,7 +2578,7 @@ msgstr ""
 msgid "Organization API key"
 msgstr "Organisations-API-Schlüssel"
 
-#: src/pages/ModelSettingsOverlay.tsx:465
+#: src/pages/ModelSettingsOverlay.tsx:469
 #: src/pages/Onboarding.tsx:435
 msgid "Other model…"
 msgstr "Anderes Modell…"
@@ -2600,16 +2613,16 @@ msgstr "Passwort aktualisiert"
 msgid "Passwords do not match"
 msgstr "Die Passwörter stimmen nicht überein"
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste a replacement key"
 msgstr "Ersatzschlüssel einfügen"
 
-#: src/pages/ModelSettingsOverlay.tsx:428
+#: src/pages/ModelSettingsOverlay.tsx:432
 #: src/pages/Onboarding.tsx:406
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "Füge die OpenAI-kompatible Adresse deines Servers ein. Rakazo ergänzt /v1 bei Bedarf."
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste your API key"
 msgstr "Füge deinen API-Schlüssel ein"
 
@@ -2617,7 +2630,7 @@ msgstr "Füge deinen API-Schlüssel ein"
 msgid "Paused"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:534
+#: src/pages/ModelSettingsOverlay.tsx:538
 msgid "Personal credential"
 msgstr "Persönliche Zugangsdaten"
 
@@ -2625,7 +2638,7 @@ msgstr "Persönliche Zugangsdaten"
 msgid "Pin"
 msgstr "Anheften"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Playing…"
 msgstr "Wiedergabe…"
 
@@ -2642,17 +2655,17 @@ msgstr "Vorschau von {0}"
 msgid "Private"
 msgstr "Privat"
 
-#: src/components/integrations/IntegrationSetup.tsx:177
+#: src/components/integrations/IntegrationSetup.tsx:182
 msgid "Project ID"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:215
+#: src/pages/MemorySettingsOverlay.tsx:219
 #: src/pages/Onboarding.tsx:292
 msgid "Provider"
 msgstr "Anbieter"
 
-#: src/pages/ModelSettingsOverlay.tsx:352
-#: src/pages/VoiceSettingsOverlay.tsx:166
+#: src/pages/ModelSettingsOverlay.tsx:356
+#: src/pages/VoiceSettingsOverlay.tsx:170
 msgid "Providers"
 msgstr "Anbieter"
 
@@ -2684,7 +2697,7 @@ msgstr "Kürzlich"
 msgid "Reconnect OAuth"
 msgstr "OAuth erneut verbinden"
 
-#: src/App.tsx:150
+#: src/App.tsx:157
 #: src/components/ComputerUpdateProgress.tsx:54
 msgid "Reconnecting"
 msgstr "Verbindung wird wiederhergestellt"
@@ -2747,7 +2760,7 @@ msgstr ""
 msgid "Refreshing…"
 msgstr ""
 
-#: src/pages/Shell.tsx:5164
+#: src/pages/Shell.tsx:5178
 msgid "Release"
 msgstr "Freigeben"
 
@@ -2767,7 +2780,7 @@ msgid "Remove"
 msgstr "Entfernen"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4683
+#: src/pages/Shell.tsx:4697
 msgid "Remove {0}"
 msgstr "{0} entfernen"
 
@@ -2776,7 +2789,7 @@ msgid "Remove Git event"
 msgstr ""
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4845
 msgid "Remove mention {0}"
 msgstr "Erwähnung von {0} entfernen"
 
@@ -2789,13 +2802,13 @@ msgid "Remove schedule"
 msgstr ""
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4824
 msgid "Remove skill {0}"
 msgstr "Skill {0} entfernen"
 
-#: src/pages/Shell.tsx:4262
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:4276
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Remove thumbs-up"
 msgstr ""
 
@@ -2803,7 +2816,7 @@ msgstr ""
 msgid "Remove webhook"
 msgstr ""
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5443
 msgid "Removed with chat, computer, and memory."
 msgstr "Zusammen mit Chat, Computer und Erinnerungen entfernt."
 
@@ -2822,21 +2835,21 @@ msgstr "Wird entfernt…"
 msgid "Reopen"
 msgstr "Erneut öffnen"
 
-#: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/ModelSettingsOverlay.tsx:695
+#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:699
 msgid "Replace API key"
 msgstr "API-Schlüssel ersetzen"
 
-#: src/pages/VoiceSettingsOverlay.tsx:239
+#: src/pages/VoiceSettingsOverlay.tsx:243
 msgid "Replace key"
 msgstr "Schlüssel ersetzen"
 
-#: src/pages/Shell.tsx:5074
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5088
+#: src/pages/Shell.tsx:5119
 msgid "Reply"
 msgstr "Antworten"
 
-#: src/pages/Shell.tsx:4646
+#: src/pages/Shell.tsx:4660
 msgid "Replying to {replyName}"
 msgstr "Antwort an {replyName}"
 
@@ -2870,8 +2883,8 @@ msgstr ""
 msgid "Restart to update"
 msgstr ""
 
-#: src/pages/Shell.tsx:2816
-#: src/pages/Shell.tsx:2847
+#: src/pages/Shell.tsx:2826
+#: src/pages/Shell.tsx:2857
 msgid "Restore"
 msgstr "Wiederherstellen"
 
@@ -2883,12 +2896,12 @@ msgstr ""
 msgid "Restoring your workspace"
 msgstr ""
 
-#: src/App.tsx:164
+#: src/App.tsx:171
 #: src/pages/PeerMessagesOverlay.tsx:109
 msgid "Retry now"
 msgstr "Jetzt erneut versuchen"
 
-#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2398
 msgid "Retry screen"
 msgstr ""
 
@@ -2918,8 +2931,8 @@ msgid "Rotate key"
 msgstr ""
 
 #: src/pages/RoutineEditor.tsx:265
-#: src/pages/Shell.tsx:3419
-#: src/pages/Shell.tsx:3431
+#: src/pages/Shell.tsx:3429
+#: src/pages/Shell.tsx:3441
 msgid "Routine"
 msgstr "Routine"
 
@@ -2936,7 +2949,7 @@ msgstr ""
 msgid "Run history"
 msgstr ""
 
-#: src/pages/Shell.tsx:3412
+#: src/pages/Shell.tsx:3422
 msgid "Run time must be in the future."
 msgstr ""
 
@@ -2966,7 +2979,7 @@ msgstr ""
 #: src/pages/GroupPanel.tsx:236
 #: src/pages/KnowledgeSection.tsx:203
 #: src/pages/KnowledgeSection.tsx:422
-#: src/pages/ModelSettingsOverlay.tsx:693
+#: src/pages/ModelSettingsOverlay.tsx:697
 #: src/pages/RoutineEditor.tsx:489
 #: src/pages/shell/bot-panel.tsx:539
 msgid "Save"
@@ -2983,7 +2996,7 @@ msgstr "Gespeichert"
 msgid "Saved, but list refresh failed"
 msgstr "Gespeichert, aber die Liste konnte nicht aktualisiert werden"
 
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Saved."
 msgstr "Gespeichert."
 
@@ -3002,7 +3015,7 @@ msgstr ""
 #: src/components/AskCard.tsx:157
 #: src/components/teach/SkillDraftCard.tsx:142
 #: src/pages/GroupPanel.tsx:236
-#: src/pages/ModelSettingsOverlay.tsx:691
+#: src/pages/ModelSettingsOverlay.tsx:695
 #: src/pages/RoutineEditor.tsx:489
 msgid "Saving…"
 msgstr "Wird gespeichert…"
@@ -3016,15 +3029,15 @@ msgstr "Sag etwas. Bei Stille wird es gesendet."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "Antworte mit Ja oder Nein oder in einem Satz."
 
-#: src/pages/ModelSettingsOverlay.tsx:984
+#: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
-#: src/pages/Shell.tsx:2530
+#: src/pages/Shell.tsx:2540
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "Suchen"
 
-#: src/components/integrations/IntegrationSetup.tsx:241
-#: src/components/integrations/IntegrationSetup.tsx:242
+#: src/components/integrations/IntegrationSetup.tsx:250
+#: src/components/integrations/IntegrationSetup.tsx:251
 #: src/pages/PluginsOverlay.tsx:696
 #: src/pages/PluginsOverlay.tsx:697
 msgid "Search apps"
@@ -3038,11 +3051,11 @@ msgstr ""
 msgid "Search by domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:247
+#: src/components/integrations/IntegrationSetup.tsx:256
 msgid "Search integrations.sh"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:979
+#: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr "Modelle suchen"
 
@@ -3051,8 +3064,8 @@ msgstr "Modelle suchen"
 msgid "Search or create Bots"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:355
-#: src/pages/ModelSettingsOverlay.tsx:361
+#: src/pages/ModelSettingsOverlay.tsx:359
+#: src/pages/ModelSettingsOverlay.tsx:365
 msgid "Search providers"
 msgstr "Anbieter suchen"
 
@@ -3066,7 +3079,7 @@ msgstr "Anbieter und Modelle suchen"
 msgid "Searching…"
 msgstr "Suche…"
 
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3030
 msgid "Select a bot"
 msgstr "Bot auswählen"
 
@@ -3074,8 +3087,8 @@ msgstr "Bot auswählen"
 msgid "Selected"
 msgstr ""
 
-#: src/pages/Shell.tsx:4929
-#: src/pages/Shell.tsx:4950
+#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4964
 msgid "Send"
 msgstr "Senden"
 
@@ -3105,8 +3118,9 @@ msgstr "Wird gesendet…"
 msgid "Sentry alert"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/AccountSettingsOverlay.tsx:158
+#: src/pages/LocalSettings.tsx:42
 msgid "Server integrations"
 msgstr ""
 
@@ -3114,33 +3128,33 @@ msgstr ""
 msgid "Server name"
 msgstr "Servername"
 
-#: src/components/integrations/IntegrationSetup.tsx:273
-#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:282
+#: src/components/integrations/IntegrationSetup.tsx:300
 #: src/pages/McpServersOverlay.tsx:329
-#: src/pages/ModelSettingsOverlay.tsx:412
+#: src/pages/ModelSettingsOverlay.tsx:416
 #: src/pages/Onboarding.tsx:390
 msgid "Server URL"
 msgstr "Server-URL"
 
 #: src/pages/MessagingSettingsOverlay.tsx:361
 #: src/pages/SettingsOverlay.tsx:103
-#: src/pages/SettingsOverlay.tsx:151
-#: src/pages/Shell.tsx:2896
-#: src/pages/Shell.tsx:2903
-#: src/pages/Shell.tsx:3152
+#: src/pages/SettingsOverlay.tsx:158
+#: src/pages/Shell.tsx:2906
+#: src/pages/Shell.tsx:2913
+#: src/pages/Shell.tsx:3162
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4982
 msgid "Settings: General"
 msgstr "Einstellungen: Allgemein"
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4984
 msgid "Settings: Usage"
 msgstr "Einstellungen: Nutzung"
 
-#: src/components/integrations/IntegrationSetup.tsx:319
-#: src/pages/ModelSettingsOverlay.tsx:425
+#: src/components/integrations/IntegrationSetup.tsx:328
+#: src/pages/ModelSettingsOverlay.tsx:429
 #: src/pages/Onboarding.tsx:403
 msgid "Setup help"
 msgstr "Einrichtungshilfe"
@@ -3158,11 +3172,11 @@ msgstr "Geteilte Dokumente"
 msgid "Show all providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Show bots"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show computer"
 msgstr "Computer anzeigen"
 
@@ -3178,14 +3192,14 @@ msgstr ""
 msgid "Show popular providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show settings"
 msgstr "Einstellungen anzeigen"
 
 #: src/lib/localized-provider-hint.ts:7
 #: src/pages/Auth.tsx:230
 #: src/pages/Auth.tsx:288
-#: src/pages/ModelSettingsOverlay.tsx:632
+#: src/pages/ModelSettingsOverlay.tsx:636
 #: src/pages/Onboarding.tsx:152
 msgid "Sign in"
 msgstr "Anmelden"
@@ -3200,7 +3214,7 @@ msgid "Sign up"
 msgstr "Registrieren"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4758
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
@@ -3208,8 +3222,8 @@ msgstr "Skill {0}"
 msgid "Skills"
 msgstr "Skills"
 
-#: src/components/integrations/IntegrationSetup.tsx:355
-#: src/pages/Shell.tsx:5171
+#: src/components/integrations/IntegrationSetup.tsx:364
+#: src/pages/Shell.tsx:5185
 msgid "Skip"
 msgstr "Überspringen"
 
@@ -3218,7 +3232,7 @@ msgid "Skip or deploy key"
 msgstr "Überspringen oder Deploy-Key"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1842
+#: src/pages/Shell.tsx:1852
 msgid "Skipped {0}"
 msgstr "{0} übersprungen"
 
@@ -3250,21 +3264,21 @@ msgstr "Leertaste unterbricht · Esc legt auf"
 msgid "Spaces"
 msgstr ""
 
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Speak"
 msgstr "Vorlesen"
 
-#: src/pages/VoiceSettingsOverlay.tsx:190
+#: src/pages/VoiceSettingsOverlay.tsx:194
 msgid "Speak + transcribe"
 msgstr "Sprechen + transkribieren"
 
-#: src/pages/VoiceSettingsOverlay.tsx:192
+#: src/pages/VoiceSettingsOverlay.tsx:196
 msgid "Speak only"
 msgstr "Nur sprechen"
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Speak this reply"
 msgstr "Diese Antwort vorlesen"
 
@@ -3281,7 +3295,7 @@ msgid "Starting"
 msgstr "Startet"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
-#: src/pages/ModelSettingsOverlay.tsx:630
+#: src/pages/ModelSettingsOverlay.tsx:634
 #: src/pages/Onboarding.tsx:554
 msgid "Starting…"
 msgstr "Wird gestartet…"
@@ -3290,11 +3304,11 @@ msgstr "Wird gestartet…"
 msgid "Steps"
 msgstr "Schritte"
 
-#: src/pages/Shell.tsx:3912
-#: src/pages/Shell.tsx:3917
-#: src/pages/Shell.tsx:4939
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:3926
+#: src/pages/Shell.tsx:3931
+#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Stop"
 msgstr "Stoppen"
 
@@ -3302,8 +3316,8 @@ msgstr "Stoppen"
 msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
 msgstr ""
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Stop speaking"
 msgstr "Vorlesen stoppen"
 
@@ -3321,20 +3335,20 @@ msgstr "Gestoppt."
 msgid "Stored encrypted"
 msgstr "Verschlüsselt gespeichert"
 
-#: src/pages/ModelSettingsOverlay.tsx:545
+#: src/pages/ModelSettingsOverlay.tsx:549
 msgid "Stored securely. Never shown here."
 msgstr "Sicher gespeichert. Hier nie angezeigt."
 
-#: src/pages/Shell.tsx:5383
+#: src/pages/Shell.tsx:5397
 msgid "subagent"
 msgstr "Subagent"
 
-#: src/pages/ModelSettingsOverlay.tsx:590
+#: src/pages/ModelSettingsOverlay.tsx:594
 #: src/pages/Onboarding.tsx:521
 msgid "Submit"
 msgstr "Absenden"
 
-#: src/pages/ModelSettingsOverlay.tsx:503
+#: src/pages/ModelSettingsOverlay.tsx:507
 #: src/pages/Onboarding.tsx:462
 msgid "Supports thinking"
 msgstr "Unterstützt Denkmodus"
@@ -3343,7 +3357,7 @@ msgstr "Unterstützt Denkmodus"
 msgid "Switch bot"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:723
+#: src/pages/ModelSettingsOverlay.tsx:727
 msgid "Switching…"
 msgstr "Wird gewechselt…"
 
@@ -3356,7 +3370,7 @@ msgstr "System"
 msgid "Teach a task"
 msgstr "Aufgabe anlernen"
 
-#: src/pages/Shell.tsx:3076
+#: src/pages/Shell.tsx:3086
 msgid "Teaching in progress. Stop teaching before sending a new message."
 msgstr "Aufgabe wird angelernt. Beende das Anlernen, bevor du eine neue Nachricht sendest."
 
@@ -3364,7 +3378,7 @@ msgstr "Aufgabe wird angelernt. Beende das Anlernen, bevor du eine neue Nachrich
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "Team Computer"
 msgstr "Team-Computer"
 
@@ -3394,7 +3408,7 @@ msgstr ""
 msgid "The API did not come back. Refresh this page."
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:241
+#: src/pages/MemorySettingsOverlay.tsx:245
 msgid "The selected memory provider is not available in this build."
 msgstr "Der ausgewählte Erinnerungsanbieter ist in diesem Build nicht verfügbar."
 
@@ -3402,7 +3416,7 @@ msgstr "Der ausgewählte Erinnerungsanbieter ist in diesem Build nicht verfügba
 msgid "Thinking"
 msgstr "Denkmodus"
 
-#: src/pages/Shell.tsx:5632
+#: src/pages/Shell.tsx:5646
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Dieser Bot wird auf diesem Computer und nicht auf einem Linux-Desktop ausgeführt. Shell und Dateien verwenden deinen persönlichen Ordner."
 
@@ -3455,7 +3469,7 @@ msgstr "Dieser Server ist bereits verbunden. Trenne zuerst die Verbindung, um ih
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools. A popup will open."
 msgstr "Dieser Server verwendet die Browseranmeldung. Autorisiere ihn, damit deine Agents seine Tools verwenden können. Ein Pop-up wird geöffnet."
 
-#: src/pages/ModelSettingsOverlay.tsx:705
+#: src/pages/ModelSettingsOverlay.tsx:709
 msgid "This subscription sign-in is not available in Rakazo yet. Use a deployment credential or choose another provider."
 msgstr "Diese Abonnementanmeldung ist in Rakazo noch nicht verfügbar. Verwende Zugangsdaten der Bereitstellung oder wähle einen anderen Anbieter."
 
@@ -3514,7 +3528,7 @@ msgid "Unpin"
 msgstr "Lösen"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1920
+#: src/pages/Shell.tsx:1930
 msgid "Unsupported file type: {0}"
 msgstr "Nicht unterstützter Dateityp: {0}"
 
@@ -3574,8 +3588,8 @@ msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:199
 #: src/pages/SettingsOverlay.tsx:96
-#: src/pages/Shell.tsx:2908
-#: src/pages/Shell.tsx:2919
+#: src/pages/Shell.tsx:2918
+#: src/pages/Shell.tsx:2929
 msgid "Usage"
 msgstr "Nutzung"
 
@@ -3583,7 +3597,7 @@ msgstr "Nutzung"
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} verwenden"
 
-#: src/pages/ModelSettingsOverlay.tsx:490
+#: src/pages/ModelSettingsOverlay.tsx:494
 #: src/pages/Onboarding.tsx:454
 msgid "Use a found model"
 msgstr "Gefundenes Modell verwenden"
@@ -3593,7 +3607,7 @@ msgstr "Gefundenes Modell verwenden"
 msgid "Use default guidance"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:725
+#: src/pages/ModelSettingsOverlay.tsx:729
 msgid "Use this model"
 msgstr "Dieses Modell verwenden"
 
@@ -3606,16 +3620,16 @@ msgid "Verifying…"
 msgstr "Wird geprüft…"
 
 #: src/pages/SettingsOverlay.tsx:95
-#: src/pages/Shell.tsx:4916
-#: src/pages/Shell.tsx:4917
+#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:4931
 #: src/pages/shell/bot-panel.tsx:482
-#: src/pages/VoiceSettingsOverlay.tsx:150
-#: src/pages/VoiceSettingsOverlay.tsx:249
+#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Voice"
 msgstr "Stimme"
 
-#: src/pages/ModelSettingsOverlay.tsx:594
-#: src/pages/ModelSettingsOverlay.tsx:616
+#: src/pages/ModelSettingsOverlay.tsx:598
+#: src/pages/ModelSettingsOverlay.tsx:620
 #: src/pages/Onboarding.tsx:525
 #: src/pages/Onboarding.tsx:547
 msgid "Waiting for sign-in…"
@@ -3687,8 +3701,8 @@ msgstr ""
 msgid "Working…"
 msgstr "Wird verarbeitet…"
 
-#: src/pages/Shell.tsx:1616
-#: src/pages/Shell.tsx:2393
+#: src/pages/Shell.tsx:1626
+#: src/pages/Shell.tsx:2403
 msgid "You"
 msgstr "Du"
 
@@ -3700,7 +3714,7 @@ msgstr "Du kannst diesen Tab schließen, wenn du nicht automatisch weitergeleite
 msgid "You can close this window."
 msgstr "Du kannst dieses Fenster schließen."
 
-#: src/pages/Shell.tsx:3901
+#: src/pages/Shell.tsx:3915
 msgid "You have control"
 msgstr "Du hast die Kontrolle"
 

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -13,22 +13,22 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2720
+#: src/pages/Shell.tsx:2730
 msgid " (unread)"
 msgstr " (unread)"
 
 #. placeholder {0}: group.entries.length
-#: src/pages/ModelSettingsOverlay.tsx:382
+#: src/pages/ModelSettingsOverlay.tsx:386
 msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# model} other {# models}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1822
+#: src/pages/Shell.tsx:1832
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1826
+#: src/pages/Shell.tsx:1836
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (over 10 MiB)"
 
@@ -80,11 +80,11 @@ msgid "{0} will still respond to direct mentions."
 msgstr "{0} will still respond to direct mentions."
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3245
+#: src/pages/Shell.tsx:3255
 msgid "{0}'s screen"
 msgstr "{0}'s screen"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "{botName}’s computer"
 msgstr "{botName}’s computer"
 
@@ -132,12 +132,12 @@ msgstr "{title}, {label}"
 msgid "{toolCount, plural, one {# tool} other {# tools}}"
 msgstr "{toolCount, plural, one {# tool} other {# tools}}"
 
-#: src/pages/Shell.tsx:4072
+#: src/pages/Shell.tsx:4086
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} is working"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4711
+#: src/pages/Shell.tsx:4725
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -155,7 +155,7 @@ msgstr "About groups"
 msgid "About spaces"
 msgstr "About spaces"
 
-#: src/components/integrations/IntegrationSetup.tsx:301
+#: src/components/integrations/IntegrationSetup.tsx:310
 msgid "Access token"
 msgstr "Access token"
 
@@ -188,7 +188,7 @@ msgstr "Action confirmations"
 msgid "Actions for {0}"
 msgstr "Actions for {0}"
 
-#: src/pages/Shell.tsx:3619
+#: src/pages/Shell.tsx:3629
 msgid "Actions for space"
 msgstr "Actions for space"
 
@@ -196,12 +196,12 @@ msgstr "Actions for space"
 msgid "Active"
 msgstr "Active"
 
-#: src/pages/ModelSettingsOverlay.tsx:337
+#: src/pages/ModelSettingsOverlay.tsx:341
 msgid "Active model"
 msgstr "Active model"
 
-#: src/pages/Shell.tsx:2440
-#: src/pages/Shell.tsx:2442
+#: src/pages/Shell.tsx:2450
+#: src/pages/Shell.tsx:2452
 msgid "Activity"
 msgstr "Activity"
 
@@ -215,11 +215,11 @@ msgstr "Add"
 msgid "Add a model in Settings to use this."
 msgstr "Add a model in Settings to use this."
 
-#: src/pages/Shell.tsx:3407
+#: src/pages/Shell.tsx:3417
 msgid "Add a run time for this one-shot."
 msgstr "Add a run time for this one-shot."
 
-#: src/pages/Shell.tsx:3385
+#: src/pages/Shell.tsx:3395
 msgid "Add a schedule, webhook, GitHub, or message trigger"
 msgstr "Add a schedule, webhook, GitHub, or message trigger"
 
@@ -259,7 +259,7 @@ msgstr "Add GraphQL endpoint"
 msgid "Add item"
 msgstr "Add item"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/PluginsOverlay.tsx:951
 msgid "Add MCP server"
 msgstr "Add MCP server"
@@ -277,12 +277,12 @@ msgstr "Add remote MCP server"
 msgid "Add server"
 msgstr "Add server"
 
-#: src/components/integrations/IntegrationSetup.tsx:269
+#: src/components/integrations/IntegrationSetup.tsx:278
 msgid "Add server URL"
 msgstr "Add server URL"
 
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Add thumbs-up"
 msgstr "Add thumbs-up"
 
@@ -311,7 +311,7 @@ msgstr "Adding…"
 
 #: src/pages/AccountSettingsOverlay.tsx:166
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/ModelSettingsOverlay.tsx:502
+#: src/pages/ModelSettingsOverlay.tsx:506
 #: src/pages/Onboarding.tsx:461
 #: src/pages/PluginsOverlay.tsx:836
 #: src/pages/RoutineSchedule.tsx:43
@@ -323,7 +323,7 @@ msgstr "Advanced"
 msgid "Advanced..."
 msgstr "Advanced..."
 
-#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3039
 msgid "Agent computer"
 msgstr "Agent computer"
 
@@ -405,15 +405,15 @@ msgid "API is back, but the update did not finish. Check the host logs."
 msgstr "API is back, but the update did not finish. Check the host logs."
 
 #: src/components/AskCard.tsx:44
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 #: src/lib/localized-provider-hint.ts:9
-#: src/pages/ModelSettingsOverlay.tsx:644
-#: src/pages/ModelSettingsOverlay.tsx:647
-#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:648
+#: src/pages/ModelSettingsOverlay.tsx:651
+#: src/pages/ModelSettingsOverlay.tsx:670
 #: src/pages/Onboarding.tsx:563
 #: src/pages/Onboarding.tsx:566
 #: src/pages/Onboarding.tsx:580
-#: src/pages/VoiceSettingsOverlay.tsx:219
+#: src/pages/VoiceSettingsOverlay.tsx:223
 msgid "API key"
 msgstr "API key"
 
@@ -444,15 +444,15 @@ msgstr "Approve this server to let your agent use its tools."
 msgid "Archive"
 msgstr "Archive"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5431
 msgid "archived"
 msgstr "archived"
 
-#: src/pages/Shell.tsx:2789
+#: src/pages/Shell.tsx:2799
 msgid "Archived"
 msgstr "Archived"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5442
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archived. Chat, memory, and files kept."
 
@@ -491,7 +491,7 @@ msgstr "Ask before purchases"
 msgid "Ask before sending external email"
 msgstr "Ask before sending external email"
 
-#: src/components/integrations/IntegrationSetup.tsx:219
+#: src/components/integrations/IntegrationSetup.tsx:228
 msgid "Ask the server owner to configure this provider."
 msgstr "Ask the server owner to configure this provider."
 
@@ -506,15 +506,15 @@ msgstr "at {0}"
 msgid "at {timeSelect}"
 msgstr "at {timeSelect}"
 
-#: src/pages/Shell.tsx:4791
+#: src/pages/Shell.tsx:4805
 msgid "Attach file"
 msgstr "Attach file"
 
-#: src/pages/Shell.tsx:5023
+#: src/pages/Shell.tsx:5037
 msgid "Attachment"
 msgstr "Attachment"
 
-#: src/pages/ModelSettingsOverlay.tsx:577
+#: src/pages/ModelSettingsOverlay.tsx:581
 #: src/pages/Onboarding.tsx:512
 msgid "Authorization code or callback URL"
 msgstr "Authorization code or callback URL"
@@ -567,23 +567,23 @@ msgstr "Base URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5644
+#: src/pages/Shell.tsx:5658
 msgid "Booting live desktop…"
 msgstr "Booting live desktop…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3877
 msgid "Booting up {0}’s computer"
 msgstr "Booting up {0}’s computer"
 
-#: src/pages/Shell.tsx:5292
-#: src/pages/Shell.tsx:5293
-#: src/pages/Shell.tsx:5421
+#: src/pages/Shell.tsx:5306
+#: src/pages/Shell.tsx:5307
+#: src/pages/Shell.tsx:5435
 msgid "bot"
 msgstr "bot"
 
 #: src/pages/IntegrationSetup.tsx:51
-#: src/pages/Shell.tsx:1617
+#: src/pages/Shell.tsx:1627
 msgid "Bot"
 msgstr "Bot"
 
@@ -592,11 +592,11 @@ msgstr "Bot"
 msgid "Bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:3971
+#: src/pages/Shell.tsx:3985
 msgid "Bot screen"
 msgstr "Bot screen"
 
-#: src/pages/Shell.tsx:3208
+#: src/pages/Shell.tsx:3218
 msgid "Bot screen preview"
 msgstr "Bot screen preview"
 
@@ -608,7 +608,7 @@ msgstr "Bot to link"
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first."
 msgstr "Bots act without asking by default. Add an exception only when you want to review a type of action first."
 
-#: src/pages/Shell.tsx:4073
+#: src/pages/Shell.tsx:4087
 msgid "Bots are working"
 msgstr "Bots are working"
 
@@ -620,7 +620,7 @@ msgstr "Browse MCP servers"
 msgid "Call"
 msgstr "Call"
 
-#: src/App.tsx:152
+#: src/App.tsx:159
 msgid "Can't reach the server."
 msgstr "Can't reach the server."
 
@@ -648,7 +648,7 @@ msgstr "Cancel new bot"
 msgid "Cancel new group"
 msgstr "Cancel new group"
 
-#: src/pages/Shell.tsx:4649
+#: src/pages/Shell.tsx:4663
 msgid "Cancel reply"
 msgstr "Cancel reply"
 
@@ -685,7 +685,7 @@ msgstr "Chat apps"
 msgid "Chat apps, group channels, and agent connections."
 msgstr "Chat apps, group channels, and agent connections."
 
-#: src/pages/Shell.tsx:4966
+#: src/pages/Shell.tsx:4980
 msgid "Chat Settings"
 msgstr "Chat Settings"
 
@@ -699,8 +699,8 @@ msgstr "Check failed"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/pages/Shell.tsx:3420
-#: src/pages/Shell.tsx:3432
+#: src/pages/Shell.tsx:3430
+#: src/pages/Shell.tsx:3442
 msgid "Check in."
 msgstr "Check in."
 
@@ -725,7 +725,7 @@ msgstr "Choose a bot…"
 msgid "Choose a new password"
 msgstr "Choose a new password"
 
-#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:312
 msgid "Choose which connected model Rakazo uses."
 msgstr "Choose which connected model Rakazo uses."
 
@@ -747,11 +747,11 @@ msgstr "Clear conversation"
 msgid "Clearing…"
 msgstr "Clearing…"
 
-#: src/components/integrations/IntegrationSetup.tsx:167
+#: src/components/integrations/IntegrationSetup.tsx:172
 msgid "Client ID"
 msgstr "Client ID"
 
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 msgid "Client secret"
 msgstr "Client secret"
 
@@ -768,7 +768,7 @@ msgstr "Close"
 msgid "Close chart"
 msgstr "Close chart"
 
-#: src/pages/Shell.tsx:3950
+#: src/pages/Shell.tsx:3964
 msgid "Close computer"
 msgstr "Close computer"
 
@@ -784,7 +784,7 @@ msgstr "Close integrations"
 msgid "Close MCP servers"
 msgstr "Close MCP servers"
 
-#: src/pages/MemorySettingsOverlay.tsx:164
+#: src/pages/MemorySettingsOverlay.tsx:168
 #: src/pages/SettingsOverlay.tsx:109
 msgid "Close memory settings"
 msgstr "Close memory settings"
@@ -793,16 +793,16 @@ msgstr "Close memory settings"
 msgid "Close messaging settings"
 msgstr "Close messaging settings"
 
-#: src/pages/ModelSettingsOverlay.tsx:324
+#: src/pages/ModelSettingsOverlay.tsx:328
 #: src/pages/SettingsOverlay.tsx:107
 msgid "Close model settings"
 msgstr "Close model settings"
 
-#: src/pages/Shell.tsx:2418
+#: src/pages/Shell.tsx:2428
 msgid "Close navigation"
 msgstr "Close navigation"
 
-#: src/pages/Shell.tsx:3186
+#: src/pages/Shell.tsx:3196
 msgid "Close panel"
 msgstr "Close panel"
 
@@ -815,7 +815,7 @@ msgid "Close user settings"
 msgstr "Close user settings"
 
 #: src/pages/SettingsOverlay.tsx:111
-#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:158
 msgid "Close voice settings"
 msgstr "Close voice settings"
 
@@ -828,7 +828,7 @@ msgid "Code"
 msgstr "Code"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2590
+#: src/pages/Shell.tsx:2600
 msgid "Collapse {0}"
 msgstr "Collapse {0}"
 
@@ -855,24 +855,24 @@ msgid "Complete"
 msgstr "Complete"
 
 #: src/pages/SettingsOverlay.tsx:97
-#: src/pages/Shell.tsx:5578
+#: src/pages/Shell.tsx:5592
 #: src/pages/shell/bot-panel.tsx:57
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5647
+#: src/pages/Shell.tsx:5661
 msgid "Computer failed to boot"
 msgstr "Computer failed to boot"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4008
 msgid "Computer is asleep"
 msgstr "Computer is asleep"
 
-#: src/pages/Shell.tsx:5646
+#: src/pages/Shell.tsx:5660
 msgid "Computer is asleep. Open it to wake."
 msgstr "Computer is asleep. Open it to wake."
 
-#: src/pages/Shell.tsx:5648
+#: src/pages/Shell.tsx:5662
 msgid "Computer is stopped"
 msgstr "Computer is stopped"
 
@@ -884,7 +884,7 @@ msgstr "Computers"
 msgid "Computers are off. Set SANDBOX_PROVIDER=docker with SANDBOX_SUPERVISOR_TOKEN, or set SANDBOX_PROVIDER to e2b, daytona, or box with its API key. Recreate the stack after changing .env."
 msgstr "Computers are off. Set SANDBOX_PROVIDER=docker with SANDBOX_SUPERVISOR_TOKEN, or set SANDBOX_PROVIDER to e2b, daytona, or box with its API key. Recreate the stack after changing .env."
 
-#: src/pages/ModelSettingsOverlay.tsx:344
+#: src/pages/ModelSettingsOverlay.tsx:348
 msgid "Configured by deployment"
 msgstr "Configured by deployment"
 
@@ -902,12 +902,12 @@ msgstr "Confirm delete"
 msgid "Confirm password"
 msgstr "Confirm password"
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:258
-#: src/components/integrations/IntegrationSetup.tsx:282
-#: src/components/integrations/IntegrationSetup.tsx:315
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:267
+#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:324
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
-#: src/pages/VoiceSettingsOverlay.tsx:241
+#: src/pages/VoiceSettingsOverlay.tsx:245
 msgid "Connect"
 msgstr "Connect"
 
@@ -915,7 +915,7 @@ msgstr "Connect"
 msgid "Connect a model"
 msgstr "Connect a model"
 
-#: src/pages/ModelSettingsOverlay.tsx:697
+#: src/pages/ModelSettingsOverlay.tsx:701
 msgid "Connect API key"
 msgstr "Connect API key"
 
@@ -931,7 +931,7 @@ msgstr "Connect MCP server “{name}”"
 msgid "Connect OAuth"
 msgstr "Connect OAuth"
 
-#: src/pages/ModelSettingsOverlay.tsx:547
+#: src/pages/ModelSettingsOverlay.tsx:551
 msgid "Connect this provider to use it as your personal model."
 msgstr "Connect this provider to use it as your personal model."
 
@@ -939,30 +939,30 @@ msgstr "Connect this provider to use it as your personal model."
 msgid "Connect Treg"
 msgstr "Connect Treg"
 
-#: src/components/integrations/IntegrationSetup.tsx:159
-#: src/components/integrations/IntegrationSetup.tsx:258
+#: src/components/integrations/IntegrationSetup.tsx:164
+#: src/components/integrations/IntegrationSetup.tsx:267
 #: src/pages/McpOAuthCallback.tsx:54
-#: src/pages/MemorySettingsOverlay.tsx:187
-#: src/pages/ModelSettingsOverlay.tsx:389
+#: src/pages/MemorySettingsOverlay.tsx:191
+#: src/pages/ModelSettingsOverlay.tsx:393
 #: src/pages/shell/message-cards.tsx:187
-#: src/pages/VoiceSettingsOverlay.tsx:198
+#: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Connected"
 
 #. placeholder {0}: credential.label
-#: src/pages/ModelSettingsOverlay.tsx:538
+#: src/pages/ModelSettingsOverlay.tsx:542
 msgid "Connected · {0}"
 msgstr "Connected · {0}"
 
 #. placeholder {0}: selected.name
-#: src/pages/VoiceSettingsOverlay.tsx:102
+#: src/pages/VoiceSettingsOverlay.tsx:106
 msgid "Connected {0}."
 msgstr "Connected {0}."
 
 #. placeholder {0}: selected.label
 #. placeholder {0}: selectedLabelRef.current ?? "this model"
-#: src/pages/ModelSettingsOverlay.tsx:82
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:84
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Connected and using {0}."
 msgstr "Connected and using {0}."
 
@@ -970,12 +970,12 @@ msgstr "Connected and using {0}."
 msgid "Connected. Its tools are available from your next message."
 msgstr "Connected. Its tools are available from your next message."
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/McpServersOverlay.tsx:38
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
 #: src/pages/shell/message-cards.tsx:360
-#: src/pages/VoiceSettingsOverlay.tsx:237
+#: src/pages/VoiceSettingsOverlay.tsx:241
 msgid "Connecting…"
 msgstr "Connecting…"
 
@@ -984,7 +984,7 @@ msgstr "Connecting…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "Connection to {0} is still pending. You can close this and check again."
 
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/Onboarding.tsx:604
 #: src/pages/Onboarding.tsx:667
 msgid "Continue"
@@ -998,7 +998,7 @@ msgstr "Continue in Background"
 msgid "Continue with email"
 msgstr "Continue with email"
 
-#: src/pages/Shell.tsx:5109
+#: src/pages/Shell.tsx:5123
 msgid "Copy"
 msgstr "Copy"
 
@@ -1022,7 +1022,7 @@ msgstr "Could not authorize this app"
 msgid "Could not change password"
 msgstr "Could not change password"
 
-#: src/pages/ModelSettingsOverlay.tsx:245
+#: src/pages/ModelSettingsOverlay.tsx:247
 msgid "Could not change the default model"
 msgstr "Could not change the default model"
 
@@ -1046,30 +1046,30 @@ msgstr "Could not complete OAuth"
 msgid "Could not complete the update. Try again."
 msgstr "Could not complete the update. Try again."
 
-#: src/components/integrations/IntegrationSetup.tsx:76
+#: src/components/integrations/IntegrationSetup.tsx:79
 #: src/pages/PluginsOverlay.tsx:264
 msgid "Could not connect"
 msgstr "Could not connect"
 
 #. placeholder {0}: registration.name
-#: src/pages/MemorySettingsOverlay.tsx:115
+#: src/pages/MemorySettingsOverlay.tsx:119
 msgid "Could not connect {0}"
 msgstr "Could not connect {0}"
 
-#: src/pages/ModelSettingsOverlay.tsx:284
+#: src/pages/ModelSettingsOverlay.tsx:286
 msgid "Could not connect this provider"
 msgstr "Could not connect this provider"
 
-#: src/pages/VoiceSettingsOverlay.tsx:104
+#: src/pages/VoiceSettingsOverlay.tsx:108
 msgid "Could not connect this voice provider"
 msgstr "Could not connect this voice provider"
 
-#: src/pages/Shell.tsx:875
+#: src/pages/Shell.tsx:885
 msgid "Could not connect to the computer screen"
 msgstr "Could not connect to the computer screen"
 
 #: src/pages/Auth.tsx:99
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2368
 msgid "Could not continue"
 msgstr "Could not continue"
 
@@ -1117,7 +1117,7 @@ msgstr "Could not delete skill"
 msgid "Could not delete space"
 msgstr "Could not delete space"
 
-#: src/pages/MemorySettingsOverlay.tsx:129
+#: src/pages/MemorySettingsOverlay.tsx:133
 msgid "Could not disconnect memory provider"
 msgstr "Could not disconnect memory provider"
 
@@ -1158,7 +1158,7 @@ msgstr "Could not load approval rules"
 msgid "Could not load bots. Reload to try again."
 msgstr "Could not load bots. Reload to try again."
 
-#: src/components/integrations/IntegrationSetup.tsx:67
+#: src/components/integrations/IntegrationSetup.tsx:70
 #: src/pages/PluginsOverlay.tsx:143
 #: src/pages/PluginsOverlay.tsx:719
 msgid "Could not load integrations"
@@ -1168,7 +1168,7 @@ msgstr "Could not load integrations"
 msgid "Could not load MCP servers"
 msgstr "Could not load MCP servers"
 
-#: src/pages/ModelSettingsOverlay.tsx:129
+#: src/pages/ModelSettingsOverlay.tsx:131
 msgid "Could not load model settings"
 msgstr "Could not load model settings"
 
@@ -1188,11 +1188,15 @@ msgstr "Could not load this file."
 msgid "Could not load update status"
 msgstr "Could not load update status"
 
-#: src/pages/VoiceSettingsOverlay.tsx:77
+#: src/pages/VoiceSettingsOverlay.tsx:81
 msgid "Could not load voice settings"
 msgstr "Could not load voice settings"
 
-#: src/pages/VoiceSettingsOverlay.tsx:138
+#: src/pages/LocalSettings.tsx:26
+msgid "Could not open local settings. Start the local server and create its owner account, then try again."
+msgstr "Could not open local settings. Start the local server and create its owner account, then try again."
+
+#: src/pages/VoiceSettingsOverlay.tsx:142
 msgid "Could not play a test clip"
 msgstr "Could not play a test clip"
 
@@ -1202,7 +1206,7 @@ msgstr "Could not play a test clip"
 msgid "Could not reach the server"
 msgstr "Could not reach the server"
 
-#: src/pages/ModelSettingsOverlay.tsx:229
+#: src/pages/ModelSettingsOverlay.tsx:231
 #: src/pages/Onboarding.tsx:191
 msgid "Could not reach this model server"
 msgstr "Could not reach this model server"
@@ -1240,7 +1244,7 @@ msgstr "Could not reset password"
 msgid "Could not revoke connection"
 msgstr "Could not revoke connection"
 
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3496
 msgid "Could not run routine"
 msgstr "Could not run routine"
 
@@ -1262,7 +1266,7 @@ msgstr "Could not save group"
 msgid "Could not save model"
 msgstr "Could not save model"
 
-#: src/pages/Shell.tsx:3457
+#: src/pages/Shell.tsx:3467
 msgid "Could not save routine"
 msgstr "Could not save routine"
 
@@ -1278,7 +1282,7 @@ msgstr "Could not save skill"
 msgid "Could not save that choice"
 msgstr "Could not save that choice"
 
-#: src/pages/VoiceSettingsOverlay.tsx:119
+#: src/pages/VoiceSettingsOverlay.tsx:123
 msgid "Could not save that voice"
 msgstr "Could not save that voice"
 
@@ -1310,7 +1314,7 @@ msgstr "Could not start teaching"
 msgid "Could not submit this answer"
 msgstr "Could not submit this answer"
 
-#: src/pages/Shell.tsx:2212
+#: src/pages/Shell.tsx:2222
 msgid "Could not take control"
 msgstr "Could not take control"
 
@@ -1326,11 +1330,11 @@ msgstr "Could not update agent access"
 msgid "Could not update computer"
 msgstr "Could not update computer"
 
-#: src/pages/Shell.tsx:1808
+#: src/pages/Shell.tsx:1818
 msgid "Could not update reaction"
 msgstr "Could not update reaction"
 
-#: src/pages/MemorySettingsOverlay.tsx:143
+#: src/pages/MemorySettingsOverlay.tsx:147
 msgid "Could not update the default memory scope"
 msgstr "Could not update the default memory scope"
 
@@ -1346,7 +1350,7 @@ msgstr "Couldn't update avatars"
 msgid "Couldn't update messaging settings"
 msgstr "Couldn't update messaging settings"
 
-#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2481
 #: src/pages/shell/bot-panel.tsx:184
 #: src/pages/shell/dialogs.tsx:208
 msgid "Create"
@@ -1460,8 +1464,8 @@ msgstr "Default scope"
 #: src/pages/KnowledgeSection.tsx:449
 #: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:301
-#: src/pages/Shell.tsx:2825
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2835
+#: src/pages/Shell.tsx:2866
 #: src/pages/shell/dialogs.tsx:351
 #: src/pages/shell/dialogs.tsx:412
 msgid "Delete"
@@ -1469,8 +1473,8 @@ msgstr "Delete"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2822
-#: src/pages/Shell.tsx:2853
+#: src/pages/Shell.tsx:2832
+#: src/pages/Shell.tsx:2863
 msgid "Delete {0}"
 msgstr "Delete {0}"
 
@@ -1489,11 +1493,11 @@ msgstr "Delete group"
 msgid "Delete memories too"
 msgstr "Delete memories too"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3643
 msgid "Delete space"
 msgstr "Delete space"
 
-#: src/pages/Shell.tsx:5419
+#: src/pages/Shell.tsx:5433
 msgid "deleted"
 msgstr "deleted"
 
@@ -1511,7 +1515,7 @@ msgstr "Denied"
 msgid "Deny"
 msgstr "Deny"
 
-#: src/pages/ModelSettingsOverlay.tsx:340
+#: src/pages/ModelSettingsOverlay.tsx:344
 msgid "Deployment default"
 msgstr "Deployment default"
 
@@ -1534,16 +1538,16 @@ msgstr "Desktop app"
 msgid "Desktop update"
 msgstr "Desktop update"
 
-#: src/components/integrations/IntegrationSetup.tsx:40
+#: src/components/integrations/IntegrationSetup.tsx:43
 msgid "Direct MCP"
 msgstr "Direct MCP"
 
 #: src/pages/McpServersOverlay.tsx:493
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnecting…"
 msgstr "Disconnecting…"
 
@@ -1553,7 +1557,7 @@ msgstr "Disconnecting…"
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: src/pages/Shell.tsx:4629
+#: src/pages/Shell.tsx:4643
 msgid "Dismiss error"
 msgstr "Dismiss error"
 
@@ -1601,7 +1605,7 @@ msgstr "Download {name}"
 msgid "Download as markdown"
 msgstr "Download as markdown"
 
-#: src/components/integrations/IntegrationSetup.tsx:327
+#: src/components/integrations/IntegrationSetup.tsx:336
 msgid "Download Executor"
 msgstr "Download Executor"
 
@@ -1617,7 +1621,7 @@ msgstr "Draft skill"
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: src/pages/Shell.tsx:5245
+#: src/pages/Shell.tsx:5259
 msgid "Earlier message"
 msgstr "Earlier message"
 
@@ -1638,7 +1642,7 @@ msgid "Engage when... Ignore..."
 msgstr "Engage when... Ignore..."
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
-#: src/pages/ModelSettingsOverlay.tsx:600
+#: src/pages/ModelSettingsOverlay.tsx:604
 #: src/pages/Onboarding.tsx:531
 msgid "Enter this code at <0>{0}</0>"
 msgstr "Enter this code at <0>{0}</0>"
@@ -1687,7 +1691,7 @@ msgid "Expand"
 msgstr "Expand"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2589
+#: src/pages/Shell.tsx:2599
 msgid "Expand {0}"
 msgstr "Expand {0}"
 
@@ -1716,14 +1720,14 @@ msgstr "failed"
 msgid "Failed"
 msgstr "Failed"
 
-#: src/pages/Shell.tsx:1981
-#: src/pages/Shell.tsx:1983
-#: src/pages/Shell.tsx:1985
+#: src/pages/Shell.tsx:1991
+#: src/pages/Shell.tsx:1993
+#: src/pages/Shell.tsx:1995
 msgid "Failed to send message"
 msgstr "Failed to send message"
 
-#: src/pages/Shell.tsx:2018
-#: src/pages/Shell.tsx:2037
+#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2047
 msgid "Failed to stop"
 msgstr "Failed to stop"
 
@@ -1736,18 +1740,18 @@ msgstr "Failed."
 msgid "Failure handling"
 msgstr "Failure handling"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Find models"
 msgstr "Find models"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Finding…"
 msgstr "Finding…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
-#: src/pages/ModelSettingsOverlay.tsx:560
+#: src/pages/ModelSettingsOverlay.tsx:564
 #: src/pages/Onboarding.tsx:495
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
@@ -1773,7 +1777,7 @@ msgstr "Flag unexpected actions"
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
-#: src/pages/ModelSettingsOverlay.tsx:1071
+#: src/pages/ModelSettingsOverlay.tsx:1075
 msgid "Free"
 msgstr "Free"
 
@@ -1786,7 +1790,7 @@ msgstr "Fullscreen"
 msgid "General"
 msgstr "General"
 
-#: src/components/integrations/IntegrationSetup.tsx:209
+#: src/components/integrations/IntegrationSetup.tsx:214
 msgid "Get credentials"
 msgstr "Get credentials"
 
@@ -1801,8 +1805,8 @@ msgid "Git event"
 msgstr "Git event"
 
 #: src/pages/MessagingSettingsOverlay.tsx:204
-#: src/pages/Shell.tsx:3019
-#: src/pages/Shell.tsx:3156
+#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3166
 msgid "Group"
 msgstr "Group"
 
@@ -1844,15 +1848,15 @@ msgstr "Header name"
 msgid "Header value"
 msgstr "Header value"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Hear a sample"
 msgstr "Hear a sample"
 
-#: src/pages/VoiceSettingsOverlay.tsx:131
+#: src/pages/VoiceSettingsOverlay.tsx:135
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hi, this is how I'll sound when I read replies out loud."
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Hide bots"
 msgstr "Hide bots"
 
@@ -1881,11 +1885,11 @@ msgstr "How often"
 msgid "How to check"
 msgstr "How to check"
 
-#: src/pages/Shell.tsx:5174
+#: src/pages/Shell.tsx:5188
 msgid "I’m done"
 msgstr "I’m done"
 
-#: src/pages/VoiceSettingsOverlay.tsx:136
+#: src/pages/VoiceSettingsOverlay.tsx:140
 msgid "If you heard that, voice is ready."
 msgstr "If you heard that, voice is ready."
 
@@ -1917,12 +1921,12 @@ msgstr "Instruction"
 msgid "Integration domain"
 msgstr "Integration domain"
 
-#: src/components/integrations/IntegrationSetup.tsx:133
+#: src/components/integrations/IntegrationSetup.tsx:136
 msgid "Integration options"
 msgstr "Integration options"
 
 #: src/pages/PluginsOverlay.tsx:679
-#: src/pages/Shell.tsx:2874
+#: src/pages/Shell.tsx:2884
 msgid "Integrations"
 msgstr "Integrations"
 
@@ -1952,11 +1956,11 @@ msgstr "Isolated"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 
-#: src/pages/Shell.tsx:4289
+#: src/pages/Shell.tsx:4303
 msgid "Jump to latest"
 msgstr "Jump to latest"
 
-#: src/pages/Shell.tsx:5240
+#: src/pages/Shell.tsx:5254
 msgid "Jump to replied message"
 msgstr "Jump to replied message"
 
@@ -2014,7 +2018,7 @@ msgstr "Listening"
 msgid "Listening…"
 msgstr "Listening…"
 
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Load earlier messages"
 msgstr "Load earlier messages"
 
@@ -2026,12 +2030,12 @@ msgstr "Loading activity…"
 msgid "Loading integrations…"
 msgstr "Loading integrations…"
 
-#: src/pages/MemorySettingsOverlay.tsx:182
+#: src/pages/MemorySettingsOverlay.tsx:186
 msgid "Loading memory settings…"
 msgstr "Loading memory settings…"
 
-#: src/pages/ModelSettingsOverlay.tsx:306
-#: src/pages/ModelSettingsOverlay.tsx:733
+#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:737
 msgid "Loading model catalog…"
 msgstr "Loading model catalog…"
 
@@ -2047,15 +2051,15 @@ msgstr "Loading rules…"
 msgid "Loading tools…"
 msgstr "Loading tools…"
 
-#: src/pages/VoiceSettingsOverlay.tsx:210
+#: src/pages/VoiceSettingsOverlay.tsx:214
 msgid "Loading voice providers…"
 msgstr "Loading voice providers…"
 
-#: src/App.tsx:58
+#: src/App.tsx:65
 #: src/pages/IntegrationSetup.tsx:72
 #: src/pages/Onboarding.tsx:282
 #: src/pages/PeerMessagesOverlay.tsx:98
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Loading…"
 msgstr "Loading…"
 
@@ -2067,7 +2071,11 @@ msgstr "Local"
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 
-#: src/pages/Shell.tsx:2932
+#: src/pages/LocalSettings.tsx:22
+msgid "Local Server Settings"
+msgstr "Local Server Settings"
+
+#: src/pages/Shell.tsx:2942
 msgid "Log out"
 msgstr "Log out"
 
@@ -2083,8 +2091,8 @@ msgstr "Manage MCP servers"
 msgid "Manage messaging settings"
 msgstr "Manage messaging settings"
 
-#: src/pages/MemorySettingsOverlay.tsx:159
-#: src/pages/MemorySettingsOverlay.tsx:173
+#: src/pages/MemorySettingsOverlay.tsx:163
+#: src/pages/MemorySettingsOverlay.tsx:177
 msgid "Manage the Space semantic memory provider."
 msgstr "Manage the Space semantic memory provider."
 
@@ -2125,7 +2133,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/KnowledgeSection.tsx:39
-#: src/pages/MemorySettingsOverlay.tsx:155
+#: src/pages/MemorySettingsOverlay.tsx:159
 #: src/pages/SettingsOverlay.tsx:94
 msgid "Memory"
 msgstr "Memory"
@@ -2134,7 +2142,7 @@ msgstr "Memory"
 msgid "Memory scope"
 msgstr "Memory scope"
 
-#: src/pages/Shell.tsx:4697
+#: src/pages/Shell.tsx:4711
 msgid "Mentions"
 msgstr "Mentions"
 
@@ -2142,8 +2150,8 @@ msgstr "Mentions"
 msgid "Mentions only"
 msgstr "Mentions only"
 
-#: src/pages/Shell.tsx:4898
-#: src/pages/Shell.tsx:5025
+#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:5039
 msgid "Message"
 msgstr "Message"
 
@@ -2152,12 +2160,12 @@ msgstr "Message"
 msgid "Message"
 msgstr "Message"
 
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4898
+#: src/pages/Shell.tsx:4908
+#: src/pages/Shell.tsx:4912
 msgid "Message {activeName}"
 msgstr "Message {activeName}"
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4623
 msgid "Message composer"
 msgstr "Message composer"
 
@@ -2166,15 +2174,15 @@ msgstr "Message composer"
 msgid "Message event"
 msgstr "Message event"
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Message from {peer}"
 msgstr "Message from {peer}"
 
-#: src/pages/Shell.tsx:4895
+#: src/pages/Shell.tsx:4909
 msgid "Message…"
 msgstr "Message…"
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Messaged {peer}"
 msgstr "Messaged {peer}"
 
@@ -2195,8 +2203,8 @@ msgstr "Minimal"
 msgid "Minimize"
 msgstr "Minimize"
 
-#: src/pages/Shell.tsx:2461
-#: src/pages/Shell.tsx:2462
+#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2472
 msgid "Minimize bots"
 msgstr "Minimize bots"
 
@@ -2208,9 +2216,9 @@ msgstr "minute"
 msgid "minutes"
 msgstr "minutes"
 
-#: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/ModelSettingsOverlay.tsx:509
-#: src/pages/ModelSettingsOverlay.tsx:959
+#: src/pages/ModelSettingsOverlay.tsx:448
+#: src/pages/ModelSettingsOverlay.tsx:513
+#: src/pages/ModelSettingsOverlay.tsx:963
 #: src/pages/Onboarding.tsx:420
 #: src/pages/Onboarding.tsx:468
 #: src/pages/Onboarding.tsx:476
@@ -2218,12 +2226,12 @@ msgstr "minutes"
 msgid "Model"
 msgstr "Model"
 
-#: src/pages/ModelSettingsOverlay.tsx:478
+#: src/pages/ModelSettingsOverlay.tsx:482
 #: src/pages/Onboarding.tsx:442
 msgid "Model id"
 msgstr "Model id"
 
-#: src/pages/ModelSettingsOverlay.tsx:995
+#: src/pages/ModelSettingsOverlay.tsx:999
 msgid "Model options"
 msgstr "Model options"
 
@@ -2235,16 +2243,21 @@ msgstr "Model providers"
 msgid "Model spend uses your provider keys."
 msgstr "Model spend uses your provider keys."
 
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Model updated."
 msgstr "Model updated."
 
-#: src/pages/ModelSettingsOverlay.tsx:317
+#: src/pages/LocalSettings.tsx:36
+#: src/pages/ModelSettingsOverlay.tsx:321
 #: src/pages/SettingsOverlay.tsx:93
 msgid "Models"
 msgstr "Models"
 
-#: src/pages/ModelSettingsOverlay.tsx:457
+#: src/pages/ModelSettingsOverlay.tsx:310
+msgid "Models for the server owner’s default space."
+msgstr "Models for the server owner’s default space."
+
+#: src/pages/ModelSettingsOverlay.tsx:461
 #: src/pages/Onboarding.tsx:426
 msgid "Models from server"
 msgstr "Models from server"
@@ -2253,7 +2266,7 @@ msgstr "Models from server"
 msgid "Monthly"
 msgstr "Monthly"
 
-#: src/pages/Shell.tsx:5082
+#: src/pages/Shell.tsx:5096
 msgid "More"
 msgstr "More"
 
@@ -2303,7 +2316,7 @@ msgstr "Needs input"
 msgid "Needs takeover"
 msgstr "Needs takeover"
 
-#: src/pages/Shell.tsx:3897
+#: src/pages/Shell.tsx:3911
 msgid "Needs you"
 msgstr "Needs you"
 
@@ -2381,7 +2394,7 @@ msgstr "No longer active"
 msgid "No managed app catalog is configured on this deployment."
 msgstr "No managed app catalog is configured on this deployment."
 
-#: src/pages/ModelSettingsOverlay.tsx:1023
+#: src/pages/ModelSettingsOverlay.tsx:1027
 msgid "No matching models"
 msgstr "No matching models"
 
@@ -2397,7 +2410,7 @@ msgstr "No MCP servers yet."
 msgid "No messages with {peerBotName} yet."
 msgstr "No messages with {peerBotName} yet."
 
-#: src/pages/ModelSettingsOverlay.tsx:737
+#: src/pages/ModelSettingsOverlay.tsx:741
 msgid "No model catalog is available."
 msgstr "No model catalog is available."
 
@@ -2405,11 +2418,11 @@ msgstr "No model catalog is available."
 msgid "No providers found"
 msgstr "No providers found"
 
-#: src/pages/ModelSettingsOverlay.tsx:397
+#: src/pages/ModelSettingsOverlay.tsx:401
 msgid "No providers found."
 msgstr "No providers found."
 
-#: src/components/integrations/IntegrationSetup.tsx:264
+#: src/components/integrations/IntegrationSetup.tsx:273
 msgid "No remote MCP servers found"
 msgstr "No remote MCP servers found"
 
@@ -2442,7 +2455,7 @@ msgstr "No trigger"
 msgid "None yet"
 msgstr "None yet"
 
-#: src/pages/ModelSettingsOverlay.tsx:540
+#: src/pages/ModelSettingsOverlay.tsx:544
 msgid "Not connected"
 msgstr "Not connected"
 
@@ -2463,7 +2476,7 @@ msgid "Now"
 msgstr "Now"
 
 #. placeholder {0}: selected.label
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Now using {0}."
 msgstr "Now using {0}."
 
@@ -2496,26 +2509,26 @@ msgstr "on the 1st at {0}"
 msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
 msgstr "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
 
-#: src/pages/Shell.tsx:3671
+#: src/pages/Shell.tsx:3681
 msgid "Only empty spaces can be deleted. Delete its bots and groups first."
 msgstr "Only empty spaces can be deleted. Delete its bots and groups first."
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3234
-#: src/pages/Shell.tsx:3239
+#: src/pages/Shell.tsx:3244
+#: src/pages/Shell.tsx:3249
 msgid "Open"
 msgstr "Open"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2597
 msgid "Open {0}"
 msgstr "Open {0}"
 
-#: src/pages/Shell.tsx:3202
+#: src/pages/Shell.tsx:3212
 msgid "Open in full window"
 msgstr "Open in full window"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3001
 msgid "Open navigation"
 msgstr "Open navigation"
 
@@ -2523,20 +2536,20 @@ msgstr "Open navigation"
 msgid "Open work"
 msgstr "Open work"
 
-#: src/pages/ModelSettingsOverlay.tsx:417
+#: src/pages/ModelSettingsOverlay.tsx:421
 #: src/pages/Onboarding.tsx:395
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-compatible server URL"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5444
 msgid "Opened its thread."
 msgstr "Opened its thread."
 
-#: src/App.tsx:195
+#: src/App.tsx:202
 msgid "Opening your Space…"
 msgstr "Opening your Space…"
 
-#: src/pages/ModelSettingsOverlay.tsx:650
+#: src/pages/ModelSettingsOverlay.tsx:654
 #: src/pages/Onboarding.tsx:569
 msgid "Optional"
 msgstr "Optional"
@@ -2549,7 +2562,7 @@ msgstr "Optional controls most people never need"
 msgid "Optional header value"
 msgstr "Optional header value"
 
-#: src/pages/ModelSettingsOverlay.tsx:664
+#: src/pages/ModelSettingsOverlay.tsx:668
 msgid "Or connect an API key"
 msgstr "Or connect an API key"
 
@@ -2565,7 +2578,7 @@ msgstr "Organic"
 msgid "Organization API key"
 msgstr "Organization API key"
 
-#: src/pages/ModelSettingsOverlay.tsx:465
+#: src/pages/ModelSettingsOverlay.tsx:469
 #: src/pages/Onboarding.tsx:435
 msgid "Other model…"
 msgstr "Other model…"
@@ -2600,16 +2613,16 @@ msgstr "Password updated"
 msgid "Passwords do not match"
 msgstr "Passwords do not match"
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste a replacement key"
 msgstr "Paste a replacement key"
 
-#: src/pages/ModelSettingsOverlay.tsx:428
+#: src/pages/ModelSettingsOverlay.tsx:432
 #: src/pages/Onboarding.tsx:406
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste your API key"
 msgstr "Paste your API key"
 
@@ -2617,7 +2630,7 @@ msgstr "Paste your API key"
 msgid "Paused"
 msgstr "Paused"
 
-#: src/pages/ModelSettingsOverlay.tsx:534
+#: src/pages/ModelSettingsOverlay.tsx:538
 msgid "Personal credential"
 msgstr "Personal credential"
 
@@ -2625,7 +2638,7 @@ msgstr "Personal credential"
 msgid "Pin"
 msgstr "Pin"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Playing…"
 msgstr "Playing…"
 
@@ -2642,17 +2655,17 @@ msgstr "Preview {0}"
 msgid "Private"
 msgstr "Private"
 
-#: src/components/integrations/IntegrationSetup.tsx:177
+#: src/components/integrations/IntegrationSetup.tsx:182
 msgid "Project ID"
 msgstr "Project ID"
 
-#: src/pages/MemorySettingsOverlay.tsx:215
+#: src/pages/MemorySettingsOverlay.tsx:219
 #: src/pages/Onboarding.tsx:292
 msgid "Provider"
 msgstr "Provider"
 
-#: src/pages/ModelSettingsOverlay.tsx:352
-#: src/pages/VoiceSettingsOverlay.tsx:166
+#: src/pages/ModelSettingsOverlay.tsx:356
+#: src/pages/VoiceSettingsOverlay.tsx:170
 msgid "Providers"
 msgstr "Providers"
 
@@ -2684,7 +2697,7 @@ msgstr "Recent"
 msgid "Reconnect OAuth"
 msgstr "Reconnect OAuth"
 
-#: src/App.tsx:150
+#: src/App.tsx:157
 #: src/components/ComputerUpdateProgress.tsx:54
 msgid "Reconnecting"
 msgstr "Reconnecting"
@@ -2747,7 +2760,7 @@ msgstr "Refresh view"
 msgid "Refreshing…"
 msgstr "Refreshing…"
 
-#: src/pages/Shell.tsx:5164
+#: src/pages/Shell.tsx:5178
 msgid "Release"
 msgstr "Release"
 
@@ -2767,7 +2780,7 @@ msgid "Remove"
 msgstr "Remove"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4683
+#: src/pages/Shell.tsx:4697
 msgid "Remove {0}"
 msgstr "Remove {0}"
 
@@ -2776,7 +2789,7 @@ msgid "Remove Git event"
 msgstr "Remove Git event"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4845
 msgid "Remove mention {0}"
 msgstr "Remove mention {0}"
 
@@ -2789,13 +2802,13 @@ msgid "Remove schedule"
 msgstr "Remove schedule"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4824
 msgid "Remove skill {0}"
 msgstr "Remove skill {0}"
 
-#: src/pages/Shell.tsx:4262
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:4276
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Remove thumbs-up"
 msgstr "Remove thumbs-up"
 
@@ -2803,7 +2816,7 @@ msgstr "Remove thumbs-up"
 msgid "Remove webhook"
 msgstr "Remove webhook"
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5443
 msgid "Removed with chat, computer, and memory."
 msgstr "Removed with chat, computer, and memory."
 
@@ -2822,21 +2835,21 @@ msgstr "Removing…"
 msgid "Reopen"
 msgstr "Reopen"
 
-#: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/ModelSettingsOverlay.tsx:695
+#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:699
 msgid "Replace API key"
 msgstr "Replace API key"
 
-#: src/pages/VoiceSettingsOverlay.tsx:239
+#: src/pages/VoiceSettingsOverlay.tsx:243
 msgid "Replace key"
 msgstr "Replace key"
 
-#: src/pages/Shell.tsx:5074
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5088
+#: src/pages/Shell.tsx:5119
 msgid "Reply"
 msgstr "Reply"
 
-#: src/pages/Shell.tsx:4646
+#: src/pages/Shell.tsx:4660
 msgid "Replying to {replyName}"
 msgstr "Replying to {replyName}"
 
@@ -2870,8 +2883,8 @@ msgstr "Resetting…"
 msgid "Restart to update"
 msgstr "Restart to update"
 
-#: src/pages/Shell.tsx:2816
-#: src/pages/Shell.tsx:2847
+#: src/pages/Shell.tsx:2826
+#: src/pages/Shell.tsx:2857
 msgid "Restore"
 msgstr "Restore"
 
@@ -2883,12 +2896,12 @@ msgstr "Restore the last saved workspace. Unsaved work on the computer is lost."
 msgid "Restoring your workspace"
 msgstr "Restoring your workspace"
 
-#: src/App.tsx:164
+#: src/App.tsx:171
 #: src/pages/PeerMessagesOverlay.tsx:109
 msgid "Retry now"
 msgstr "Retry now"
 
-#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2398
 msgid "Retry screen"
 msgstr "Retry screen"
 
@@ -2918,8 +2931,8 @@ msgid "Rotate key"
 msgstr "Rotate key"
 
 #: src/pages/RoutineEditor.tsx:265
-#: src/pages/Shell.tsx:3419
-#: src/pages/Shell.tsx:3431
+#: src/pages/Shell.tsx:3429
+#: src/pages/Shell.tsx:3441
 msgid "Routine"
 msgstr "Routine"
 
@@ -2936,7 +2949,7 @@ msgstr "Run at"
 msgid "Run history"
 msgstr "Run history"
 
-#: src/pages/Shell.tsx:3412
+#: src/pages/Shell.tsx:3422
 msgid "Run time must be in the future."
 msgstr "Run time must be in the future."
 
@@ -2966,7 +2979,7 @@ msgstr "Runs when this bot receives a verified message from this provider."
 #: src/pages/GroupPanel.tsx:236
 #: src/pages/KnowledgeSection.tsx:203
 #: src/pages/KnowledgeSection.tsx:422
-#: src/pages/ModelSettingsOverlay.tsx:693
+#: src/pages/ModelSettingsOverlay.tsx:697
 #: src/pages/RoutineEditor.tsx:489
 #: src/pages/shell/bot-panel.tsx:539
 msgid "Save"
@@ -2983,7 +2996,7 @@ msgstr "Saved"
 msgid "Saved, but list refresh failed"
 msgstr "Saved, but list refresh failed"
 
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Saved."
 msgstr "Saved."
 
@@ -3002,7 +3015,7 @@ msgstr "Saving..."
 #: src/components/AskCard.tsx:157
 #: src/components/teach/SkillDraftCard.tsx:142
 #: src/pages/GroupPanel.tsx:236
-#: src/pages/ModelSettingsOverlay.tsx:691
+#: src/pages/ModelSettingsOverlay.tsx:695
 #: src/pages/RoutineEditor.tsx:489
 msgid "Saving…"
 msgstr "Saving…"
@@ -3016,15 +3029,15 @@ msgstr "Say something. Silence sends it."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "Say yes or no, or answer in a sentence."
 
-#: src/pages/ModelSettingsOverlay.tsx:984
+#: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
-#: src/pages/Shell.tsx:2530
+#: src/pages/Shell.tsx:2540
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "Search"
 
-#: src/components/integrations/IntegrationSetup.tsx:241
-#: src/components/integrations/IntegrationSetup.tsx:242
+#: src/components/integrations/IntegrationSetup.tsx:250
+#: src/components/integrations/IntegrationSetup.tsx:251
 #: src/pages/PluginsOverlay.tsx:696
 #: src/pages/PluginsOverlay.tsx:697
 msgid "Search apps"
@@ -3038,11 +3051,11 @@ msgstr "Search bots and switch conversations"
 msgid "Search by domain"
 msgstr "Search by domain"
 
-#: src/components/integrations/IntegrationSetup.tsx:247
+#: src/components/integrations/IntegrationSetup.tsx:256
 msgid "Search integrations.sh"
 msgstr "Search integrations.sh"
 
-#: src/pages/ModelSettingsOverlay.tsx:979
+#: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr "Search models"
 
@@ -3051,8 +3064,8 @@ msgstr "Search models"
 msgid "Search or create Bots"
 msgstr "Search or create Bots"
 
-#: src/pages/ModelSettingsOverlay.tsx:355
-#: src/pages/ModelSettingsOverlay.tsx:361
+#: src/pages/ModelSettingsOverlay.tsx:359
+#: src/pages/ModelSettingsOverlay.tsx:365
 msgid "Search providers"
 msgstr "Search providers"
 
@@ -3066,7 +3079,7 @@ msgstr "Search providers and models"
 msgid "Searching…"
 msgstr "Searching…"
 
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3030
 msgid "Select a bot"
 msgstr "Select a bot"
 
@@ -3074,8 +3087,8 @@ msgstr "Select a bot"
 msgid "Selected"
 msgstr "Selected"
 
-#: src/pages/Shell.tsx:4929
-#: src/pages/Shell.tsx:4950
+#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4964
 msgid "Send"
 msgstr "Send"
 
@@ -3105,8 +3118,9 @@ msgstr "Sending…"
 msgid "Sentry alert"
 msgstr "Sentry alert"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/AccountSettingsOverlay.tsx:158
+#: src/pages/LocalSettings.tsx:42
 msgid "Server integrations"
 msgstr "Server integrations"
 
@@ -3114,33 +3128,33 @@ msgstr "Server integrations"
 msgid "Server name"
 msgstr "Server name"
 
-#: src/components/integrations/IntegrationSetup.tsx:273
-#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:282
+#: src/components/integrations/IntegrationSetup.tsx:300
 #: src/pages/McpServersOverlay.tsx:329
-#: src/pages/ModelSettingsOverlay.tsx:412
+#: src/pages/ModelSettingsOverlay.tsx:416
 #: src/pages/Onboarding.tsx:390
 msgid "Server URL"
 msgstr "Server URL"
 
 #: src/pages/MessagingSettingsOverlay.tsx:361
 #: src/pages/SettingsOverlay.tsx:103
-#: src/pages/SettingsOverlay.tsx:151
-#: src/pages/Shell.tsx:2896
-#: src/pages/Shell.tsx:2903
-#: src/pages/Shell.tsx:3152
+#: src/pages/SettingsOverlay.tsx:158
+#: src/pages/Shell.tsx:2906
+#: src/pages/Shell.tsx:2913
+#: src/pages/Shell.tsx:3162
 msgid "Settings"
 msgstr "Settings"
 
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4982
 msgid "Settings: General"
 msgstr "Settings: General"
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4984
 msgid "Settings: Usage"
 msgstr "Settings: Usage"
 
-#: src/components/integrations/IntegrationSetup.tsx:319
-#: src/pages/ModelSettingsOverlay.tsx:425
+#: src/components/integrations/IntegrationSetup.tsx:328
+#: src/pages/ModelSettingsOverlay.tsx:429
 #: src/pages/Onboarding.tsx:403
 msgid "Setup help"
 msgstr "Setup help"
@@ -3158,11 +3172,11 @@ msgstr "Shared documents"
 msgid "Show all providers"
 msgstr "Show all providers"
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Show bots"
 msgstr "Show bots"
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show computer"
 msgstr "Show computer"
 
@@ -3178,14 +3192,14 @@ msgstr "Show password"
 msgid "Show popular providers"
 msgstr "Show popular providers"
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show settings"
 msgstr "Show settings"
 
 #: src/lib/localized-provider-hint.ts:7
 #: src/pages/Auth.tsx:230
 #: src/pages/Auth.tsx:288
-#: src/pages/ModelSettingsOverlay.tsx:632
+#: src/pages/ModelSettingsOverlay.tsx:636
 #: src/pages/Onboarding.tsx:152
 msgid "Sign in"
 msgstr "Sign in"
@@ -3200,7 +3214,7 @@ msgid "Sign up"
 msgstr "Sign up"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4758
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
@@ -3208,8 +3222,8 @@ msgstr "Skill {0}"
 msgid "Skills"
 msgstr "Skills"
 
-#: src/components/integrations/IntegrationSetup.tsx:355
-#: src/pages/Shell.tsx:5171
+#: src/components/integrations/IntegrationSetup.tsx:364
+#: src/pages/Shell.tsx:5185
 msgid "Skip"
 msgstr "Skip"
 
@@ -3218,7 +3232,7 @@ msgid "Skip or deploy key"
 msgstr "Skip or deploy key"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1842
+#: src/pages/Shell.tsx:1852
 msgid "Skipped {0}"
 msgstr "Skipped {0}"
 
@@ -3250,21 +3264,21 @@ msgstr "Space interrupts · Esc hangs up"
 msgid "Spaces"
 msgstr "Spaces"
 
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Speak"
 msgstr "Speak"
 
-#: src/pages/VoiceSettingsOverlay.tsx:190
+#: src/pages/VoiceSettingsOverlay.tsx:194
 msgid "Speak + transcribe"
 msgstr "Speak + transcribe"
 
-#: src/pages/VoiceSettingsOverlay.tsx:192
+#: src/pages/VoiceSettingsOverlay.tsx:196
 msgid "Speak only"
 msgstr "Speak only"
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Speak this reply"
 msgstr "Speak this reply"
 
@@ -3281,7 +3295,7 @@ msgid "Starting"
 msgstr "Starting"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
-#: src/pages/ModelSettingsOverlay.tsx:630
+#: src/pages/ModelSettingsOverlay.tsx:634
 #: src/pages/Onboarding.tsx:554
 msgid "Starting…"
 msgstr "Starting…"
@@ -3290,11 +3304,11 @@ msgstr "Starting…"
 msgid "Steps"
 msgstr "Steps"
 
-#: src/pages/Shell.tsx:3912
-#: src/pages/Shell.tsx:3917
-#: src/pages/Shell.tsx:4939
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:3926
+#: src/pages/Shell.tsx:3931
+#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Stop"
 msgstr "Stop"
 
@@ -3302,8 +3316,8 @@ msgstr "Stop"
 msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
 msgstr "Stop all workers and confirm that provider operations have stopped before releasing this computer."
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Stop speaking"
 msgstr "Stop speaking"
 
@@ -3321,20 +3335,20 @@ msgstr "Stopped."
 msgid "Stored encrypted"
 msgstr "Stored encrypted"
 
-#: src/pages/ModelSettingsOverlay.tsx:545
+#: src/pages/ModelSettingsOverlay.tsx:549
 msgid "Stored securely. Never shown here."
 msgstr "Stored securely. Never shown here."
 
-#: src/pages/Shell.tsx:5383
+#: src/pages/Shell.tsx:5397
 msgid "subagent"
 msgstr "subagent"
 
-#: src/pages/ModelSettingsOverlay.tsx:590
+#: src/pages/ModelSettingsOverlay.tsx:594
 #: src/pages/Onboarding.tsx:521
 msgid "Submit"
 msgstr "Submit"
 
-#: src/pages/ModelSettingsOverlay.tsx:503
+#: src/pages/ModelSettingsOverlay.tsx:507
 #: src/pages/Onboarding.tsx:462
 msgid "Supports thinking"
 msgstr "Supports thinking"
@@ -3343,7 +3357,7 @@ msgstr "Supports thinking"
 msgid "Switch bot"
 msgstr "Switch bot"
 
-#: src/pages/ModelSettingsOverlay.tsx:723
+#: src/pages/ModelSettingsOverlay.tsx:727
 msgid "Switching…"
 msgstr "Switching…"
 
@@ -3356,7 +3370,7 @@ msgstr "System"
 msgid "Teach a task"
 msgstr "Teach a task"
 
-#: src/pages/Shell.tsx:3076
+#: src/pages/Shell.tsx:3086
 msgid "Teaching in progress. Stop teaching before sending a new message."
 msgstr "Teaching in progress. Stop teaching before sending a new message."
 
@@ -3364,7 +3378,7 @@ msgstr "Teaching in progress. Stop teaching before sending a new message."
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "Team Computer"
 msgstr "Team Computer"
 
@@ -3394,7 +3408,7 @@ msgstr "Test run"
 msgid "The API did not come back. Refresh this page."
 msgstr "The API did not come back. Refresh this page."
 
-#: src/pages/MemorySettingsOverlay.tsx:241
+#: src/pages/MemorySettingsOverlay.tsx:245
 msgid "The selected memory provider is not available in this build."
 msgstr "The selected memory provider is not available in this build."
 
@@ -3402,7 +3416,7 @@ msgstr "The selected memory provider is not available in this build."
 msgid "Thinking"
 msgstr "Thinking"
 
-#: src/pages/Shell.tsx:5632
+#: src/pages/Shell.tsx:5646
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 
@@ -3455,7 +3469,7 @@ msgstr "This server is already connected. Disconnect it first to authorize again
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools. A popup will open."
 msgstr "This server uses browser sign-in. Authorize it to let your agents use its tools. A popup will open."
 
-#: src/pages/ModelSettingsOverlay.tsx:705
+#: src/pages/ModelSettingsOverlay.tsx:709
 msgid "This subscription sign-in is not available in Rakazo yet. Use a deployment credential or choose another provider."
 msgstr "This subscription sign-in is not available in Rakazo yet. Use a deployment credential or choose another provider."
 
@@ -3514,7 +3528,7 @@ msgid "Unpin"
 msgstr "Unpin"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1920
+#: src/pages/Shell.tsx:1930
 msgid "Unsupported file type: {0}"
 msgstr "Unsupported file type: {0}"
 
@@ -3574,8 +3588,8 @@ msgstr "Updating…"
 
 #: src/pages/AccountSettingsOverlay.tsx:199
 #: src/pages/SettingsOverlay.tsx:96
-#: src/pages/Shell.tsx:2908
-#: src/pages/Shell.tsx:2919
+#: src/pages/Shell.tsx:2918
+#: src/pages/Shell.tsx:2929
 msgid "Usage"
 msgstr "Usage"
 
@@ -3583,7 +3597,7 @@ msgstr "Usage"
 msgid "Use {hostLabel}"
 msgstr "Use {hostLabel}"
 
-#: src/pages/ModelSettingsOverlay.tsx:490
+#: src/pages/ModelSettingsOverlay.tsx:494
 #: src/pages/Onboarding.tsx:454
 msgid "Use a found model"
 msgstr "Use a found model"
@@ -3593,7 +3607,7 @@ msgstr "Use a found model"
 msgid "Use default guidance"
 msgstr "Use default guidance"
 
-#: src/pages/ModelSettingsOverlay.tsx:725
+#: src/pages/ModelSettingsOverlay.tsx:729
 msgid "Use this model"
 msgstr "Use this model"
 
@@ -3606,16 +3620,16 @@ msgid "Verifying…"
 msgstr "Verifying…"
 
 #: src/pages/SettingsOverlay.tsx:95
-#: src/pages/Shell.tsx:4916
-#: src/pages/Shell.tsx:4917
+#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:4931
 #: src/pages/shell/bot-panel.tsx:482
-#: src/pages/VoiceSettingsOverlay.tsx:150
-#: src/pages/VoiceSettingsOverlay.tsx:249
+#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Voice"
 msgstr "Voice"
 
-#: src/pages/ModelSettingsOverlay.tsx:594
-#: src/pages/ModelSettingsOverlay.tsx:616
+#: src/pages/ModelSettingsOverlay.tsx:598
+#: src/pages/ModelSettingsOverlay.tsx:620
 #: src/pages/Onboarding.tsx:525
 #: src/pages/Onboarding.tsx:547
 msgid "Waiting for sign-in…"
@@ -3687,8 +3701,8 @@ msgstr "Workers and operations are stopped"
 msgid "Working…"
 msgstr "Working…"
 
-#: src/pages/Shell.tsx:1616
-#: src/pages/Shell.tsx:2393
+#: src/pages/Shell.tsx:1626
+#: src/pages/Shell.tsx:2403
 msgid "You"
 msgstr "You"
 
@@ -3700,7 +3714,7 @@ msgstr "You can close this tab if it does not redirect automatically."
 msgid "You can close this window."
 msgstr "You can close this window."
 
-#: src/pages/Shell.tsx:3901
+#: src/pages/Shell.tsx:3915
 msgid "You have control"
 msgstr "You have control"
 

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -13,22 +13,22 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/pages/Shell.tsx:2720
+#: src/pages/Shell.tsx:2730
 msgid " (unread)"
 msgstr " (sin leer)"
 
 #. placeholder {0}: group.entries.length
-#: src/pages/ModelSettingsOverlay.tsx:382
+#: src/pages/ModelSettingsOverlay.tsx:386
 msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# modelo} other {# modelos}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1822
+#: src/pages/Shell.tsx:1832
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (máx. {ATTACHMENT_MAX_COUNT} archivos adjuntos)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1826
+#: src/pages/Shell.tsx:1836
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (más de 10 MiB)"
 
@@ -80,11 +80,11 @@ msgid "{0} will still respond to direct mentions."
 msgstr ""
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3245
+#: src/pages/Shell.tsx:3255
 msgid "{0}'s screen"
 msgstr "Pantalla de {0}"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "{botName}’s computer"
 msgstr "Computadora de {botName}"
 
@@ -132,12 +132,12 @@ msgstr "{title}, {label}"
 msgid "{toolCount, plural, one {# tool} other {# tools}}"
 msgstr ""
 
-#: src/pages/Shell.tsx:4072
+#: src/pages/Shell.tsx:4086
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} está trabajando"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4711
+#: src/pages/Shell.tsx:4725
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "About spaces"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:301
+#: src/components/integrations/IntegrationSetup.tsx:310
 msgid "Access token"
 msgstr ""
 
@@ -188,7 +188,7 @@ msgstr "Confirmaciones de acción"
 msgid "Actions for {0}"
 msgstr "Acciones para {0}"
 
-#: src/pages/Shell.tsx:3619
+#: src/pages/Shell.tsx:3629
 msgid "Actions for space"
 msgstr ""
 
@@ -196,12 +196,12 @@ msgstr ""
 msgid "Active"
 msgstr "Activo"
 
-#: src/pages/ModelSettingsOverlay.tsx:337
+#: src/pages/ModelSettingsOverlay.tsx:341
 msgid "Active model"
 msgstr "Modelo activo"
 
-#: src/pages/Shell.tsx:2440
-#: src/pages/Shell.tsx:2442
+#: src/pages/Shell.tsx:2450
+#: src/pages/Shell.tsx:2452
 msgid "Activity"
 msgstr "Actividad"
 
@@ -215,11 +215,11 @@ msgstr "Agregar"
 msgid "Add a model in Settings to use this."
 msgstr "Agrega un modelo en Configuración para usarlo."
 
-#: src/pages/Shell.tsx:3407
+#: src/pages/Shell.tsx:3417
 msgid "Add a run time for this one-shot."
 msgstr "Agrega una hora de ejecución para este one-shot."
 
-#: src/pages/Shell.tsx:3385
+#: src/pages/Shell.tsx:3395
 msgid "Add a schedule, webhook, GitHub, or message trigger"
 msgstr ""
 
@@ -259,7 +259,7 @@ msgstr "Añadir endpoint de GraphQL"
 msgid "Add item"
 msgstr "Agregar elemento"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/PluginsOverlay.tsx:951
 msgid "Add MCP server"
 msgstr "Agregar servidor MCP"
@@ -277,12 +277,12 @@ msgstr "Agregar servidor MCP remoto"
 msgid "Add server"
 msgstr "Agregar servidor"
 
-#: src/components/integrations/IntegrationSetup.tsx:269
+#: src/components/integrations/IntegrationSetup.tsx:278
 msgid "Add server URL"
 msgstr ""
 
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Add thumbs-up"
 msgstr "Agregar me gusta"
 
@@ -311,7 +311,7 @@ msgstr "Agregando…"
 
 #: src/pages/AccountSettingsOverlay.tsx:166
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/ModelSettingsOverlay.tsx:502
+#: src/pages/ModelSettingsOverlay.tsx:506
 #: src/pages/Onboarding.tsx:461
 #: src/pages/PluginsOverlay.tsx:836
 #: src/pages/RoutineSchedule.tsx:43
@@ -323,7 +323,7 @@ msgstr "Avanzado"
 msgid "Advanced..."
 msgstr "Avanzado..."
 
-#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3039
 msgid "Agent computer"
 msgstr "Computadora del agente"
 
@@ -405,15 +405,15 @@ msgid "API is back, but the update did not finish. Check the host logs."
 msgstr "La API volvió, pero la actualización no terminó. Revisa los logs del host."
 
 #: src/components/AskCard.tsx:44
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 #: src/lib/localized-provider-hint.ts:9
-#: src/pages/ModelSettingsOverlay.tsx:644
-#: src/pages/ModelSettingsOverlay.tsx:647
-#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:648
+#: src/pages/ModelSettingsOverlay.tsx:651
+#: src/pages/ModelSettingsOverlay.tsx:670
 #: src/pages/Onboarding.tsx:563
 #: src/pages/Onboarding.tsx:566
 #: src/pages/Onboarding.tsx:580
-#: src/pages/VoiceSettingsOverlay.tsx:219
+#: src/pages/VoiceSettingsOverlay.tsx:223
 msgid "API key"
 msgstr "Clave de API"
 
@@ -444,15 +444,15 @@ msgstr "Aprueba este servidor para que tu agente use sus herramientas."
 msgid "Archive"
 msgstr "Archivar"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5431
 msgid "archived"
 msgstr "archivado"
 
-#: src/pages/Shell.tsx:2789
+#: src/pages/Shell.tsx:2799
 msgid "Archived"
 msgstr "Archivado"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5442
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archivado. Se conservan el chat, la memoria y los archivos."
 
@@ -491,7 +491,7 @@ msgstr "Preguntar antes de compras"
 msgid "Ask before sending external email"
 msgstr "Preguntar antes de enviar correo externo"
 
-#: src/components/integrations/IntegrationSetup.tsx:219
+#: src/components/integrations/IntegrationSetup.tsx:228
 msgid "Ask the server owner to configure this provider."
 msgstr ""
 
@@ -506,15 +506,15 @@ msgstr "a las {0}"
 msgid "at {timeSelect}"
 msgstr "a las {timeSelect}"
 
-#: src/pages/Shell.tsx:4791
+#: src/pages/Shell.tsx:4805
 msgid "Attach file"
 msgstr "Adjuntar archivo"
 
-#: src/pages/Shell.tsx:5023
+#: src/pages/Shell.tsx:5037
 msgid "Attachment"
 msgstr "Archivo adjunto"
 
-#: src/pages/ModelSettingsOverlay.tsx:577
+#: src/pages/ModelSettingsOverlay.tsx:581
 #: src/pages/Onboarding.tsx:512
 msgid "Authorization code or callback URL"
 msgstr "Código de autorización o URL de callback"
@@ -567,23 +567,23 @@ msgstr "URL base"
 msgid "Bearer token"
 msgstr "Token Bearer"
 
-#: src/pages/Shell.tsx:5644
+#: src/pages/Shell.tsx:5658
 msgid "Booting live desktop…"
 msgstr "Iniciando escritorio en vivo…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3877
 msgid "Booting up {0}’s computer"
 msgstr "Iniciando la computadora de {0}"
 
-#: src/pages/Shell.tsx:5292
-#: src/pages/Shell.tsx:5293
-#: src/pages/Shell.tsx:5421
+#: src/pages/Shell.tsx:5306
+#: src/pages/Shell.tsx:5307
+#: src/pages/Shell.tsx:5435
 msgid "bot"
 msgstr "bot"
 
 #: src/pages/IntegrationSetup.tsx:51
-#: src/pages/Shell.tsx:1617
+#: src/pages/Shell.tsx:1627
 msgid "Bot"
 msgstr "Bot"
 
@@ -592,11 +592,11 @@ msgstr "Bot"
 msgid "Bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:3971
+#: src/pages/Shell.tsx:3985
 msgid "Bot screen"
 msgstr "Pantalla del bot"
 
-#: src/pages/Shell.tsx:3208
+#: src/pages/Shell.tsx:3218
 msgid "Bot screen preview"
 msgstr "Vista previa de la pantalla del bot"
 
@@ -608,7 +608,7 @@ msgstr "Bot a vincular"
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first."
 msgstr "Los bots actúan sin preguntar de forma predeterminada. Agrega una excepción solo cuando quieras revisar primero un tipo de acción."
 
-#: src/pages/Shell.tsx:4073
+#: src/pages/Shell.tsx:4087
 msgid "Bots are working"
 msgstr "Los bots están trabajando"
 
@@ -620,7 +620,7 @@ msgstr ""
 msgid "Call"
 msgstr "Llamar"
 
-#: src/App.tsx:152
+#: src/App.tsx:159
 msgid "Can't reach the server."
 msgstr "No se puede alcanzar el servidor."
 
@@ -648,7 +648,7 @@ msgstr "Cancelar nuevo bot"
 msgid "Cancel new group"
 msgstr "Cancelar nuevo grupo"
 
-#: src/pages/Shell.tsx:4649
+#: src/pages/Shell.tsx:4663
 msgid "Cancel reply"
 msgstr "Cancelar respuesta"
 
@@ -685,7 +685,7 @@ msgstr "Apps de chat"
 msgid "Chat apps, group channels, and agent connections."
 msgstr "Apps de chat, canales de grupo y conexiones de agentes."
 
-#: src/pages/Shell.tsx:4966
+#: src/pages/Shell.tsx:4980
 msgid "Chat Settings"
 msgstr "Configuración del chat"
 
@@ -699,8 +699,8 @@ msgstr "La comprobación falló"
 msgid "Check for updates"
 msgstr "Buscar actualizaciones"
 
-#: src/pages/Shell.tsx:3420
-#: src/pages/Shell.tsx:3432
+#: src/pages/Shell.tsx:3430
+#: src/pages/Shell.tsx:3442
 msgid "Check in."
 msgstr "Regístrate."
 
@@ -725,7 +725,7 @@ msgstr "Elige un bot…"
 msgid "Choose a new password"
 msgstr "Elige una contraseña nueva"
 
-#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:312
 msgid "Choose which connected model Rakazo uses."
 msgstr "Elige qué modelo conectado usa Rakazo."
 
@@ -747,11 +747,11 @@ msgstr "Borrar conversación"
 msgid "Clearing…"
 msgstr "Borrando…"
 
-#: src/components/integrations/IntegrationSetup.tsx:167
+#: src/components/integrations/IntegrationSetup.tsx:172
 msgid "Client ID"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 msgid "Client secret"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr "Cerrar"
 msgid "Close chart"
 msgstr "Cerrar gráfico"
 
-#: src/pages/Shell.tsx:3950
+#: src/pages/Shell.tsx:3964
 msgid "Close computer"
 msgstr "Cerrar computadora"
 
@@ -784,7 +784,7 @@ msgstr "Cerrar integraciones"
 msgid "Close MCP servers"
 msgstr "Cerrar servidores MCP"
 
-#: src/pages/MemorySettingsOverlay.tsx:164
+#: src/pages/MemorySettingsOverlay.tsx:168
 #: src/pages/SettingsOverlay.tsx:109
 msgid "Close memory settings"
 msgstr "Cerrar configuración de memoria"
@@ -793,16 +793,16 @@ msgstr "Cerrar configuración de memoria"
 msgid "Close messaging settings"
 msgstr "Cerrar configuración de mensajería"
 
-#: src/pages/ModelSettingsOverlay.tsx:324
+#: src/pages/ModelSettingsOverlay.tsx:328
 #: src/pages/SettingsOverlay.tsx:107
 msgid "Close model settings"
 msgstr "Cerrar configuración de modelos"
 
-#: src/pages/Shell.tsx:2418
+#: src/pages/Shell.tsx:2428
 msgid "Close navigation"
 msgstr "Cerrar navegación"
 
-#: src/pages/Shell.tsx:3186
+#: src/pages/Shell.tsx:3196
 msgid "Close panel"
 msgstr "Cerrar panel"
 
@@ -815,7 +815,7 @@ msgid "Close user settings"
 msgstr "Cerrar configuración de usuario"
 
 #: src/pages/SettingsOverlay.tsx:111
-#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:158
 msgid "Close voice settings"
 msgstr "Cerrar configuración de voz"
 
@@ -828,7 +828,7 @@ msgid "Code"
 msgstr "Código"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2590
+#: src/pages/Shell.tsx:2600
 msgid "Collapse {0}"
 msgstr "Contraer {0}"
 
@@ -855,24 +855,24 @@ msgid "Complete"
 msgstr "Completado"
 
 #: src/pages/SettingsOverlay.tsx:97
-#: src/pages/Shell.tsx:5578
+#: src/pages/Shell.tsx:5592
 #: src/pages/shell/bot-panel.tsx:57
 msgid "Computer"
 msgstr "Computadora"
 
-#: src/pages/Shell.tsx:5647
+#: src/pages/Shell.tsx:5661
 msgid "Computer failed to boot"
 msgstr "La computadora no pudo iniciarse"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4008
 msgid "Computer is asleep"
 msgstr "La computadora está en reposo"
 
-#: src/pages/Shell.tsx:5646
+#: src/pages/Shell.tsx:5660
 msgid "Computer is asleep. Open it to wake."
 msgstr "La computadora está en reposo. Ábrela para despertarla."
 
-#: src/pages/Shell.tsx:5648
+#: src/pages/Shell.tsx:5662
 msgid "Computer is stopped"
 msgstr "La computadora está detenida"
 
@@ -884,7 +884,7 @@ msgstr "Computadoras"
 msgid "Computers are off. Set SANDBOX_PROVIDER=docker with SANDBOX_SUPERVISOR_TOKEN, or set SANDBOX_PROVIDER to e2b, daytona, or box with its API key. Recreate the stack after changing .env."
 msgstr "Las computadoras están apagadas. Configura SANDBOX_PROVIDER=docker con SANDBOX_SUPERVISOR_TOKEN, o establece SANDBOX_PROVIDER en e2b, daytona o box con su clave de API. Recrea el stack después de cambiar .env."
 
-#: src/pages/ModelSettingsOverlay.tsx:344
+#: src/pages/ModelSettingsOverlay.tsx:348
 msgid "Configured by deployment"
 msgstr "Configurado por el despliegue"
 
@@ -902,12 +902,12 @@ msgstr "Confirmar eliminación"
 msgid "Confirm password"
 msgstr "Confirmar contraseña"
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:258
-#: src/components/integrations/IntegrationSetup.tsx:282
-#: src/components/integrations/IntegrationSetup.tsx:315
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:267
+#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:324
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
-#: src/pages/VoiceSettingsOverlay.tsx:241
+#: src/pages/VoiceSettingsOverlay.tsx:245
 msgid "Connect"
 msgstr "Conectar"
 
@@ -915,7 +915,7 @@ msgstr "Conectar"
 msgid "Connect a model"
 msgstr "Conectar un modelo"
 
-#: src/pages/ModelSettingsOverlay.tsx:697
+#: src/pages/ModelSettingsOverlay.tsx:701
 msgid "Connect API key"
 msgstr "Conectar clave de API"
 
@@ -931,7 +931,7 @@ msgstr "Conectar servidor MCP “{name}”"
 msgid "Connect OAuth"
 msgstr "Conectar OAuth"
 
-#: src/pages/ModelSettingsOverlay.tsx:547
+#: src/pages/ModelSettingsOverlay.tsx:551
 msgid "Connect this provider to use it as your personal model."
 msgstr "Conecta este proveedor para usarlo como tu modelo personal."
 
@@ -939,30 +939,30 @@ msgstr "Conecta este proveedor para usarlo como tu modelo personal."
 msgid "Connect Treg"
 msgstr "Conectar Treg"
 
-#: src/components/integrations/IntegrationSetup.tsx:159
-#: src/components/integrations/IntegrationSetup.tsx:258
+#: src/components/integrations/IntegrationSetup.tsx:164
+#: src/components/integrations/IntegrationSetup.tsx:267
 #: src/pages/McpOAuthCallback.tsx:54
-#: src/pages/MemorySettingsOverlay.tsx:187
-#: src/pages/ModelSettingsOverlay.tsx:389
+#: src/pages/MemorySettingsOverlay.tsx:191
+#: src/pages/ModelSettingsOverlay.tsx:393
 #: src/pages/shell/message-cards.tsx:187
-#: src/pages/VoiceSettingsOverlay.tsx:198
+#: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Conectado"
 
 #. placeholder {0}: credential.label
-#: src/pages/ModelSettingsOverlay.tsx:538
+#: src/pages/ModelSettingsOverlay.tsx:542
 msgid "Connected · {0}"
 msgstr "Conectado · {0}"
 
 #. placeholder {0}: selected.name
-#: src/pages/VoiceSettingsOverlay.tsx:102
+#: src/pages/VoiceSettingsOverlay.tsx:106
 msgid "Connected {0}."
 msgstr "Se conectó {0}."
 
 #. placeholder {0}: selected.label
 #. placeholder {0}: selectedLabelRef.current ?? "this model"
-#: src/pages/ModelSettingsOverlay.tsx:82
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:84
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Connected and using {0}."
 msgstr "Conectado y usando {0}."
 
@@ -970,12 +970,12 @@ msgstr "Conectado y usando {0}."
 msgid "Connected. Its tools are available from your next message."
 msgstr "Conectado: sus herramientas estarán disponibles desde tu próximo mensaje."
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/McpServersOverlay.tsx:38
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
 #: src/pages/shell/message-cards.tsx:360
-#: src/pages/VoiceSettingsOverlay.tsx:237
+#: src/pages/VoiceSettingsOverlay.tsx:241
 msgid "Connecting…"
 msgstr "Conectando…"
 
@@ -984,7 +984,7 @@ msgstr "Conectando…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "La conexión con {0} sigue pendiente. Puedes cerrar esto y volver a comprobar."
 
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/Onboarding.tsx:604
 #: src/pages/Onboarding.tsx:667
 msgid "Continue"
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Continue with email"
 msgstr "Continuar con el correo"
 
-#: src/pages/Shell.tsx:5109
+#: src/pages/Shell.tsx:5123
 msgid "Copy"
 msgstr "Copiar"
 
@@ -1022,7 +1022,7 @@ msgstr "No se pudo autorizar esta app"
 msgid "Could not change password"
 msgstr "No se pudo cambiar la contraseña"
 
-#: src/pages/ModelSettingsOverlay.tsx:245
+#: src/pages/ModelSettingsOverlay.tsx:247
 msgid "Could not change the default model"
 msgstr "No se pudo cambiar el modelo predeterminado"
 
@@ -1046,30 +1046,30 @@ msgstr "No se pudo completar OAuth"
 msgid "Could not complete the update. Try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:76
+#: src/components/integrations/IntegrationSetup.tsx:79
 #: src/pages/PluginsOverlay.tsx:264
 msgid "Could not connect"
 msgstr "No se pudo conectar"
 
 #. placeholder {0}: registration.name
-#: src/pages/MemorySettingsOverlay.tsx:115
+#: src/pages/MemorySettingsOverlay.tsx:119
 msgid "Could not connect {0}"
 msgstr "No se pudo conectar {0}"
 
-#: src/pages/ModelSettingsOverlay.tsx:284
+#: src/pages/ModelSettingsOverlay.tsx:286
 msgid "Could not connect this provider"
 msgstr "No se pudo conectar este proveedor"
 
-#: src/pages/VoiceSettingsOverlay.tsx:104
+#: src/pages/VoiceSettingsOverlay.tsx:108
 msgid "Could not connect this voice provider"
 msgstr "No se pudo conectar este proveedor de voz"
 
-#: src/pages/Shell.tsx:875
+#: src/pages/Shell.tsx:885
 msgid "Could not connect to the computer screen"
 msgstr "No se pudo conectar a la pantalla de la computadora"
 
 #: src/pages/Auth.tsx:99
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2368
 msgid "Could not continue"
 msgstr "No se pudo continuar"
 
@@ -1117,7 +1117,7 @@ msgstr "No se pudo eliminar la habilidad"
 msgid "Could not delete space"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:129
+#: src/pages/MemorySettingsOverlay.tsx:133
 msgid "Could not disconnect memory provider"
 msgstr "No se pudo desconectar el proveedor de memoria"
 
@@ -1158,7 +1158,7 @@ msgstr "No se pudieron cargar las reglas de aprobación"
 msgid "Could not load bots. Reload to try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:67
+#: src/components/integrations/IntegrationSetup.tsx:70
 #: src/pages/PluginsOverlay.tsx:143
 #: src/pages/PluginsOverlay.tsx:719
 msgid "Could not load integrations"
@@ -1168,7 +1168,7 @@ msgstr "No se pudieron cargar las integraciones"
 msgid "Could not load MCP servers"
 msgstr "No se pudieron cargar los servidores MCP"
 
-#: src/pages/ModelSettingsOverlay.tsx:129
+#: src/pages/ModelSettingsOverlay.tsx:131
 msgid "Could not load model settings"
 msgstr "No se pudo cargar la configuración de modelos"
 
@@ -1188,11 +1188,15 @@ msgstr "No se pudo cargar este archivo."
 msgid "Could not load update status"
 msgstr "No se pudo cargar el estado de actualización"
 
-#: src/pages/VoiceSettingsOverlay.tsx:77
+#: src/pages/VoiceSettingsOverlay.tsx:81
 msgid "Could not load voice settings"
 msgstr "No se pudo cargar la configuración de voz"
 
-#: src/pages/VoiceSettingsOverlay.tsx:138
+#: src/pages/LocalSettings.tsx:26
+msgid "Could not open local settings. Start the local server and create its owner account, then try again."
+msgstr ""
+
+#: src/pages/VoiceSettingsOverlay.tsx:142
 msgid "Could not play a test clip"
 msgstr "No se pudo reproducir un clip de prueba"
 
@@ -1202,7 +1206,7 @@ msgstr "No se pudo reproducir un clip de prueba"
 msgid "Could not reach the server"
 msgstr "No se pudo alcanzar el servidor"
 
-#: src/pages/ModelSettingsOverlay.tsx:229
+#: src/pages/ModelSettingsOverlay.tsx:231
 #: src/pages/Onboarding.tsx:191
 msgid "Could not reach this model server"
 msgstr "No se pudo alcanzar este servidor de modelos"
@@ -1240,7 +1244,7 @@ msgstr "No se pudo restablecer la contraseña"
 msgid "Could not revoke connection"
 msgstr "No se pudo revocar la conexión"
 
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3496
 msgid "Could not run routine"
 msgstr "No se pudo ejecutar la rutina"
 
@@ -1262,7 +1266,7 @@ msgstr "No se pudo guardar el grupo"
 msgid "Could not save model"
 msgstr "No se pudo guardar el modelo"
 
-#: src/pages/Shell.tsx:3457
+#: src/pages/Shell.tsx:3467
 msgid "Could not save routine"
 msgstr "No se pudo guardar la rutina"
 
@@ -1278,7 +1282,7 @@ msgstr "No se pudo guardar la habilidad"
 msgid "Could not save that choice"
 msgstr "No se pudo guardar esa opción"
 
-#: src/pages/VoiceSettingsOverlay.tsx:119
+#: src/pages/VoiceSettingsOverlay.tsx:123
 msgid "Could not save that voice"
 msgstr "No se pudo guardar esa voz"
 
@@ -1310,7 +1314,7 @@ msgstr "No se pudo iniciar la enseñanza"
 msgid "Could not submit this answer"
 msgstr "No se pudo enviar esta respuesta"
 
-#: src/pages/Shell.tsx:2212
+#: src/pages/Shell.tsx:2222
 msgid "Could not take control"
 msgstr "No se pudo tomar el control"
 
@@ -1326,11 +1330,11 @@ msgstr "No se pudo actualizar el acceso del agente"
 msgid "Could not update computer"
 msgstr "No se pudo actualizar la computadora"
 
-#: src/pages/Shell.tsx:1808
+#: src/pages/Shell.tsx:1818
 msgid "Could not update reaction"
 msgstr "No se pudo actualizar la reacción"
 
-#: src/pages/MemorySettingsOverlay.tsx:143
+#: src/pages/MemorySettingsOverlay.tsx:147
 msgid "Could not update the default memory scope"
 msgstr "No se pudo actualizar el alcance de memoria predeterminado"
 
@@ -1346,7 +1350,7 @@ msgstr "No se pudieron actualizar los avatares"
 msgid "Couldn't update messaging settings"
 msgstr "No se pudo actualizar la configuración de mensajería"
 
-#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2481
 #: src/pages/shell/bot-panel.tsx:184
 #: src/pages/shell/dialogs.tsx:208
 msgid "Create"
@@ -1460,8 +1464,8 @@ msgstr "Alcance predeterminado"
 #: src/pages/KnowledgeSection.tsx:449
 #: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:301
-#: src/pages/Shell.tsx:2825
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2835
+#: src/pages/Shell.tsx:2866
 #: src/pages/shell/dialogs.tsx:351
 #: src/pages/shell/dialogs.tsx:412
 msgid "Delete"
@@ -1469,8 +1473,8 @@ msgstr "Eliminar"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2822
-#: src/pages/Shell.tsx:2853
+#: src/pages/Shell.tsx:2832
+#: src/pages/Shell.tsx:2863
 msgid "Delete {0}"
 msgstr "Eliminar {0}"
 
@@ -1489,11 +1493,11 @@ msgstr "Eliminar grupo"
 msgid "Delete memories too"
 msgstr "Eliminar también las memorias"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3643
 msgid "Delete space"
 msgstr ""
 
-#: src/pages/Shell.tsx:5419
+#: src/pages/Shell.tsx:5433
 msgid "deleted"
 msgstr "eliminado"
 
@@ -1511,7 +1515,7 @@ msgstr "Denegado"
 msgid "Deny"
 msgstr "Denegar"
 
-#: src/pages/ModelSettingsOverlay.tsx:340
+#: src/pages/ModelSettingsOverlay.tsx:344
 msgid "Deployment default"
 msgstr "Predeterminado del despliegue"
 
@@ -1534,16 +1538,16 @@ msgstr ""
 msgid "Desktop update"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:40
+#: src/components/integrations/IntegrationSetup.tsx:43
 msgid "Direct MCP"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:493
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnecting…"
 msgstr "Desconectando…"
 
@@ -1553,7 +1557,7 @@ msgstr "Desconectando…"
 msgid "Dismiss"
 msgstr "Descartar"
 
-#: src/pages/Shell.tsx:4629
+#: src/pages/Shell.tsx:4643
 msgid "Dismiss error"
 msgstr "Descartar error"
 
@@ -1601,7 +1605,7 @@ msgstr "Descargar {name}"
 msgid "Download as markdown"
 msgstr "Descargar como Markdown"
 
-#: src/components/integrations/IntegrationSetup.tsx:327
+#: src/components/integrations/IntegrationSetup.tsx:336
 msgid "Download Executor"
 msgstr ""
 
@@ -1617,7 +1621,7 @@ msgstr "Habilidad en borrador"
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/pages/Shell.tsx:5245
+#: src/pages/Shell.tsx:5259
 msgid "Earlier message"
 msgstr "Mensaje anterior"
 
@@ -1638,7 +1642,7 @@ msgid "Engage when... Ignore..."
 msgstr ""
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
-#: src/pages/ModelSettingsOverlay.tsx:600
+#: src/pages/ModelSettingsOverlay.tsx:604
 #: src/pages/Onboarding.tsx:531
 msgid "Enter this code at <0>{0}</0>"
 msgstr "Ingresa este código en <0>{0}</0>"
@@ -1687,7 +1691,7 @@ msgid "Expand"
 msgstr "Expandir"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2589
+#: src/pages/Shell.tsx:2599
 msgid "Expand {0}"
 msgstr "Expandir {0}"
 
@@ -1716,14 +1720,14 @@ msgstr "fallido"
 msgid "Failed"
 msgstr "Falló"
 
-#: src/pages/Shell.tsx:1981
-#: src/pages/Shell.tsx:1983
-#: src/pages/Shell.tsx:1985
+#: src/pages/Shell.tsx:1991
+#: src/pages/Shell.tsx:1993
+#: src/pages/Shell.tsx:1995
 msgid "Failed to send message"
 msgstr "No se pudo enviar el mensaje"
 
-#: src/pages/Shell.tsx:2018
-#: src/pages/Shell.tsx:2037
+#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2047
 msgid "Failed to stop"
 msgstr "No se pudo detener"
 
@@ -1736,18 +1740,18 @@ msgstr "Falló."
 msgid "Failure handling"
 msgstr "Manejo de fallos"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Find models"
 msgstr "Buscar modelos"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Finding…"
 msgstr "Buscando…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
-#: src/pages/ModelSettingsOverlay.tsx:560
+#: src/pages/ModelSettingsOverlay.tsx:564
 #: src/pages/Onboarding.tsx:495
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "Termina de iniciar sesión en <0>{0}</0>. Es posible que la página final no cargue; pega aquí su URL o código."
@@ -1773,7 +1777,7 @@ msgstr "Marcar acciones inesperadas"
 msgid "Forgot password?"
 msgstr "¿Olvidaste la contraseña?"
 
-#: src/pages/ModelSettingsOverlay.tsx:1071
+#: src/pages/ModelSettingsOverlay.tsx:1075
 msgid "Free"
 msgstr "Gratis"
 
@@ -1786,7 +1790,7 @@ msgstr "Pantalla completa"
 msgid "General"
 msgstr "General"
 
-#: src/components/integrations/IntegrationSetup.tsx:209
+#: src/components/integrations/IntegrationSetup.tsx:214
 msgid "Get credentials"
 msgstr ""
 
@@ -1801,8 +1805,8 @@ msgid "Git event"
 msgstr "Evento de Git"
 
 #: src/pages/MessagingSettingsOverlay.tsx:204
-#: src/pages/Shell.tsx:3019
-#: src/pages/Shell.tsx:3156
+#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3166
 msgid "Group"
 msgstr "Grupo"
 
@@ -1844,15 +1848,15 @@ msgstr "Nombre del encabezado"
 msgid "Header value"
 msgstr "Valor del encabezado"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Hear a sample"
 msgstr "Escuchar una muestra"
 
-#: src/pages/VoiceSettingsOverlay.tsx:131
+#: src/pages/VoiceSettingsOverlay.tsx:135
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hola, así sonaré cuando lea las respuestas en voz alta."
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Hide bots"
 msgstr ""
 
@@ -1881,11 +1885,11 @@ msgstr "Con qué frecuencia"
 msgid "How to check"
 msgstr "Cómo comprobar"
 
-#: src/pages/Shell.tsx:5174
+#: src/pages/Shell.tsx:5188
 msgid "I’m done"
 msgstr "Listo"
 
-#: src/pages/VoiceSettingsOverlay.tsx:136
+#: src/pages/VoiceSettingsOverlay.tsx:140
 msgid "If you heard that, voice is ready."
 msgstr "Si escuchaste eso, la voz está lista."
 
@@ -1917,12 +1921,12 @@ msgstr "Instrucción"
 msgid "Integration domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:133
+#: src/components/integrations/IntegrationSetup.tsx:136
 msgid "Integration options"
 msgstr ""
 
 #: src/pages/PluginsOverlay.tsx:679
-#: src/pages/Shell.tsx:2874
+#: src/pages/Shell.tsx:2884
 msgid "Integrations"
 msgstr "Integraciones"
 
@@ -1952,11 +1956,11 @@ msgstr "Aislado"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Su conversación, archivos y rutinas se eliminarán de forma permanente. Los bots que creó permanecerán en tu lista."
 
-#: src/pages/Shell.tsx:4289
+#: src/pages/Shell.tsx:4303
 msgid "Jump to latest"
 msgstr "Ir al más reciente"
 
-#: src/pages/Shell.tsx:5240
+#: src/pages/Shell.tsx:5254
 msgid "Jump to replied message"
 msgstr "Ir al mensaje respondido"
 
@@ -2014,7 +2018,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "Escuchando…"
 
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Load earlier messages"
 msgstr "Cargar mensajes anteriores"
 
@@ -2026,12 +2030,12 @@ msgstr "Cargando actividad…"
 msgid "Loading integrations…"
 msgstr "Cargando integraciones…"
 
-#: src/pages/MemorySettingsOverlay.tsx:182
+#: src/pages/MemorySettingsOverlay.tsx:186
 msgid "Loading memory settings…"
 msgstr "Cargando configuración de memoria…"
 
-#: src/pages/ModelSettingsOverlay.tsx:306
-#: src/pages/ModelSettingsOverlay.tsx:733
+#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:737
 msgid "Loading model catalog…"
 msgstr "Cargando catálogo de modelos…"
 
@@ -2047,15 +2051,15 @@ msgstr "Cargando reglas…"
 msgid "Loading tools…"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:210
+#: src/pages/VoiceSettingsOverlay.tsx:214
 msgid "Loading voice providers…"
 msgstr "Cargando proveedores de voz…"
 
-#: src/App.tsx:58
+#: src/App.tsx:65
 #: src/pages/IntegrationSetup.tsx:72
 #: src/pages/Onboarding.tsx:282
 #: src/pages/PeerMessagesOverlay.tsx:98
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Loading…"
 msgstr "Cargando…"
 
@@ -2067,7 +2071,11 @@ msgstr "Local"
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "El acceso local permite que los bots ejecuten comandos sin preguntar. Evítalo en servidores compartidos o públicos."
 
-#: src/pages/Shell.tsx:2932
+#: src/pages/LocalSettings.tsx:22
+msgid "Local Server Settings"
+msgstr ""
+
+#: src/pages/Shell.tsx:2942
 msgid "Log out"
 msgstr "Cerrar sesión"
 
@@ -2083,8 +2091,8 @@ msgstr "Gestionar servidores MCP"
 msgid "Manage messaging settings"
 msgstr "Administrar configuración de mensajería"
 
-#: src/pages/MemorySettingsOverlay.tsx:159
-#: src/pages/MemorySettingsOverlay.tsx:173
+#: src/pages/MemorySettingsOverlay.tsx:163
+#: src/pages/MemorySettingsOverlay.tsx:177
 msgid "Manage the Space semantic memory provider."
 msgstr "Administra el proveedor de memoria semántica del Space."
 
@@ -2125,7 +2133,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Miembros (elige {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/KnowledgeSection.tsx:39
-#: src/pages/MemorySettingsOverlay.tsx:155
+#: src/pages/MemorySettingsOverlay.tsx:159
 #: src/pages/SettingsOverlay.tsx:94
 msgid "Memory"
 msgstr "Memoria"
@@ -2134,7 +2142,7 @@ msgstr "Memoria"
 msgid "Memory scope"
 msgstr "Alcance de memoria"
 
-#: src/pages/Shell.tsx:4697
+#: src/pages/Shell.tsx:4711
 msgid "Mentions"
 msgstr "Menciones"
 
@@ -2142,8 +2150,8 @@ msgstr "Menciones"
 msgid "Mentions only"
 msgstr ""
 
-#: src/pages/Shell.tsx:4898
-#: src/pages/Shell.tsx:5025
+#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:5039
 msgid "Message"
 msgstr "Mensaje"
 
@@ -2152,12 +2160,12 @@ msgstr "Mensaje"
 msgid "Message"
 msgstr "Mensaje"
 
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4898
+#: src/pages/Shell.tsx:4908
+#: src/pages/Shell.tsx:4912
 msgid "Message {activeName}"
 msgstr "Mensaje a {activeName}"
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4623
 msgid "Message composer"
 msgstr "Redactor de mensajes"
 
@@ -2166,15 +2174,15 @@ msgstr "Redactor de mensajes"
 msgid "Message event"
 msgstr ""
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Message from {peer}"
 msgstr "Mensaje de {peer}"
 
-#: src/pages/Shell.tsx:4895
+#: src/pages/Shell.tsx:4909
 msgid "Message…"
 msgstr "Mensaje…"
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Messaged {peer}"
 msgstr "Mensaje enviado a {peer}"
 
@@ -2195,8 +2203,8 @@ msgstr "Mínimo"
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: src/pages/Shell.tsx:2461
-#: src/pages/Shell.tsx:2462
+#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2472
 msgid "Minimize bots"
 msgstr ""
 
@@ -2208,9 +2216,9 @@ msgstr "minuto"
 msgid "minutes"
 msgstr "minutos"
 
-#: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/ModelSettingsOverlay.tsx:509
-#: src/pages/ModelSettingsOverlay.tsx:959
+#: src/pages/ModelSettingsOverlay.tsx:448
+#: src/pages/ModelSettingsOverlay.tsx:513
+#: src/pages/ModelSettingsOverlay.tsx:963
 #: src/pages/Onboarding.tsx:420
 #: src/pages/Onboarding.tsx:468
 #: src/pages/Onboarding.tsx:476
@@ -2218,12 +2226,12 @@ msgstr "minutos"
 msgid "Model"
 msgstr "Modelo"
 
-#: src/pages/ModelSettingsOverlay.tsx:478
+#: src/pages/ModelSettingsOverlay.tsx:482
 #: src/pages/Onboarding.tsx:442
 msgid "Model id"
 msgstr "ID del modelo"
 
-#: src/pages/ModelSettingsOverlay.tsx:995
+#: src/pages/ModelSettingsOverlay.tsx:999
 msgid "Model options"
 msgstr "Opciones del modelo"
 
@@ -2235,16 +2243,21 @@ msgstr "Proveedores de modelos"
 msgid "Model spend uses your provider keys."
 msgstr "El gasto del modelo usa tus claves de proveedor."
 
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Model updated."
 msgstr "Modelo actualizado."
 
-#: src/pages/ModelSettingsOverlay.tsx:317
+#: src/pages/LocalSettings.tsx:36
+#: src/pages/ModelSettingsOverlay.tsx:321
 #: src/pages/SettingsOverlay.tsx:93
 msgid "Models"
 msgstr "Modelos"
 
-#: src/pages/ModelSettingsOverlay.tsx:457
+#: src/pages/ModelSettingsOverlay.tsx:310
+msgid "Models for the server owner’s default space."
+msgstr ""
+
+#: src/pages/ModelSettingsOverlay.tsx:461
 #: src/pages/Onboarding.tsx:426
 msgid "Models from server"
 msgstr "Modelos del servidor"
@@ -2253,7 +2266,7 @@ msgstr "Modelos del servidor"
 msgid "Monthly"
 msgstr "Mensual"
 
-#: src/pages/Shell.tsx:5082
+#: src/pages/Shell.tsx:5096
 msgid "More"
 msgstr ""
 
@@ -2303,7 +2316,7 @@ msgstr "Necesita entrada"
 msgid "Needs takeover"
 msgstr "Necesita toma de control"
 
-#: src/pages/Shell.tsx:3897
+#: src/pages/Shell.tsx:3911
 msgid "Needs you"
 msgstr ""
 
@@ -2381,7 +2394,7 @@ msgstr "Ya no está activo"
 msgid "No managed app catalog is configured on this deployment."
 msgstr "No hay un catálogo de apps administradas configurado en este despliegue."
 
-#: src/pages/ModelSettingsOverlay.tsx:1023
+#: src/pages/ModelSettingsOverlay.tsx:1027
 msgid "No matching models"
 msgstr "No hay modelos coincidentes"
 
@@ -2397,7 +2410,7 @@ msgstr "Aún no hay servidores MCP."
 msgid "No messages with {peerBotName} yet."
 msgstr "Aún no hay mensajes con {peerBotName}."
 
-#: src/pages/ModelSettingsOverlay.tsx:737
+#: src/pages/ModelSettingsOverlay.tsx:741
 msgid "No model catalog is available."
 msgstr "No hay un catálogo de modelos disponible."
 
@@ -2405,11 +2418,11 @@ msgstr "No hay un catálogo de modelos disponible."
 msgid "No providers found"
 msgstr "No se encontraron proveedores"
 
-#: src/pages/ModelSettingsOverlay.tsx:397
+#: src/pages/ModelSettingsOverlay.tsx:401
 msgid "No providers found."
 msgstr "No se encontraron proveedores."
 
-#: src/components/integrations/IntegrationSetup.tsx:264
+#: src/components/integrations/IntegrationSetup.tsx:273
 msgid "No remote MCP servers found"
 msgstr ""
 
@@ -2442,7 +2455,7 @@ msgstr "Sin disparador"
 msgid "None yet"
 msgstr "Ninguno aún"
 
-#: src/pages/ModelSettingsOverlay.tsx:540
+#: src/pages/ModelSettingsOverlay.tsx:544
 msgid "Not connected"
 msgstr "No conectado"
 
@@ -2463,7 +2476,7 @@ msgid "Now"
 msgstr "Ahora"
 
 #. placeholder {0}: selected.label
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Now using {0}."
 msgstr "Ahora usando {0}."
 
@@ -2496,26 +2509,26 @@ msgstr "el día 1 a las {0}"
 msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
 msgstr ""
 
-#: src/pages/Shell.tsx:3671
+#: src/pages/Shell.tsx:3681
 msgid "Only empty spaces can be deleted. Delete its bots and groups first."
 msgstr ""
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3234
-#: src/pages/Shell.tsx:3239
+#: src/pages/Shell.tsx:3244
+#: src/pages/Shell.tsx:3249
 msgid "Open"
 msgstr "Abrir"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2597
 msgid "Open {0}"
 msgstr "Abrir {0}"
 
-#: src/pages/Shell.tsx:3202
+#: src/pages/Shell.tsx:3212
 msgid "Open in full window"
 msgstr "Abrir en ventana completa"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3001
 msgid "Open navigation"
 msgstr "Abrir navegación"
 
@@ -2523,20 +2536,20 @@ msgstr "Abrir navegación"
 msgid "Open work"
 msgstr "Trabajo abierto"
 
-#: src/pages/ModelSettingsOverlay.tsx:417
+#: src/pages/ModelSettingsOverlay.tsx:421
 #: src/pages/Onboarding.tsx:395
 msgid "OpenAI-compatible server URL"
 msgstr "URL de servidor compatible con OpenAI"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5444
 msgid "Opened its thread."
 msgstr "Se abrió su hilo."
 
-#: src/App.tsx:195
+#: src/App.tsx:202
 msgid "Opening your Space…"
 msgstr "Abriendo tu Space…"
 
-#: src/pages/ModelSettingsOverlay.tsx:650
+#: src/pages/ModelSettingsOverlay.tsx:654
 #: src/pages/Onboarding.tsx:569
 msgid "Optional"
 msgstr "Opcional"
@@ -2549,7 +2562,7 @@ msgstr "Controles opcionales que la mayoría nunca necesita"
 msgid "Optional header value"
 msgstr "Valor de encabezado opcional"
 
-#: src/pages/ModelSettingsOverlay.tsx:664
+#: src/pages/ModelSettingsOverlay.tsx:668
 msgid "Or connect an API key"
 msgstr "O conecta una clave de API"
 
@@ -2565,7 +2578,7 @@ msgstr "Orgánico"
 msgid "Organization API key"
 msgstr "Clave de API de organización"
 
-#: src/pages/ModelSettingsOverlay.tsx:465
+#: src/pages/ModelSettingsOverlay.tsx:469
 #: src/pages/Onboarding.tsx:435
 msgid "Other model…"
 msgstr "Otro modelo…"
@@ -2600,16 +2613,16 @@ msgstr "Contraseña actualizada"
 msgid "Passwords do not match"
 msgstr "Las contraseñas no coinciden"
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste a replacement key"
 msgstr "Pega una clave de reemplazo"
 
-#: src/pages/ModelSettingsOverlay.tsx:428
+#: src/pages/ModelSettingsOverlay.tsx:432
 #: src/pages/Onboarding.tsx:406
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "Pega la dirección compatible con OpenAI de tu servidor. Rakazo agrega /v1 si es necesario."
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste your API key"
 msgstr "Pega tu clave de API"
 
@@ -2617,7 +2630,7 @@ msgstr "Pega tu clave de API"
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/pages/ModelSettingsOverlay.tsx:534
+#: src/pages/ModelSettingsOverlay.tsx:538
 msgid "Personal credential"
 msgstr "Credencial personal"
 
@@ -2625,7 +2638,7 @@ msgstr "Credencial personal"
 msgid "Pin"
 msgstr "Fijar"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Playing…"
 msgstr "Reproduciendo…"
 
@@ -2642,17 +2655,17 @@ msgstr "Vista previa de {0}"
 msgid "Private"
 msgstr "Privado"
 
-#: src/components/integrations/IntegrationSetup.tsx:177
+#: src/components/integrations/IntegrationSetup.tsx:182
 msgid "Project ID"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:215
+#: src/pages/MemorySettingsOverlay.tsx:219
 #: src/pages/Onboarding.tsx:292
 msgid "Provider"
 msgstr "Proveedor"
 
-#: src/pages/ModelSettingsOverlay.tsx:352
-#: src/pages/VoiceSettingsOverlay.tsx:166
+#: src/pages/ModelSettingsOverlay.tsx:356
+#: src/pages/VoiceSettingsOverlay.tsx:170
 msgid "Providers"
 msgstr "Proveedores"
 
@@ -2684,7 +2697,7 @@ msgstr "Recientes"
 msgid "Reconnect OAuth"
 msgstr "Reconectar OAuth"
 
-#: src/App.tsx:150
+#: src/App.tsx:157
 #: src/components/ComputerUpdateProgress.tsx:54
 msgid "Reconnecting"
 msgstr "Reconectando"
@@ -2747,7 +2760,7 @@ msgstr "Actualizar vista"
 msgid "Refreshing…"
 msgstr "Actualizando…"
 
-#: src/pages/Shell.tsx:5164
+#: src/pages/Shell.tsx:5178
 msgid "Release"
 msgstr "Liberar"
 
@@ -2767,7 +2780,7 @@ msgid "Remove"
 msgstr "Quitar"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4683
+#: src/pages/Shell.tsx:4697
 msgid "Remove {0}"
 msgstr "Quitar {0}"
 
@@ -2776,7 +2789,7 @@ msgid "Remove Git event"
 msgstr ""
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4845
 msgid "Remove mention {0}"
 msgstr "Quitar mención {0}"
 
@@ -2789,13 +2802,13 @@ msgid "Remove schedule"
 msgstr "Quitar horario"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4824
 msgid "Remove skill {0}"
 msgstr "Quitar habilidad {0}"
 
-#: src/pages/Shell.tsx:4262
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:4276
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Remove thumbs-up"
 msgstr "Quitar me gusta"
 
@@ -2803,7 +2816,7 @@ msgstr "Quitar me gusta"
 msgid "Remove webhook"
 msgstr "Quitar webhook"
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5443
 msgid "Removed with chat, computer, and memory."
 msgstr "Eliminado junto con el chat, la computadora y la memoria."
 
@@ -2822,21 +2835,21 @@ msgstr "Quitando…"
 msgid "Reopen"
 msgstr "Reabrir"
 
-#: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/ModelSettingsOverlay.tsx:695
+#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:699
 msgid "Replace API key"
 msgstr "Reemplazar clave de API"
 
-#: src/pages/VoiceSettingsOverlay.tsx:239
+#: src/pages/VoiceSettingsOverlay.tsx:243
 msgid "Replace key"
 msgstr "Reemplazar clave"
 
-#: src/pages/Shell.tsx:5074
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5088
+#: src/pages/Shell.tsx:5119
 msgid "Reply"
 msgstr "Responder"
 
-#: src/pages/Shell.tsx:4646
+#: src/pages/Shell.tsx:4660
 msgid "Replying to {replyName}"
 msgstr "Respondiendo a {replyName}"
 
@@ -2870,8 +2883,8 @@ msgstr "Restableciendo…"
 msgid "Restart to update"
 msgstr ""
 
-#: src/pages/Shell.tsx:2816
-#: src/pages/Shell.tsx:2847
+#: src/pages/Shell.tsx:2826
+#: src/pages/Shell.tsx:2857
 msgid "Restore"
 msgstr "Restaurar"
 
@@ -2883,12 +2896,12 @@ msgstr "Restaura el último espacio de trabajo guardado. Se pierde el trabajo si
 msgid "Restoring your workspace"
 msgstr ""
 
-#: src/App.tsx:164
+#: src/App.tsx:171
 #: src/pages/PeerMessagesOverlay.tsx:109
 msgid "Retry now"
 msgstr "Reintentar ahora"
 
-#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2398
 msgid "Retry screen"
 msgstr "Reintentar pantalla"
 
@@ -2918,8 +2931,8 @@ msgid "Rotate key"
 msgstr "Rotar clave"
 
 #: src/pages/RoutineEditor.tsx:265
-#: src/pages/Shell.tsx:3419
-#: src/pages/Shell.tsx:3431
+#: src/pages/Shell.tsx:3429
+#: src/pages/Shell.tsx:3441
 msgid "Routine"
 msgstr "Rutina"
 
@@ -2936,7 +2949,7 @@ msgstr "Ejecutar a las"
 msgid "Run history"
 msgstr "Historial de ejecuciones"
 
-#: src/pages/Shell.tsx:3412
+#: src/pages/Shell.tsx:3422
 msgid "Run time must be in the future."
 msgstr "La hora de ejecución debe ser en el futuro."
 
@@ -2966,7 +2979,7 @@ msgstr ""
 #: src/pages/GroupPanel.tsx:236
 #: src/pages/KnowledgeSection.tsx:203
 #: src/pages/KnowledgeSection.tsx:422
-#: src/pages/ModelSettingsOverlay.tsx:693
+#: src/pages/ModelSettingsOverlay.tsx:697
 #: src/pages/RoutineEditor.tsx:489
 #: src/pages/shell/bot-panel.tsx:539
 msgid "Save"
@@ -2983,7 +2996,7 @@ msgstr "Guardado"
 msgid "Saved, but list refresh failed"
 msgstr "Guardado, pero falló la actualización de la lista"
 
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Saved."
 msgstr "Guardado."
 
@@ -3002,7 +3015,7 @@ msgstr ""
 #: src/components/AskCard.tsx:157
 #: src/components/teach/SkillDraftCard.tsx:142
 #: src/pages/GroupPanel.tsx:236
-#: src/pages/ModelSettingsOverlay.tsx:691
+#: src/pages/ModelSettingsOverlay.tsx:695
 #: src/pages/RoutineEditor.tsx:489
 msgid "Saving…"
 msgstr "Guardando…"
@@ -3016,15 +3029,15 @@ msgstr "Di algo. El silencio lo envía."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "Di sí o no, o responde en una frase."
 
-#: src/pages/ModelSettingsOverlay.tsx:984
+#: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
-#: src/pages/Shell.tsx:2530
+#: src/pages/Shell.tsx:2540
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "Buscar"
 
-#: src/components/integrations/IntegrationSetup.tsx:241
-#: src/components/integrations/IntegrationSetup.tsx:242
+#: src/components/integrations/IntegrationSetup.tsx:250
+#: src/components/integrations/IntegrationSetup.tsx:251
 #: src/pages/PluginsOverlay.tsx:696
 #: src/pages/PluginsOverlay.tsx:697
 msgid "Search apps"
@@ -3038,11 +3051,11 @@ msgstr ""
 msgid "Search by domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:247
+#: src/components/integrations/IntegrationSetup.tsx:256
 msgid "Search integrations.sh"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:979
+#: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr "Buscar modelos"
 
@@ -3051,8 +3064,8 @@ msgstr "Buscar modelos"
 msgid "Search or create Bots"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:355
-#: src/pages/ModelSettingsOverlay.tsx:361
+#: src/pages/ModelSettingsOverlay.tsx:359
+#: src/pages/ModelSettingsOverlay.tsx:365
 msgid "Search providers"
 msgstr "Buscar proveedores"
 
@@ -3066,7 +3079,7 @@ msgstr "Buscar proveedores y modelos"
 msgid "Searching…"
 msgstr "Buscando…"
 
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3030
 msgid "Select a bot"
 msgstr "Selecciona un bot"
 
@@ -3074,8 +3087,8 @@ msgstr "Selecciona un bot"
 msgid "Selected"
 msgstr "Seleccionado"
 
-#: src/pages/Shell.tsx:4929
-#: src/pages/Shell.tsx:4950
+#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4964
 msgid "Send"
 msgstr "Enviar"
 
@@ -3105,8 +3118,9 @@ msgstr "Enviando…"
 msgid "Sentry alert"
 msgstr "Alerta de Sentry"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/AccountSettingsOverlay.tsx:158
+#: src/pages/LocalSettings.tsx:42
 msgid "Server integrations"
 msgstr ""
 
@@ -3114,33 +3128,33 @@ msgstr ""
 msgid "Server name"
 msgstr "Nombre del servidor"
 
-#: src/components/integrations/IntegrationSetup.tsx:273
-#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:282
+#: src/components/integrations/IntegrationSetup.tsx:300
 #: src/pages/McpServersOverlay.tsx:329
-#: src/pages/ModelSettingsOverlay.tsx:412
+#: src/pages/ModelSettingsOverlay.tsx:416
 #: src/pages/Onboarding.tsx:390
 msgid "Server URL"
 msgstr "URL del servidor"
 
 #: src/pages/MessagingSettingsOverlay.tsx:361
 #: src/pages/SettingsOverlay.tsx:103
-#: src/pages/SettingsOverlay.tsx:151
-#: src/pages/Shell.tsx:2896
-#: src/pages/Shell.tsx:2903
-#: src/pages/Shell.tsx:3152
+#: src/pages/SettingsOverlay.tsx:158
+#: src/pages/Shell.tsx:2906
+#: src/pages/Shell.tsx:2913
+#: src/pages/Shell.tsx:3162
 msgid "Settings"
 msgstr "Configuración"
 
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4982
 msgid "Settings: General"
 msgstr "Configuración: General"
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4984
 msgid "Settings: Usage"
 msgstr "Configuración: Uso"
 
-#: src/components/integrations/IntegrationSetup.tsx:319
-#: src/pages/ModelSettingsOverlay.tsx:425
+#: src/components/integrations/IntegrationSetup.tsx:328
+#: src/pages/ModelSettingsOverlay.tsx:429
 #: src/pages/Onboarding.tsx:403
 msgid "Setup help"
 msgstr "Ayuda de configuración"
@@ -3158,11 +3172,11 @@ msgstr "Documentos compartidos"
 msgid "Show all providers"
 msgstr "Mostrar todos los proveedores"
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Show bots"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show computer"
 msgstr "Mostrar computadora"
 
@@ -3178,14 +3192,14 @@ msgstr "Mostrar contraseña"
 msgid "Show popular providers"
 msgstr "Mostrar proveedores populares"
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show settings"
 msgstr "Mostrar configuración"
 
 #: src/lib/localized-provider-hint.ts:7
 #: src/pages/Auth.tsx:230
 #: src/pages/Auth.tsx:288
-#: src/pages/ModelSettingsOverlay.tsx:632
+#: src/pages/ModelSettingsOverlay.tsx:636
 #: src/pages/Onboarding.tsx:152
 msgid "Sign in"
 msgstr "Iniciar sesión"
@@ -3200,7 +3214,7 @@ msgid "Sign up"
 msgstr "Registrarse"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4758
 msgid "Skill {0}"
 msgstr "Habilidad {0}"
 
@@ -3208,8 +3222,8 @@ msgstr "Habilidad {0}"
 msgid "Skills"
 msgstr "Habilidades"
 
-#: src/components/integrations/IntegrationSetup.tsx:355
-#: src/pages/Shell.tsx:5171
+#: src/components/integrations/IntegrationSetup.tsx:364
+#: src/pages/Shell.tsx:5185
 msgid "Skip"
 msgstr "Omitir"
 
@@ -3218,7 +3232,7 @@ msgid "Skip or deploy key"
 msgstr "Omitir o desplegar clave"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1842
+#: src/pages/Shell.tsx:1852
 msgid "Skipped {0}"
 msgstr "Se omitió {0}"
 
@@ -3250,21 +3264,21 @@ msgstr "Space interrumpe · Esc cuelga"
 msgid "Spaces"
 msgstr ""
 
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Speak"
 msgstr "Hablar"
 
-#: src/pages/VoiceSettingsOverlay.tsx:190
+#: src/pages/VoiceSettingsOverlay.tsx:194
 msgid "Speak + transcribe"
 msgstr "Hablar + transcribir"
 
-#: src/pages/VoiceSettingsOverlay.tsx:192
+#: src/pages/VoiceSettingsOverlay.tsx:196
 msgid "Speak only"
 msgstr "Solo hablar"
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Speak this reply"
 msgstr "Leer esta respuesta"
 
@@ -3281,7 +3295,7 @@ msgid "Starting"
 msgstr "Iniciando"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
-#: src/pages/ModelSettingsOverlay.tsx:630
+#: src/pages/ModelSettingsOverlay.tsx:634
 #: src/pages/Onboarding.tsx:554
 msgid "Starting…"
 msgstr "Iniciando…"
@@ -3290,11 +3304,11 @@ msgstr "Iniciando…"
 msgid "Steps"
 msgstr "Pasos"
 
-#: src/pages/Shell.tsx:3912
-#: src/pages/Shell.tsx:3917
-#: src/pages/Shell.tsx:4939
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:3926
+#: src/pages/Shell.tsx:3931
+#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Stop"
 msgstr "Detener"
 
@@ -3302,8 +3316,8 @@ msgstr "Detener"
 msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
 msgstr ""
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Stop speaking"
 msgstr "Dejar de hablar"
 
@@ -3321,20 +3335,20 @@ msgstr "Detenido."
 msgid "Stored encrypted"
 msgstr "Almacenado cifrado"
 
-#: src/pages/ModelSettingsOverlay.tsx:545
+#: src/pages/ModelSettingsOverlay.tsx:549
 msgid "Stored securely. Never shown here."
 msgstr "Almacenado de forma segura. Nunca se muestra aquí."
 
-#: src/pages/Shell.tsx:5383
+#: src/pages/Shell.tsx:5397
 msgid "subagent"
 msgstr "subagente"
 
-#: src/pages/ModelSettingsOverlay.tsx:590
+#: src/pages/ModelSettingsOverlay.tsx:594
 #: src/pages/Onboarding.tsx:521
 msgid "Submit"
 msgstr "Enviar"
 
-#: src/pages/ModelSettingsOverlay.tsx:503
+#: src/pages/ModelSettingsOverlay.tsx:507
 #: src/pages/Onboarding.tsx:462
 msgid "Supports thinking"
 msgstr "Admite razonamiento"
@@ -3343,7 +3357,7 @@ msgstr "Admite razonamiento"
 msgid "Switch bot"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:723
+#: src/pages/ModelSettingsOverlay.tsx:727
 msgid "Switching…"
 msgstr "Cambiando…"
 
@@ -3356,7 +3370,7 @@ msgstr "Sistema"
 msgid "Teach a task"
 msgstr "Enseñar una tarea"
 
-#: src/pages/Shell.tsx:3076
+#: src/pages/Shell.tsx:3086
 msgid "Teaching in progress. Stop teaching before sending a new message."
 msgstr "Enseñanza en curso: detén la enseñanza antes de enviar un nuevo mensaje."
 
@@ -3364,7 +3378,7 @@ msgstr "Enseñanza en curso: detén la enseñanza antes de enviar un nuevo mensa
 msgid "Team"
 msgstr "Equipo"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "Team Computer"
 msgstr "Team Computer"
 
@@ -3394,7 +3408,7 @@ msgstr "Ejecución de prueba"
 msgid "The API did not come back. Refresh this page."
 msgstr "La API no volvió. Actualiza esta página."
 
-#: src/pages/MemorySettingsOverlay.tsx:241
+#: src/pages/MemorySettingsOverlay.tsx:245
 msgid "The selected memory provider is not available in this build."
 msgstr "El proveedor de memoria seleccionado no está disponible en esta build."
 
@@ -3402,7 +3416,7 @@ msgstr "El proveedor de memoria seleccionado no está disponible en esta build."
 msgid "Thinking"
 msgstr "Pensando"
 
-#: src/pages/Shell.tsx:5632
+#: src/pages/Shell.tsx:5646
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Este bot se ejecuta en esta computadora, no en un escritorio Linux. El shell y los archivos usan tu carpeta de inicio."
 
@@ -3455,7 +3469,7 @@ msgstr "Este servidor ya está conectado. Desconéctalo primero para autorizarlo
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools. A popup will open."
 msgstr "Este servidor usa inicio de sesión en el navegador. Autorízalo para que tus agentes usen sus herramientas: se abrirá una ventana emergente."
 
-#: src/pages/ModelSettingsOverlay.tsx:705
+#: src/pages/ModelSettingsOverlay.tsx:709
 msgid "This subscription sign-in is not available in Rakazo yet. Use a deployment credential or choose another provider."
 msgstr "Este inicio de sesión por suscripción aún no está disponible en Rakazo. Usa una credencial de despliegue o elige otro proveedor."
 
@@ -3514,7 +3528,7 @@ msgid "Unpin"
 msgstr "Desfijar"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1920
+#: src/pages/Shell.tsx:1930
 msgid "Unsupported file type: {0}"
 msgstr "Tipo de archivo no compatible: {0}"
 
@@ -3574,8 +3588,8 @@ msgstr "Actualizando…"
 
 #: src/pages/AccountSettingsOverlay.tsx:199
 #: src/pages/SettingsOverlay.tsx:96
-#: src/pages/Shell.tsx:2908
-#: src/pages/Shell.tsx:2919
+#: src/pages/Shell.tsx:2918
+#: src/pages/Shell.tsx:2929
 msgid "Usage"
 msgstr "Uso"
 
@@ -3583,7 +3597,7 @@ msgstr "Uso"
 msgid "Use {hostLabel}"
 msgstr "Usar {hostLabel}"
 
-#: src/pages/ModelSettingsOverlay.tsx:490
+#: src/pages/ModelSettingsOverlay.tsx:494
 #: src/pages/Onboarding.tsx:454
 msgid "Use a found model"
 msgstr "Usar un modelo encontrado"
@@ -3593,7 +3607,7 @@ msgstr "Usar un modelo encontrado"
 msgid "Use default guidance"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:725
+#: src/pages/ModelSettingsOverlay.tsx:729
 msgid "Use this model"
 msgstr "Usar este modelo"
 
@@ -3606,16 +3620,16 @@ msgid "Verifying…"
 msgstr "Verificando…"
 
 #: src/pages/SettingsOverlay.tsx:95
-#: src/pages/Shell.tsx:4916
-#: src/pages/Shell.tsx:4917
+#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:4931
 #: src/pages/shell/bot-panel.tsx:482
-#: src/pages/VoiceSettingsOverlay.tsx:150
-#: src/pages/VoiceSettingsOverlay.tsx:249
+#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Voice"
 msgstr "Voz"
 
-#: src/pages/ModelSettingsOverlay.tsx:594
-#: src/pages/ModelSettingsOverlay.tsx:616
+#: src/pages/ModelSettingsOverlay.tsx:598
+#: src/pages/ModelSettingsOverlay.tsx:620
 #: src/pages/Onboarding.tsx:525
 #: src/pages/Onboarding.tsx:547
 msgid "Waiting for sign-in…"
@@ -3687,8 +3701,8 @@ msgstr ""
 msgid "Working…"
 msgstr "Trabajando…"
 
-#: src/pages/Shell.tsx:1616
-#: src/pages/Shell.tsx:2393
+#: src/pages/Shell.tsx:1626
+#: src/pages/Shell.tsx:2403
 msgid "You"
 msgstr "Tú"
 
@@ -3700,7 +3714,7 @@ msgstr "Puedes cerrar esta pestaña si no redirige automáticamente."
 msgid "You can close this window."
 msgstr "Puedes cerrar esta ventana."
 
-#: src/pages/Shell.tsx:3901
+#: src/pages/Shell.tsx:3915
 msgid "You have control"
 msgstr "Tienes el control"
 

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -13,22 +13,22 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2720
+#: src/pages/Shell.tsx:2730
 msgid " (unread)"
 msgstr " (अपठित)"
 
 #. placeholder {0}: group.entries.length
-#: src/pages/ModelSettingsOverlay.tsx:382
+#: src/pages/ModelSettingsOverlay.tsx:386
 msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# मॉडल} other {# मॉडल}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1822
+#: src/pages/Shell.tsx:1832
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (अधिकतम {ATTACHMENT_MAX_COUNT} अटैचमेंट)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1826
+#: src/pages/Shell.tsx:1836
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB से अधिक)"
 
@@ -80,11 +80,11 @@ msgid "{0} will still respond to direct mentions."
 msgstr ""
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3245
+#: src/pages/Shell.tsx:3255
 msgid "{0}'s screen"
 msgstr ""
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "{botName}’s computer"
 msgstr "{botName} का कंप्यूटर"
 
@@ -132,12 +132,12 @@ msgstr "{title}, {label}"
 msgid "{toolCount, plural, one {# tool} other {# tools}}"
 msgstr ""
 
-#: src/pages/Shell.tsx:4072
+#: src/pages/Shell.tsx:4086
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} काम कर रहा है"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4711
+#: src/pages/Shell.tsx:4725
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "About spaces"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:301
+#: src/components/integrations/IntegrationSetup.tsx:310
 msgid "Access token"
 msgstr ""
 
@@ -188,7 +188,7 @@ msgstr "कार्रवाई की पुष्टि"
 msgid "Actions for {0}"
 msgstr "{0} के लिए कार्रवाइयां"
 
-#: src/pages/Shell.tsx:3619
+#: src/pages/Shell.tsx:3629
 msgid "Actions for space"
 msgstr ""
 
@@ -196,12 +196,12 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:337
+#: src/pages/ModelSettingsOverlay.tsx:341
 msgid "Active model"
 msgstr "सक्रिय मॉडल"
 
-#: src/pages/Shell.tsx:2440
-#: src/pages/Shell.tsx:2442
+#: src/pages/Shell.tsx:2450
+#: src/pages/Shell.tsx:2452
 msgid "Activity"
 msgstr "गतिविधि"
 
@@ -215,11 +215,11 @@ msgstr "जोड़ें"
 msgid "Add a model in Settings to use this."
 msgstr ""
 
-#: src/pages/Shell.tsx:3407
+#: src/pages/Shell.tsx:3417
 msgid "Add a run time for this one-shot."
 msgstr ""
 
-#: src/pages/Shell.tsx:3385
+#: src/pages/Shell.tsx:3395
 msgid "Add a schedule, webhook, GitHub, or message trigger"
 msgstr ""
 
@@ -259,7 +259,7 @@ msgstr "GraphQL एंडपॉइंट जोड़ें"
 msgid "Add item"
 msgstr "आइटम जोड़ें"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/PluginsOverlay.tsx:951
 msgid "Add MCP server"
 msgstr "MCP सर्वर जोड़ें"
@@ -277,12 +277,12 @@ msgstr "रिमोट MCP सर्वर जोड़ें"
 msgid "Add server"
 msgstr "सर्वर जोड़ें"
 
-#: src/components/integrations/IntegrationSetup.tsx:269
+#: src/components/integrations/IntegrationSetup.tsx:278
 msgid "Add server URL"
 msgstr ""
 
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Add thumbs-up"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr "जोड़ा जा रहा है…"
 
 #: src/pages/AccountSettingsOverlay.tsx:166
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/ModelSettingsOverlay.tsx:502
+#: src/pages/ModelSettingsOverlay.tsx:506
 #: src/pages/Onboarding.tsx:461
 #: src/pages/PluginsOverlay.tsx:836
 #: src/pages/RoutineSchedule.tsx:43
@@ -323,7 +323,7 @@ msgstr "उन्नत"
 msgid "Advanced..."
 msgstr ""
 
-#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3039
 msgid "Agent computer"
 msgstr "एजेंट कंप्यूटर"
 
@@ -405,15 +405,15 @@ msgid "API is back, but the update did not finish. Check the host logs."
 msgstr ""
 
 #: src/components/AskCard.tsx:44
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 #: src/lib/localized-provider-hint.ts:9
-#: src/pages/ModelSettingsOverlay.tsx:644
-#: src/pages/ModelSettingsOverlay.tsx:647
-#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:648
+#: src/pages/ModelSettingsOverlay.tsx:651
+#: src/pages/ModelSettingsOverlay.tsx:670
 #: src/pages/Onboarding.tsx:563
 #: src/pages/Onboarding.tsx:566
 #: src/pages/Onboarding.tsx:580
-#: src/pages/VoiceSettingsOverlay.tsx:219
+#: src/pages/VoiceSettingsOverlay.tsx:223
 msgid "API key"
 msgstr "API कुंजी"
 
@@ -444,15 +444,15 @@ msgstr "अपने एजेंट को इसके टूल उपयो�
 msgid "Archive"
 msgstr "आर्काइव करें"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5431
 msgid "archived"
 msgstr "आर्काइव किया गया"
 
-#: src/pages/Shell.tsx:2789
+#: src/pages/Shell.tsx:2799
 msgid "Archived"
 msgstr "आर्काइव किया गया"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5442
 msgid "Archived. Chat, memory, and files kept."
 msgstr "आर्काइव किया गया। चैट, मेमोरी और फ़ाइलें सुरक्षित रखी गईं।"
 
@@ -491,7 +491,7 @@ msgstr "खरीद से पहले पूछें"
 msgid "Ask before sending external email"
 msgstr "बाहरी ईमेल भेजने से पहले पूछें"
 
-#: src/components/integrations/IntegrationSetup.tsx:219
+#: src/components/integrations/IntegrationSetup.tsx:228
 msgid "Ask the server owner to configure this provider."
 msgstr ""
 
@@ -506,15 +506,15 @@ msgstr "{0} बजे"
 msgid "at {timeSelect}"
 msgstr "{timeSelect} बजे"
 
-#: src/pages/Shell.tsx:4791
+#: src/pages/Shell.tsx:4805
 msgid "Attach file"
 msgstr "फ़ाइल संलग्न करें"
 
-#: src/pages/Shell.tsx:5023
+#: src/pages/Shell.tsx:5037
 msgid "Attachment"
 msgstr "अटैचमेंट"
 
-#: src/pages/ModelSettingsOverlay.tsx:577
+#: src/pages/ModelSettingsOverlay.tsx:581
 #: src/pages/Onboarding.tsx:512
 msgid "Authorization code or callback URL"
 msgstr "ऑथराइज़ेशन कोड या कॉलबैक URL"
@@ -567,23 +567,23 @@ msgstr "बेस URL"
 msgid "Bearer token"
 msgstr "बियरर टोकन"
 
-#: src/pages/Shell.tsx:5644
+#: src/pages/Shell.tsx:5658
 msgid "Booting live desktop…"
 msgstr "लाइव डेस्कटॉप शुरू हो रहा है…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3877
 msgid "Booting up {0}’s computer"
 msgstr "{0} का कंप्यूटर शुरू हो रहा है"
 
-#: src/pages/Shell.tsx:5292
-#: src/pages/Shell.tsx:5293
-#: src/pages/Shell.tsx:5421
+#: src/pages/Shell.tsx:5306
+#: src/pages/Shell.tsx:5307
+#: src/pages/Shell.tsx:5435
 msgid "bot"
 msgstr "बॉट"
 
 #: src/pages/IntegrationSetup.tsx:51
-#: src/pages/Shell.tsx:1617
+#: src/pages/Shell.tsx:1627
 msgid "Bot"
 msgstr "बॉट"
 
@@ -592,11 +592,11 @@ msgstr "बॉट"
 msgid "Bot"
 msgstr "बॉट"
 
-#: src/pages/Shell.tsx:3971
+#: src/pages/Shell.tsx:3985
 msgid "Bot screen"
 msgstr "बॉट स्क्रीन"
 
-#: src/pages/Shell.tsx:3208
+#: src/pages/Shell.tsx:3218
 msgid "Bot screen preview"
 msgstr "बॉट स्क्रीन प्रीव्यू"
 
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first."
 msgstr "बॉट डिफ़ॉल्ट रूप से बिना पूछे कार्रवाई करते हैं। अपवाद तभी जोड़ें जब आप किसी प्रकार की कार्रवाई की पहले समीक्षा करना चाहते हों।"
 
-#: src/pages/Shell.tsx:4073
+#: src/pages/Shell.tsx:4087
 msgid "Bots are working"
 msgstr "बॉट काम कर रहे हैं"
 
@@ -620,7 +620,7 @@ msgstr ""
 msgid "Call"
 msgstr "कॉल"
 
-#: src/App.tsx:152
+#: src/App.tsx:159
 msgid "Can't reach the server."
 msgstr "सर्वर तक नहीं पहुंचा जा सका।"
 
@@ -648,7 +648,7 @@ msgstr "नया बॉट रद्द करें"
 msgid "Cancel new group"
 msgstr "नया समूह रद्द करें"
 
-#: src/pages/Shell.tsx:4649
+#: src/pages/Shell.tsx:4663
 msgid "Cancel reply"
 msgstr "उत्तर रद्द करें"
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Chat apps, group channels, and agent connections."
 msgstr ""
 
-#: src/pages/Shell.tsx:4966
+#: src/pages/Shell.tsx:4980
 msgid "Chat Settings"
 msgstr "चैट सेटिंग्स"
 
@@ -699,8 +699,8 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: src/pages/Shell.tsx:3420
-#: src/pages/Shell.tsx:3432
+#: src/pages/Shell.tsx:3430
+#: src/pages/Shell.tsx:3442
 msgid "Check in."
 msgstr "जांच करें।"
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Choose a new password"
 msgstr "नया पासवर्ड चुनें"
 
-#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:312
 msgid "Choose which connected model Rakazo uses."
 msgstr "चुनें कि Rakazo किस कनेक्टेड मॉडल का उपयोग करे।"
 
@@ -747,11 +747,11 @@ msgstr "बातचीत साफ़ करें"
 msgid "Clearing…"
 msgstr "साफ़ किया जा रहा है…"
 
-#: src/components/integrations/IntegrationSetup.tsx:167
+#: src/components/integrations/IntegrationSetup.tsx:172
 msgid "Client ID"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 msgid "Client secret"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr "बंद करें"
 msgid "Close chart"
 msgstr "चार्ट बंद करें"
 
-#: src/pages/Shell.tsx:3950
+#: src/pages/Shell.tsx:3964
 msgid "Close computer"
 msgstr "कंप्यूटर बंद करें"
 
@@ -784,7 +784,7 @@ msgstr "इंटीग्रेशन बंद करें"
 msgid "Close MCP servers"
 msgstr "MCP सर्वर बंद करें"
 
-#: src/pages/MemorySettingsOverlay.tsx:164
+#: src/pages/MemorySettingsOverlay.tsx:168
 #: src/pages/SettingsOverlay.tsx:109
 msgid "Close memory settings"
 msgstr "मेमोरी सेटिंग्स बंद करें"
@@ -793,16 +793,16 @@ msgstr "मेमोरी सेटिंग्स बंद करें"
 msgid "Close messaging settings"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:324
+#: src/pages/ModelSettingsOverlay.tsx:328
 #: src/pages/SettingsOverlay.tsx:107
 msgid "Close model settings"
 msgstr "मॉडल सेटिंग्स बंद करें"
 
-#: src/pages/Shell.tsx:2418
+#: src/pages/Shell.tsx:2428
 msgid "Close navigation"
 msgstr "नेविगेशन बंद करें"
 
-#: src/pages/Shell.tsx:3186
+#: src/pages/Shell.tsx:3196
 msgid "Close panel"
 msgstr "पैनल बंद करें"
 
@@ -815,7 +815,7 @@ msgid "Close user settings"
 msgstr "उपयोगकर्ता सेटिंग्स बंद करें"
 
 #: src/pages/SettingsOverlay.tsx:111
-#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:158
 msgid "Close voice settings"
 msgstr "आवाज़ सेटिंग्स बंद करें"
 
@@ -828,7 +828,7 @@ msgid "Code"
 msgstr "कोड"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2590
+#: src/pages/Shell.tsx:2600
 msgid "Collapse {0}"
 msgstr ""
 
@@ -855,24 +855,24 @@ msgid "Complete"
 msgstr "पूर्ण"
 
 #: src/pages/SettingsOverlay.tsx:97
-#: src/pages/Shell.tsx:5578
+#: src/pages/Shell.tsx:5592
 #: src/pages/shell/bot-panel.tsx:57
 msgid "Computer"
 msgstr "कंप्यूटर"
 
-#: src/pages/Shell.tsx:5647
+#: src/pages/Shell.tsx:5661
 msgid "Computer failed to boot"
 msgstr "कंप्यूटर शुरू नहीं हो सका"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4008
 msgid "Computer is asleep"
 msgstr "कंप्यूटर निष्क्रिय है"
 
-#: src/pages/Shell.tsx:5646
+#: src/pages/Shell.tsx:5660
 msgid "Computer is asleep. Open it to wake."
 msgstr ""
 
-#: src/pages/Shell.tsx:5648
+#: src/pages/Shell.tsx:5662
 msgid "Computer is stopped"
 msgstr "कंप्यूटर रुका हुआ है"
 
@@ -884,7 +884,7 @@ msgstr "कंप्यूटर"
 msgid "Computers are off. Set SANDBOX_PROVIDER=docker with SANDBOX_SUPERVISOR_TOKEN, or set SANDBOX_PROVIDER to e2b, daytona, or box with its API key. Recreate the stack after changing .env."
 msgstr "कंप्यूटर बंद हैं। SANDBOX_PROVIDER=docker और SANDBOX_SUPERVISOR_TOKEN सेट करें, या SANDBOX_PROVIDER को e2b, daytona, या box पर सेट कर उसका API key दें। .env बदलने के बाद स्टैक फिर बनाएँ।"
 
-#: src/pages/ModelSettingsOverlay.tsx:344
+#: src/pages/ModelSettingsOverlay.tsx:348
 msgid "Configured by deployment"
 msgstr "डिप्लॉयमेंट द्वारा कॉन्फ़िगर"
 
@@ -902,12 +902,12 @@ msgstr "डिलीट की पुष्टि करें"
 msgid "Confirm password"
 msgstr "पासवर्ड की पुष्टि करें"
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:258
-#: src/components/integrations/IntegrationSetup.tsx:282
-#: src/components/integrations/IntegrationSetup.tsx:315
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:267
+#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:324
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
-#: src/pages/VoiceSettingsOverlay.tsx:241
+#: src/pages/VoiceSettingsOverlay.tsx:245
 msgid "Connect"
 msgstr "कनेक्ट करें"
 
@@ -915,7 +915,7 @@ msgstr "कनेक्ट करें"
 msgid "Connect a model"
 msgstr "एक मॉडल कनेक्ट करें"
 
-#: src/pages/ModelSettingsOverlay.tsx:697
+#: src/pages/ModelSettingsOverlay.tsx:701
 msgid "Connect API key"
 msgstr "API कुंजी कनेक्ट करें"
 
@@ -931,7 +931,7 @@ msgstr "MCP सर्वर “{name}” कनेक्ट करें"
 msgid "Connect OAuth"
 msgstr "OAuth कनेक्ट करें"
 
-#: src/pages/ModelSettingsOverlay.tsx:547
+#: src/pages/ModelSettingsOverlay.tsx:551
 msgid "Connect this provider to use it as your personal model."
 msgstr "इस प्रोवाइडर को अपने व्यक्तिगत मॉडल के रूप में उपयोग करने के लिए कनेक्ट करें।"
 
@@ -939,30 +939,30 @@ msgstr "इस प्रोवाइडर को अपने व्यक्�
 msgid "Connect Treg"
 msgstr "Treg कनेक्ट करें"
 
-#: src/components/integrations/IntegrationSetup.tsx:159
-#: src/components/integrations/IntegrationSetup.tsx:258
+#: src/components/integrations/IntegrationSetup.tsx:164
+#: src/components/integrations/IntegrationSetup.tsx:267
 #: src/pages/McpOAuthCallback.tsx:54
-#: src/pages/MemorySettingsOverlay.tsx:187
-#: src/pages/ModelSettingsOverlay.tsx:389
+#: src/pages/MemorySettingsOverlay.tsx:191
+#: src/pages/ModelSettingsOverlay.tsx:393
 #: src/pages/shell/message-cards.tsx:187
-#: src/pages/VoiceSettingsOverlay.tsx:198
+#: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "कनेक्टेड"
 
 #. placeholder {0}: credential.label
-#: src/pages/ModelSettingsOverlay.tsx:538
+#: src/pages/ModelSettingsOverlay.tsx:542
 msgid "Connected · {0}"
 msgstr "कनेक्टेड · {0}"
 
 #. placeholder {0}: selected.name
-#: src/pages/VoiceSettingsOverlay.tsx:102
+#: src/pages/VoiceSettingsOverlay.tsx:106
 msgid "Connected {0}."
 msgstr "{0} कनेक्ट किया गया।"
 
 #. placeholder {0}: selected.label
 #. placeholder {0}: selectedLabelRef.current ?? "this model"
-#: src/pages/ModelSettingsOverlay.tsx:82
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:84
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Connected and using {0}."
 msgstr "{0} कनेक्ट किया गया और उपयोग में है।"
 
@@ -970,12 +970,12 @@ msgstr "{0} कनेक्ट किया गया और उपयोग म
 msgid "Connected. Its tools are available from your next message."
 msgstr "कनेक्टेड। इसके टूल आपके अगले संदेश से उपलब्ध हैं।"
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/McpServersOverlay.tsx:38
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
 #: src/pages/shell/message-cards.tsx:360
-#: src/pages/VoiceSettingsOverlay.tsx:237
+#: src/pages/VoiceSettingsOverlay.tsx:241
 msgid "Connecting…"
 msgstr "कनेक्ट हो रहा है…"
 
@@ -984,7 +984,7 @@ msgstr "कनेक्ट हो रहा है…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "{0} से कनेक्शन अभी लंबित है। आप इसे बंद करके बाद में जांच सकते हैं।"
 
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/Onboarding.tsx:604
 #: src/pages/Onboarding.tsx:667
 msgid "Continue"
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Continue with email"
 msgstr "ईमेल से जारी रखें"
 
-#: src/pages/Shell.tsx:5109
+#: src/pages/Shell.tsx:5123
 msgid "Copy"
 msgstr "कॉपी करें"
 
@@ -1022,7 +1022,7 @@ msgstr "इस ऐप को ऑथराइज़ नहीं किया ज
 msgid "Could not change password"
 msgstr "पासवर्ड बदला नहीं जा सका"
 
-#: src/pages/ModelSettingsOverlay.tsx:245
+#: src/pages/ModelSettingsOverlay.tsx:247
 msgid "Could not change the default model"
 msgstr "डिफ़ॉल्ट मॉडल बदला नहीं जा सका"
 
@@ -1046,30 +1046,30 @@ msgstr "OAuth पूरा नहीं हो सका"
 msgid "Could not complete the update. Try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:76
+#: src/components/integrations/IntegrationSetup.tsx:79
 #: src/pages/PluginsOverlay.tsx:264
 msgid "Could not connect"
 msgstr "कनेक्ट नहीं हो सका"
 
 #. placeholder {0}: registration.name
-#: src/pages/MemorySettingsOverlay.tsx:115
+#: src/pages/MemorySettingsOverlay.tsx:119
 msgid "Could not connect {0}"
 msgstr "{0} कनेक्ट नहीं हो सका"
 
-#: src/pages/ModelSettingsOverlay.tsx:284
+#: src/pages/ModelSettingsOverlay.tsx:286
 msgid "Could not connect this provider"
 msgstr "यह प्रोवाइडर कनेक्ट नहीं हो सका"
 
-#: src/pages/VoiceSettingsOverlay.tsx:104
+#: src/pages/VoiceSettingsOverlay.tsx:108
 msgid "Could not connect this voice provider"
 msgstr "यह आवाज़ प्रोवाइडर कनेक्ट नहीं हो सका"
 
-#: src/pages/Shell.tsx:875
+#: src/pages/Shell.tsx:885
 msgid "Could not connect to the computer screen"
 msgstr ""
 
 #: src/pages/Auth.tsx:99
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2368
 msgid "Could not continue"
 msgstr "जारी नहीं रखा जा सका"
 
@@ -1117,7 +1117,7 @@ msgstr "स्किल हटाई नहीं जा सकी"
 msgid "Could not delete space"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:129
+#: src/pages/MemorySettingsOverlay.tsx:133
 msgid "Could not disconnect memory provider"
 msgstr "मेमोरी प्रोवाइडर डिस्कनेक्ट नहीं हो सका"
 
@@ -1158,7 +1158,7 @@ msgstr "अनुमोदन नियम लोड नहीं हो सक�
 msgid "Could not load bots. Reload to try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:67
+#: src/components/integrations/IntegrationSetup.tsx:70
 #: src/pages/PluginsOverlay.tsx:143
 #: src/pages/PluginsOverlay.tsx:719
 msgid "Could not load integrations"
@@ -1168,7 +1168,7 @@ msgstr "इंटीग्रेशन लोड नहीं हो सके"
 msgid "Could not load MCP servers"
 msgstr "MCP सर्वर लोड नहीं हो सके"
 
-#: src/pages/ModelSettingsOverlay.tsx:129
+#: src/pages/ModelSettingsOverlay.tsx:131
 msgid "Could not load model settings"
 msgstr "मॉडल सेटिंग्स लोड नहीं हो सकीं"
 
@@ -1188,11 +1188,15 @@ msgstr "यह फ़ाइल लोड नहीं हो सकी।"
 msgid "Could not load update status"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:77
+#: src/pages/VoiceSettingsOverlay.tsx:81
 msgid "Could not load voice settings"
 msgstr "आवाज़ सेटिंग्स लोड नहीं हो सकीं"
 
-#: src/pages/VoiceSettingsOverlay.tsx:138
+#: src/pages/LocalSettings.tsx:26
+msgid "Could not open local settings. Start the local server and create its owner account, then try again."
+msgstr ""
+
+#: src/pages/VoiceSettingsOverlay.tsx:142
 msgid "Could not play a test clip"
 msgstr "टेस्ट क्लिप नहीं चलाई जा सकी"
 
@@ -1202,7 +1206,7 @@ msgstr "टेस्ट क्लिप नहीं चलाई जा सक�
 msgid "Could not reach the server"
 msgstr "सर्वर से संपर्क नहीं हो सका"
 
-#: src/pages/ModelSettingsOverlay.tsx:229
+#: src/pages/ModelSettingsOverlay.tsx:231
 #: src/pages/Onboarding.tsx:191
 msgid "Could not reach this model server"
 msgstr "इस मॉडल सर्वर तक नहीं पहुंचा जा सका"
@@ -1240,7 +1244,7 @@ msgstr "पासवर्ड रीसेट नहीं किया जा �
 msgid "Could not revoke connection"
 msgstr "कनेक्शन रद्द नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3496
 msgid "Could not run routine"
 msgstr ""
 
@@ -1262,7 +1266,7 @@ msgstr "समूह सहेजा नहीं जा सका"
 msgid "Could not save model"
 msgstr "मॉडल सहेजा नहीं जा सका"
 
-#: src/pages/Shell.tsx:3457
+#: src/pages/Shell.tsx:3467
 msgid "Could not save routine"
 msgstr "रूटीन सहेजा नहीं जा सका"
 
@@ -1278,7 +1282,7 @@ msgstr "स्किल सहेजी नहीं जा सकी"
 msgid "Could not save that choice"
 msgstr "वह विकल्प सहेजा नहीं जा सका"
 
-#: src/pages/VoiceSettingsOverlay.tsx:119
+#: src/pages/VoiceSettingsOverlay.tsx:123
 msgid "Could not save that voice"
 msgstr "वह आवाज़ सहेजी नहीं जा सकी"
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Could not submit this answer"
 msgstr "यह उत्तर सबमिट नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:2212
+#: src/pages/Shell.tsx:2222
 msgid "Could not take control"
 msgstr "नियंत्रण नहीं लिया जा सका"
 
@@ -1326,11 +1330,11 @@ msgstr "एजेंट एक्सेस अपडेट नहीं हो �
 msgid "Could not update computer"
 msgstr "कंप्यूटर अपडेट नहीं हो सका"
 
-#: src/pages/Shell.tsx:1808
+#: src/pages/Shell.tsx:1818
 msgid "Could not update reaction"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:143
+#: src/pages/MemorySettingsOverlay.tsx:147
 msgid "Could not update the default memory scope"
 msgstr "डिफ़ॉल्ट मेमोरी स्कोप अपडेट नहीं हो सका"
 
@@ -1346,7 +1350,7 @@ msgstr ""
 msgid "Couldn't update messaging settings"
 msgstr ""
 
-#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2481
 #: src/pages/shell/bot-panel.tsx:184
 #: src/pages/shell/dialogs.tsx:208
 msgid "Create"
@@ -1460,8 +1464,8 @@ msgstr "डिफ़ॉल्ट स्कोप"
 #: src/pages/KnowledgeSection.tsx:449
 #: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:301
-#: src/pages/Shell.tsx:2825
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2835
+#: src/pages/Shell.tsx:2866
 #: src/pages/shell/dialogs.tsx:351
 #: src/pages/shell/dialogs.tsx:412
 msgid "Delete"
@@ -1469,8 +1473,8 @@ msgstr "डिलीट करें"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2822
-#: src/pages/Shell.tsx:2853
+#: src/pages/Shell.tsx:2832
+#: src/pages/Shell.tsx:2863
 msgid "Delete {0}"
 msgstr "{0} डिलीट करें"
 
@@ -1489,11 +1493,11 @@ msgstr "समूह डिलीट करें"
 msgid "Delete memories too"
 msgstr "मेमोरी भी डिलीट करें"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3643
 msgid "Delete space"
 msgstr ""
 
-#: src/pages/Shell.tsx:5419
+#: src/pages/Shell.tsx:5433
 msgid "deleted"
 msgstr "डिलीट किया गया"
 
@@ -1511,7 +1515,7 @@ msgstr "अस्वीकृत"
 msgid "Deny"
 msgstr "अस्वीकार करें"
 
-#: src/pages/ModelSettingsOverlay.tsx:340
+#: src/pages/ModelSettingsOverlay.tsx:344
 msgid "Deployment default"
 msgstr "डिप्लॉयमेंट डिफ़ॉल्ट"
 
@@ -1534,16 +1538,16 @@ msgstr ""
 msgid "Desktop update"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:40
+#: src/components/integrations/IntegrationSetup.tsx:43
 msgid "Direct MCP"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:493
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnect"
 msgstr "डिस्कनेक्ट करें"
 
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnecting…"
 msgstr "डिस्कनेक्ट हो रहा है…"
 
@@ -1553,7 +1557,7 @@ msgstr "डिस्कनेक्ट हो रहा है…"
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/Shell.tsx:4629
+#: src/pages/Shell.tsx:4643
 msgid "Dismiss error"
 msgstr ""
 
@@ -1601,7 +1605,7 @@ msgstr "{name} डाउनलोड करें"
 msgid "Download as markdown"
 msgstr "मार्कडाउन के रूप में डाउनलोड करें"
 
-#: src/components/integrations/IntegrationSetup.tsx:327
+#: src/components/integrations/IntegrationSetup.tsx:336
 msgid "Download Executor"
 msgstr ""
 
@@ -1617,7 +1621,7 @@ msgstr "ड्राफ़्ट स्किल"
 msgid "Duplicate"
 msgstr "डुप्लिकेट"
 
-#: src/pages/Shell.tsx:5245
+#: src/pages/Shell.tsx:5259
 msgid "Earlier message"
 msgstr "पुराना संदेश"
 
@@ -1638,7 +1642,7 @@ msgid "Engage when... Ignore..."
 msgstr ""
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
-#: src/pages/ModelSettingsOverlay.tsx:600
+#: src/pages/ModelSettingsOverlay.tsx:604
 #: src/pages/Onboarding.tsx:531
 msgid "Enter this code at <0>{0}</0>"
 msgstr "यह कोड <0>{0}</0> पर दर्ज करें"
@@ -1687,7 +1691,7 @@ msgid "Expand"
 msgstr "विस्तृत करें"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2589
+#: src/pages/Shell.tsx:2599
 msgid "Expand {0}"
 msgstr ""
 
@@ -1716,14 +1720,14 @@ msgstr "असफल"
 msgid "Failed"
 msgstr "विफल"
 
-#: src/pages/Shell.tsx:1981
-#: src/pages/Shell.tsx:1983
-#: src/pages/Shell.tsx:1985
+#: src/pages/Shell.tsx:1991
+#: src/pages/Shell.tsx:1993
+#: src/pages/Shell.tsx:1995
 msgid "Failed to send message"
 msgstr "संदेश भेजने में विफल"
 
-#: src/pages/Shell.tsx:2018
-#: src/pages/Shell.tsx:2037
+#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2047
 msgid "Failed to stop"
 msgstr "रोकने में विफल"
 
@@ -1736,18 +1740,18 @@ msgstr "विफल।"
 msgid "Failure handling"
 msgstr "विफलता प्रबंधन"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Find models"
 msgstr "मॉडल खोजें"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Finding…"
 msgstr "खोजा जा रहा है…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
-#: src/pages/ModelSettingsOverlay.tsx:560
+#: src/pages/ModelSettingsOverlay.tsx:564
 #: src/pages/Onboarding.tsx:495
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "<0>{0}</0> पर साइन इन पूरा करें। अंतिम पेज शायद लोड न हो; उसका URL या कोड यहां पेस्ट करें।"
@@ -1773,7 +1777,7 @@ msgstr ""
 msgid "Forgot password?"
 msgstr "पासवर्ड भूल गए?"
 
-#: src/pages/ModelSettingsOverlay.tsx:1071
+#: src/pages/ModelSettingsOverlay.tsx:1075
 msgid "Free"
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgstr "फ़ुलस्क्रीन"
 msgid "General"
 msgstr "सामान्य"
 
-#: src/components/integrations/IntegrationSetup.tsx:209
+#: src/components/integrations/IntegrationSetup.tsx:214
 msgid "Get credentials"
 msgstr ""
 
@@ -1801,8 +1805,8 @@ msgid "Git event"
 msgstr ""
 
 #: src/pages/MessagingSettingsOverlay.tsx:204
-#: src/pages/Shell.tsx:3019
-#: src/pages/Shell.tsx:3156
+#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3166
 msgid "Group"
 msgstr "समूह"
 
@@ -1844,15 +1848,15 @@ msgstr "हेडर नाम"
 msgid "Header value"
 msgstr "हेडर मान"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Hear a sample"
 msgstr "एक नमूना सुनें"
 
-#: src/pages/VoiceSettingsOverlay.tsx:131
+#: src/pages/VoiceSettingsOverlay.tsx:135
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "नमस्ते, उत्तर पढ़कर सुनाते समय मेरी आवाज़ ऐसी होगी।"
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Hide bots"
 msgstr ""
 
@@ -1881,11 +1885,11 @@ msgstr "कितनी बार"
 msgid "How to check"
 msgstr "जांच कैसे करें"
 
-#: src/pages/Shell.tsx:5174
+#: src/pages/Shell.tsx:5188
 msgid "I’m done"
 msgstr "मेरा काम हो गया"
 
-#: src/pages/VoiceSettingsOverlay.tsx:136
+#: src/pages/VoiceSettingsOverlay.tsx:140
 msgid "If you heard that, voice is ready."
 msgstr "अगर आपने वह सुना, तो आवाज़ तैयार है।"
 
@@ -1917,12 +1921,12 @@ msgstr "निर्देश"
 msgid "Integration domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:133
+#: src/components/integrations/IntegrationSetup.tsx:136
 msgid "Integration options"
 msgstr ""
 
 #: src/pages/PluginsOverlay.tsx:679
-#: src/pages/Shell.tsx:2874
+#: src/pages/Shell.tsx:2884
 msgid "Integrations"
 msgstr "इंटीग्रेशन"
 
@@ -1952,11 +1956,11 @@ msgstr "पृथक"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "इसकी बातचीत, फ़ाइलें और रूटीन स्थायी रूप से डिलीट कर दिए जाएंगे। इसके बनाए बॉट आपकी सूची में बने रहेंगे।"
 
-#: src/pages/Shell.tsx:4289
+#: src/pages/Shell.tsx:4303
 msgid "Jump to latest"
 msgstr "नवीनतम संदेश पर जाएँ"
 
-#: src/pages/Shell.tsx:5240
+#: src/pages/Shell.tsx:5254
 msgid "Jump to replied message"
 msgstr "जिस संदेश का उत्तर दिया गया उस पर जाएं"
 
@@ -2014,7 +2018,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "सुना जा रहा है…"
 
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Load earlier messages"
 msgstr "पुराने संदेश लोड करें"
 
@@ -2026,12 +2030,12 @@ msgstr "गतिविधि लोड हो रही है…"
 msgid "Loading integrations…"
 msgstr "इंटीग्रेशन लोड हो रहे हैं…"
 
-#: src/pages/MemorySettingsOverlay.tsx:182
+#: src/pages/MemorySettingsOverlay.tsx:186
 msgid "Loading memory settings…"
 msgstr "मेमोरी सेटिंग्स लोड हो रही हैं…"
 
-#: src/pages/ModelSettingsOverlay.tsx:306
-#: src/pages/ModelSettingsOverlay.tsx:733
+#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:737
 msgid "Loading model catalog…"
 msgstr "मॉडल कैटलॉग लोड हो रहा है…"
 
@@ -2047,15 +2051,15 @@ msgstr "नियम लोड हो रहे हैं…"
 msgid "Loading tools…"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:210
+#: src/pages/VoiceSettingsOverlay.tsx:214
 msgid "Loading voice providers…"
 msgstr "आवाज़ प्रोवाइडर्स लोड हो रहे हैं…"
 
-#: src/App.tsx:58
+#: src/App.tsx:65
 #: src/pages/IntegrationSetup.tsx:72
 #: src/pages/Onboarding.tsx:282
 #: src/pages/PeerMessagesOverlay.tsx:98
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Loading…"
 msgstr "लोड हो रहा है…"
 
@@ -2067,7 +2071,11 @@ msgstr "लोकल"
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "स्थानीय पहुँच मिलने पर बॉट्स बिना पूछे कमांड चला सकते हैं। साझा या सार्वजनिक सर्वर पर इससे बचें।"
 
-#: src/pages/Shell.tsx:2932
+#: src/pages/LocalSettings.tsx:22
+msgid "Local Server Settings"
+msgstr ""
+
+#: src/pages/Shell.tsx:2942
 msgid "Log out"
 msgstr "लॉग आउट"
 
@@ -2083,8 +2091,8 @@ msgstr "MCP सर्वर प्रबंधित करें"
 msgid "Manage messaging settings"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:159
-#: src/pages/MemorySettingsOverlay.tsx:173
+#: src/pages/MemorySettingsOverlay.tsx:163
+#: src/pages/MemorySettingsOverlay.tsx:177
 msgid "Manage the Space semantic memory provider."
 msgstr "वर्कस्पेस के सिमेंटिक मेमोरी प्रोवाइडर को प्रबंधित करें।"
 
@@ -2125,7 +2133,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "सदस्य ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} चुनें)"
 
 #: src/pages/KnowledgeSection.tsx:39
-#: src/pages/MemorySettingsOverlay.tsx:155
+#: src/pages/MemorySettingsOverlay.tsx:159
 #: src/pages/SettingsOverlay.tsx:94
 msgid "Memory"
 msgstr "मेमोरी"
@@ -2134,7 +2142,7 @@ msgstr "मेमोरी"
 msgid "Memory scope"
 msgstr "मेमोरी स्कोप"
 
-#: src/pages/Shell.tsx:4697
+#: src/pages/Shell.tsx:4711
 msgid "Mentions"
 msgstr ""
 
@@ -2142,8 +2150,8 @@ msgstr ""
 msgid "Mentions only"
 msgstr ""
 
-#: src/pages/Shell.tsx:4898
-#: src/pages/Shell.tsx:5025
+#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:5039
 msgid "Message"
 msgstr "संदेश"
 
@@ -2152,12 +2160,12 @@ msgstr "संदेश"
 msgid "Message"
 msgstr "संदेश"
 
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4898
+#: src/pages/Shell.tsx:4908
+#: src/pages/Shell.tsx:4912
 msgid "Message {activeName}"
 msgstr "{activeName} को संदेश भेजें"
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4623
 msgid "Message composer"
 msgstr ""
 
@@ -2166,15 +2174,15 @@ msgstr ""
 msgid "Message event"
 msgstr ""
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Message from {peer}"
 msgstr "{peer} का संदेश"
 
-#: src/pages/Shell.tsx:4895
+#: src/pages/Shell.tsx:4909
 msgid "Message…"
 msgstr "संदेश…"
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Messaged {peer}"
 msgstr "{peer} को संदेश भेजा"
 
@@ -2195,8 +2203,8 @@ msgstr "न्यूनतम"
 msgid "Minimize"
 msgstr "छोटा करें"
 
-#: src/pages/Shell.tsx:2461
-#: src/pages/Shell.tsx:2462
+#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2472
 msgid "Minimize bots"
 msgstr ""
 
@@ -2208,9 +2216,9 @@ msgstr "मिनट"
 msgid "minutes"
 msgstr "मिनट"
 
-#: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/ModelSettingsOverlay.tsx:509
-#: src/pages/ModelSettingsOverlay.tsx:959
+#: src/pages/ModelSettingsOverlay.tsx:448
+#: src/pages/ModelSettingsOverlay.tsx:513
+#: src/pages/ModelSettingsOverlay.tsx:963
 #: src/pages/Onboarding.tsx:420
 #: src/pages/Onboarding.tsx:468
 #: src/pages/Onboarding.tsx:476
@@ -2218,12 +2226,12 @@ msgstr "मिनट"
 msgid "Model"
 msgstr "मॉडल"
 
-#: src/pages/ModelSettingsOverlay.tsx:478
+#: src/pages/ModelSettingsOverlay.tsx:482
 #: src/pages/Onboarding.tsx:442
 msgid "Model id"
 msgstr "मॉडल आईडी"
 
-#: src/pages/ModelSettingsOverlay.tsx:995
+#: src/pages/ModelSettingsOverlay.tsx:999
 msgid "Model options"
 msgstr "मॉडल विकल्प"
 
@@ -2235,16 +2243,21 @@ msgstr ""
 msgid "Model spend uses your provider keys."
 msgstr "मॉडल का खर्च आपकी प्रोवाइडर कुंजियों से होता है।"
 
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Model updated."
 msgstr "मॉडल अपडेट किया गया।"
 
-#: src/pages/ModelSettingsOverlay.tsx:317
+#: src/pages/LocalSettings.tsx:36
+#: src/pages/ModelSettingsOverlay.tsx:321
 #: src/pages/SettingsOverlay.tsx:93
 msgid "Models"
 msgstr "मॉडल्स"
 
-#: src/pages/ModelSettingsOverlay.tsx:457
+#: src/pages/ModelSettingsOverlay.tsx:310
+msgid "Models for the server owner’s default space."
+msgstr ""
+
+#: src/pages/ModelSettingsOverlay.tsx:461
 #: src/pages/Onboarding.tsx:426
 msgid "Models from server"
 msgstr "सर्वर से मॉडल"
@@ -2253,7 +2266,7 @@ msgstr "सर्वर से मॉडल"
 msgid "Monthly"
 msgstr "मासिक"
 
-#: src/pages/Shell.tsx:5082
+#: src/pages/Shell.tsx:5096
 msgid "More"
 msgstr ""
 
@@ -2303,7 +2316,7 @@ msgstr "इनपुट चाहिए"
 msgid "Needs takeover"
 msgstr "नियंत्रण लेना ज़रूरी"
 
-#: src/pages/Shell.tsx:3897
+#: src/pages/Shell.tsx:3911
 msgid "Needs you"
 msgstr ""
 
@@ -2381,7 +2394,7 @@ msgstr "अब सक्रिय नहीं"
 msgid "No managed app catalog is configured on this deployment."
 msgstr "इस डिप्लॉयमेंट पर कोई प्रबंधित ऐप कैटलॉग कॉन्फ़िगर नहीं है।"
 
-#: src/pages/ModelSettingsOverlay.tsx:1023
+#: src/pages/ModelSettingsOverlay.tsx:1027
 msgid "No matching models"
 msgstr ""
 
@@ -2397,7 +2410,7 @@ msgstr "अभी तक कोई MCP सर्वर नहीं।"
 msgid "No messages with {peerBotName} yet."
 msgstr "{peerBotName} के साथ अभी कोई संदेश नहीं."
 
-#: src/pages/ModelSettingsOverlay.tsx:737
+#: src/pages/ModelSettingsOverlay.tsx:741
 msgid "No model catalog is available."
 msgstr "कोई मॉडल कैटलॉग उपलब्ध नहीं है।"
 
@@ -2405,11 +2418,11 @@ msgstr "कोई मॉडल कैटलॉग उपलब्ध नही�
 msgid "No providers found"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:397
+#: src/pages/ModelSettingsOverlay.tsx:401
 msgid "No providers found."
 msgstr "कोई प्रोवाइडर नहीं मिला।"
 
-#: src/components/integrations/IntegrationSetup.tsx:264
+#: src/components/integrations/IntegrationSetup.tsx:273
 msgid "No remote MCP servers found"
 msgstr ""
 
@@ -2442,7 +2455,7 @@ msgstr ""
 msgid "None yet"
 msgstr "अभी तक कोई नहीं"
 
-#: src/pages/ModelSettingsOverlay.tsx:540
+#: src/pages/ModelSettingsOverlay.tsx:544
 msgid "Not connected"
 msgstr "कनेक्टेड नहीं"
 
@@ -2463,7 +2476,7 @@ msgid "Now"
 msgstr "अभी"
 
 #. placeholder {0}: selected.label
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Now using {0}."
 msgstr "अब {0} उपयोग में है।"
 
@@ -2496,26 +2509,26 @@ msgstr "1 तारीख को {0} बजे"
 msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
 msgstr ""
 
-#: src/pages/Shell.tsx:3671
+#: src/pages/Shell.tsx:3681
 msgid "Only empty spaces can be deleted. Delete its bots and groups first."
 msgstr ""
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3234
-#: src/pages/Shell.tsx:3239
+#: src/pages/Shell.tsx:3244
+#: src/pages/Shell.tsx:3249
 msgid "Open"
 msgstr "खोलें"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2597
 msgid "Open {0}"
 msgstr ""
 
-#: src/pages/Shell.tsx:3202
+#: src/pages/Shell.tsx:3212
 msgid "Open in full window"
 msgstr "पूरी विंडो में खोलें"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3001
 msgid "Open navigation"
 msgstr "नेविगेशन खोलें"
 
@@ -2523,20 +2536,20 @@ msgstr "नेविगेशन खोलें"
 msgid "Open work"
 msgstr "खुला कार्य"
 
-#: src/pages/ModelSettingsOverlay.tsx:417
+#: src/pages/ModelSettingsOverlay.tsx:421
 #: src/pages/Onboarding.tsx:395
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-संगत सर्वर URL"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5444
 msgid "Opened its thread."
 msgstr "इसका थ्रेड खोला।"
 
-#: src/App.tsx:195
+#: src/App.tsx:202
 msgid "Opening your Space…"
 msgstr "आपका वर्कस्पेस खुल रहा है…"
 
-#: src/pages/ModelSettingsOverlay.tsx:650
+#: src/pages/ModelSettingsOverlay.tsx:654
 #: src/pages/Onboarding.tsx:569
 msgid "Optional"
 msgstr "वैकल्पिक"
@@ -2549,7 +2562,7 @@ msgstr "वैकल्पिक नियंत्रण जिनकी अध
 msgid "Optional header value"
 msgstr "वैकल्पिक हेडर मान"
 
-#: src/pages/ModelSettingsOverlay.tsx:664
+#: src/pages/ModelSettingsOverlay.tsx:668
 msgid "Or connect an API key"
 msgstr "या एक API कुंजी कनेक्ट करें"
 
@@ -2565,7 +2578,7 @@ msgstr ""
 msgid "Organization API key"
 msgstr "संगठन API कुंजी"
 
-#: src/pages/ModelSettingsOverlay.tsx:465
+#: src/pages/ModelSettingsOverlay.tsx:469
 #: src/pages/Onboarding.tsx:435
 msgid "Other model…"
 msgstr "अन्य मॉडल…"
@@ -2600,16 +2613,16 @@ msgstr "पासवर्ड अपडेट हो गया"
 msgid "Passwords do not match"
 msgstr "पासवर्ड मेल नहीं खाते"
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste a replacement key"
 msgstr "बदलने के लिए नई कुंजी पेस्ट करें"
 
-#: src/pages/ModelSettingsOverlay.tsx:428
+#: src/pages/ModelSettingsOverlay.tsx:432
 #: src/pages/Onboarding.tsx:406
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "अपने सर्वर से OpenAI-संगत पता पेस्ट करें। ज़रूरत होने पर Rakazo /v1 जोड़ देता है।"
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste your API key"
 msgstr "अपनी API कुंजी पेस्ट करें"
 
@@ -2617,7 +2630,7 @@ msgstr "अपनी API कुंजी पेस्ट करें"
 msgid "Paused"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:534
+#: src/pages/ModelSettingsOverlay.tsx:538
 msgid "Personal credential"
 msgstr "व्यक्तिगत क्रेडेंशियल"
 
@@ -2625,7 +2638,7 @@ msgstr "व्यक्तिगत क्रेडेंशियल"
 msgid "Pin"
 msgstr "पिन करें"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Playing…"
 msgstr "प्ले हो रहा है…"
 
@@ -2642,17 +2655,17 @@ msgstr "{0} का प्रीव्यू"
 msgid "Private"
 msgstr "निजी"
 
-#: src/components/integrations/IntegrationSetup.tsx:177
+#: src/components/integrations/IntegrationSetup.tsx:182
 msgid "Project ID"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:215
+#: src/pages/MemorySettingsOverlay.tsx:219
 #: src/pages/Onboarding.tsx:292
 msgid "Provider"
 msgstr "प्रोवाइडर"
 
-#: src/pages/ModelSettingsOverlay.tsx:352
-#: src/pages/VoiceSettingsOverlay.tsx:166
+#: src/pages/ModelSettingsOverlay.tsx:356
+#: src/pages/VoiceSettingsOverlay.tsx:170
 msgid "Providers"
 msgstr "प्रोवाइडर्स"
 
@@ -2684,7 +2697,7 @@ msgstr "हाल के"
 msgid "Reconnect OAuth"
 msgstr "OAuth पुनः कनेक्ट करें"
 
-#: src/App.tsx:150
+#: src/App.tsx:157
 #: src/components/ComputerUpdateProgress.tsx:54
 msgid "Reconnecting"
 msgstr "पुनः कनेक्ट हो रहा है"
@@ -2747,7 +2760,7 @@ msgstr ""
 msgid "Refreshing…"
 msgstr ""
 
-#: src/pages/Shell.tsx:5164
+#: src/pages/Shell.tsx:5178
 msgid "Release"
 msgstr "नियंत्रण छोड़ें"
 
@@ -2767,7 +2780,7 @@ msgid "Remove"
 msgstr "हटाएं"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4683
+#: src/pages/Shell.tsx:4697
 msgid "Remove {0}"
 msgstr "{0} हटाएं"
 
@@ -2776,7 +2789,7 @@ msgid "Remove Git event"
 msgstr ""
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4845
 msgid "Remove mention {0}"
 msgstr "उल्लेख {0} हटाएं"
 
@@ -2789,13 +2802,13 @@ msgid "Remove schedule"
 msgstr ""
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4824
 msgid "Remove skill {0}"
 msgstr "स्किल {0} हटाएं"
 
-#: src/pages/Shell.tsx:4262
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:4276
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Remove thumbs-up"
 msgstr ""
 
@@ -2803,7 +2816,7 @@ msgstr ""
 msgid "Remove webhook"
 msgstr ""
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5443
 msgid "Removed with chat, computer, and memory."
 msgstr "चैट, कंप्यूटर और मेमोरी सहित हटाया गया।"
 
@@ -2822,21 +2835,21 @@ msgstr "हटाया जा रहा है…"
 msgid "Reopen"
 msgstr "पुनः खोलें"
 
-#: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/ModelSettingsOverlay.tsx:695
+#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:699
 msgid "Replace API key"
 msgstr "API कुंजी बदलें"
 
-#: src/pages/VoiceSettingsOverlay.tsx:239
+#: src/pages/VoiceSettingsOverlay.tsx:243
 msgid "Replace key"
 msgstr "कुंजी बदलें"
 
-#: src/pages/Shell.tsx:5074
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5088
+#: src/pages/Shell.tsx:5119
 msgid "Reply"
 msgstr "उत्तर दें"
 
-#: src/pages/Shell.tsx:4646
+#: src/pages/Shell.tsx:4660
 msgid "Replying to {replyName}"
 msgstr "{replyName} को उत्तर दे रहे हैं"
 
@@ -2870,8 +2883,8 @@ msgstr "रीसेट हो रहा है…"
 msgid "Restart to update"
 msgstr ""
 
-#: src/pages/Shell.tsx:2816
-#: src/pages/Shell.tsx:2847
+#: src/pages/Shell.tsx:2826
+#: src/pages/Shell.tsx:2857
 msgid "Restore"
 msgstr "बहाल करें"
 
@@ -2883,12 +2896,12 @@ msgstr "अंतिम सहेजे गए वर्कस्पेस क�
 msgid "Restoring your workspace"
 msgstr ""
 
-#: src/App.tsx:164
+#: src/App.tsx:171
 #: src/pages/PeerMessagesOverlay.tsx:109
 msgid "Retry now"
 msgstr "अभी पुनः प्रयास करें"
 
-#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2398
 msgid "Retry screen"
 msgstr ""
 
@@ -2918,8 +2931,8 @@ msgid "Rotate key"
 msgstr ""
 
 #: src/pages/RoutineEditor.tsx:265
-#: src/pages/Shell.tsx:3419
-#: src/pages/Shell.tsx:3431
+#: src/pages/Shell.tsx:3429
+#: src/pages/Shell.tsx:3441
 msgid "Routine"
 msgstr "रूटीन"
 
@@ -2936,7 +2949,7 @@ msgstr ""
 msgid "Run history"
 msgstr ""
 
-#: src/pages/Shell.tsx:3412
+#: src/pages/Shell.tsx:3422
 msgid "Run time must be in the future."
 msgstr ""
 
@@ -2966,7 +2979,7 @@ msgstr ""
 #: src/pages/GroupPanel.tsx:236
 #: src/pages/KnowledgeSection.tsx:203
 #: src/pages/KnowledgeSection.tsx:422
-#: src/pages/ModelSettingsOverlay.tsx:693
+#: src/pages/ModelSettingsOverlay.tsx:697
 #: src/pages/RoutineEditor.tsx:489
 #: src/pages/shell/bot-panel.tsx:539
 msgid "Save"
@@ -2983,7 +2996,7 @@ msgstr "सहेजा गया"
 msgid "Saved, but list refresh failed"
 msgstr "सहेजा गया, लेकिन सूची रिफ़्रेश विफल रही"
 
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Saved."
 msgstr "सहेजा गया।"
 
@@ -3002,7 +3015,7 @@ msgstr ""
 #: src/components/AskCard.tsx:157
 #: src/components/teach/SkillDraftCard.tsx:142
 #: src/pages/GroupPanel.tsx:236
-#: src/pages/ModelSettingsOverlay.tsx:691
+#: src/pages/ModelSettingsOverlay.tsx:695
 #: src/pages/RoutineEditor.tsx:489
 msgid "Saving…"
 msgstr "सहेजा जा रहा है…"
@@ -3016,15 +3029,15 @@ msgstr "कुछ बोलें। चुप्पी होते ही भ�
 msgid "Say yes or no, or answer in a sentence."
 msgstr "हां या ना कहें, या एक वाक्य में उत्तर दें।"
 
-#: src/pages/ModelSettingsOverlay.tsx:984
+#: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
-#: src/pages/Shell.tsx:2530
+#: src/pages/Shell.tsx:2540
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "खोजें"
 
-#: src/components/integrations/IntegrationSetup.tsx:241
-#: src/components/integrations/IntegrationSetup.tsx:242
+#: src/components/integrations/IntegrationSetup.tsx:250
+#: src/components/integrations/IntegrationSetup.tsx:251
 #: src/pages/PluginsOverlay.tsx:696
 #: src/pages/PluginsOverlay.tsx:697
 msgid "Search apps"
@@ -3038,11 +3051,11 @@ msgstr ""
 msgid "Search by domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:247
+#: src/components/integrations/IntegrationSetup.tsx:256
 msgid "Search integrations.sh"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:979
+#: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr ""
 
@@ -3051,8 +3064,8 @@ msgstr ""
 msgid "Search or create Bots"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:355
-#: src/pages/ModelSettingsOverlay.tsx:361
+#: src/pages/ModelSettingsOverlay.tsx:359
+#: src/pages/ModelSettingsOverlay.tsx:365
 msgid "Search providers"
 msgstr "प्रोवाइडर्स खोजें"
 
@@ -3066,7 +3079,7 @@ msgstr "प्रोवाइडर्स और मॉडल खोजें"
 msgid "Searching…"
 msgstr "खोजा जा रहा है…"
 
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3030
 msgid "Select a bot"
 msgstr "एक बॉट चुनें"
 
@@ -3074,8 +3087,8 @@ msgstr "एक बॉट चुनें"
 msgid "Selected"
 msgstr ""
 
-#: src/pages/Shell.tsx:4929
-#: src/pages/Shell.tsx:4950
+#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4964
 msgid "Send"
 msgstr "भेजें"
 
@@ -3105,8 +3118,9 @@ msgstr "भेजा जा रहा है…"
 msgid "Sentry alert"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/AccountSettingsOverlay.tsx:158
+#: src/pages/LocalSettings.tsx:42
 msgid "Server integrations"
 msgstr ""
 
@@ -3114,33 +3128,33 @@ msgstr ""
 msgid "Server name"
 msgstr "सर्वर का नाम"
 
-#: src/components/integrations/IntegrationSetup.tsx:273
-#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:282
+#: src/components/integrations/IntegrationSetup.tsx:300
 #: src/pages/McpServersOverlay.tsx:329
-#: src/pages/ModelSettingsOverlay.tsx:412
+#: src/pages/ModelSettingsOverlay.tsx:416
 #: src/pages/Onboarding.tsx:390
 msgid "Server URL"
 msgstr "सर्वर URL"
 
 #: src/pages/MessagingSettingsOverlay.tsx:361
 #: src/pages/SettingsOverlay.tsx:103
-#: src/pages/SettingsOverlay.tsx:151
-#: src/pages/Shell.tsx:2896
-#: src/pages/Shell.tsx:2903
-#: src/pages/Shell.tsx:3152
+#: src/pages/SettingsOverlay.tsx:158
+#: src/pages/Shell.tsx:2906
+#: src/pages/Shell.tsx:2913
+#: src/pages/Shell.tsx:3162
 msgid "Settings"
 msgstr "सेटिंग्स"
 
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4982
 msgid "Settings: General"
 msgstr "सेटिंग्स: सामान्य"
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4984
 msgid "Settings: Usage"
 msgstr "सेटिंग्स: उपयोग"
 
-#: src/components/integrations/IntegrationSetup.tsx:319
-#: src/pages/ModelSettingsOverlay.tsx:425
+#: src/components/integrations/IntegrationSetup.tsx:328
+#: src/pages/ModelSettingsOverlay.tsx:429
 #: src/pages/Onboarding.tsx:403
 msgid "Setup help"
 msgstr "सेटअप सहायता"
@@ -3158,11 +3172,11 @@ msgstr "साझा दस्तावेज़"
 msgid "Show all providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Show bots"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show computer"
 msgstr "कंप्यूटर दिखाएं"
 
@@ -3178,14 +3192,14 @@ msgstr ""
 msgid "Show popular providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show settings"
 msgstr "सेटिंग्स दिखाएं"
 
 #: src/lib/localized-provider-hint.ts:7
 #: src/pages/Auth.tsx:230
 #: src/pages/Auth.tsx:288
-#: src/pages/ModelSettingsOverlay.tsx:632
+#: src/pages/ModelSettingsOverlay.tsx:636
 #: src/pages/Onboarding.tsx:152
 msgid "Sign in"
 msgstr "साइन इन करें"
@@ -3200,7 +3214,7 @@ msgid "Sign up"
 msgstr "साइन अप करें"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4758
 msgid "Skill {0}"
 msgstr "स्किल {0}"
 
@@ -3208,8 +3222,8 @@ msgstr "स्किल {0}"
 msgid "Skills"
 msgstr "स्किल्स"
 
-#: src/components/integrations/IntegrationSetup.tsx:355
-#: src/pages/Shell.tsx:5171
+#: src/components/integrations/IntegrationSetup.tsx:364
+#: src/pages/Shell.tsx:5185
 msgid "Skip"
 msgstr "छोड़ें"
 
@@ -3218,7 +3232,7 @@ msgid "Skip or deploy key"
 msgstr "छोड़ें या डिप्लॉय कुंजी दें"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1842
+#: src/pages/Shell.tsx:1852
 msgid "Skipped {0}"
 msgstr "{0} को छोड़ा गया"
 
@@ -3250,21 +3264,21 @@ msgstr "स्पेस से बीच में रोकें · Esc से
 msgid "Spaces"
 msgstr ""
 
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Speak"
 msgstr "बोलें"
 
-#: src/pages/VoiceSettingsOverlay.tsx:190
+#: src/pages/VoiceSettingsOverlay.tsx:194
 msgid "Speak + transcribe"
 msgstr "बोलें + लिप्यंतरण करें"
 
-#: src/pages/VoiceSettingsOverlay.tsx:192
+#: src/pages/VoiceSettingsOverlay.tsx:196
 msgid "Speak only"
 msgstr "केवल बोलें"
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Speak this reply"
 msgstr "यह उत्तर बोलकर सुनाएं"
 
@@ -3281,7 +3295,7 @@ msgid "Starting"
 msgstr "शुरू हो रहा है"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
-#: src/pages/ModelSettingsOverlay.tsx:630
+#: src/pages/ModelSettingsOverlay.tsx:634
 #: src/pages/Onboarding.tsx:554
 msgid "Starting…"
 msgstr "शुरू हो रहा है…"
@@ -3290,11 +3304,11 @@ msgstr "शुरू हो रहा है…"
 msgid "Steps"
 msgstr "चरण"
 
-#: src/pages/Shell.tsx:3912
-#: src/pages/Shell.tsx:3917
-#: src/pages/Shell.tsx:4939
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:3926
+#: src/pages/Shell.tsx:3931
+#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Stop"
 msgstr "रोकें"
 
@@ -3302,8 +3316,8 @@ msgstr "रोकें"
 msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
 msgstr ""
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Stop speaking"
 msgstr "बोलना रोकें"
 
@@ -3321,20 +3335,20 @@ msgstr "रोक दिया गया।"
 msgid "Stored encrypted"
 msgstr "एन्क्रिप्टेड रूप में संग्रहीत"
 
-#: src/pages/ModelSettingsOverlay.tsx:545
+#: src/pages/ModelSettingsOverlay.tsx:549
 msgid "Stored securely. Never shown here."
 msgstr "सुरक्षित रूप से संग्रहीत। यहां कभी नहीं दिखाया जाता।"
 
-#: src/pages/Shell.tsx:5383
+#: src/pages/Shell.tsx:5397
 msgid "subagent"
 msgstr "सबएजेंट"
 
-#: src/pages/ModelSettingsOverlay.tsx:590
+#: src/pages/ModelSettingsOverlay.tsx:594
 #: src/pages/Onboarding.tsx:521
 msgid "Submit"
 msgstr "सबमिट करें"
 
-#: src/pages/ModelSettingsOverlay.tsx:503
+#: src/pages/ModelSettingsOverlay.tsx:507
 #: src/pages/Onboarding.tsx:462
 msgid "Supports thinking"
 msgstr "सोचने की क्षमता का समर्थन करता है"
@@ -3343,7 +3357,7 @@ msgstr "सोचने की क्षमता का समर्थन क�
 msgid "Switch bot"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:723
+#: src/pages/ModelSettingsOverlay.tsx:727
 msgid "Switching…"
 msgstr "बदला जा रहा है…"
 
@@ -3356,7 +3370,7 @@ msgstr "सिस्टम"
 msgid "Teach a task"
 msgstr "कोई कार्य सिखाएं"
 
-#: src/pages/Shell.tsx:3076
+#: src/pages/Shell.tsx:3086
 msgid "Teaching in progress. Stop teaching before sending a new message."
 msgstr "सिखाना जारी है। नया संदेश भेजने से पहले सिखाना रोकें।"
 
@@ -3364,7 +3378,7 @@ msgstr "सिखाना जारी है। नया संदेश भ�
 msgid "Team"
 msgstr "टीम"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "Team Computer"
 msgstr "टीम कंप्यूटर"
 
@@ -3394,7 +3408,7 @@ msgstr ""
 msgid "The API did not come back. Refresh this page."
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:241
+#: src/pages/MemorySettingsOverlay.tsx:245
 msgid "The selected memory provider is not available in this build."
 msgstr "चयनित मेमोरी प्रोवाइडर इस बिल्ड में उपलब्ध नहीं है।"
 
@@ -3402,7 +3416,7 @@ msgstr "चयनित मेमोरी प्रोवाइडर इस �
 msgid "Thinking"
 msgstr "सोच रहा है"
 
-#: src/pages/Shell.tsx:5632
+#: src/pages/Shell.tsx:5646
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "यह बॉट इसी कंप्यूटर पर चलता है, किसी Linux डेस्कटॉप पर नहीं। शेल और फ़ाइलें आपके होम फ़ोल्डर का उपयोग करती हैं।"
 
@@ -3455,7 +3469,7 @@ msgstr "यह सर्वर पहले से कनेक्टेड ह�
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools. A popup will open."
 msgstr "यह सर्वर ब्राउज़र साइन-इन का उपयोग करता है। अपने एजेंट को इसके टूल उपयोग करने देने के लिए इसे ऑथराइज़ करें। एक पॉपअप खुलेगा।"
 
-#: src/pages/ModelSettingsOverlay.tsx:705
+#: src/pages/ModelSettingsOverlay.tsx:709
 msgid "This subscription sign-in is not available in Rakazo yet. Use a deployment credential or choose another provider."
 msgstr "यह सब्सक्रिप्शन साइन-इन अभी Rakazo में उपलब्ध नहीं है। किसी डिप्लॉयमेंट क्रेडेंशियल का उपयोग करें या दूसरा प्रोवाइडर चुनें।"
 
@@ -3514,7 +3528,7 @@ msgid "Unpin"
 msgstr "पिन हटाएं"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1920
+#: src/pages/Shell.tsx:1930
 msgid "Unsupported file type: {0}"
 msgstr "असमर्थित फ़ाइल प्रकार: {0}"
 
@@ -3574,8 +3588,8 @@ msgstr "अपडेट हो रहा है…"
 
 #: src/pages/AccountSettingsOverlay.tsx:199
 #: src/pages/SettingsOverlay.tsx:96
-#: src/pages/Shell.tsx:2908
-#: src/pages/Shell.tsx:2919
+#: src/pages/Shell.tsx:2918
+#: src/pages/Shell.tsx:2929
 msgid "Usage"
 msgstr "उपयोग"
 
@@ -3583,7 +3597,7 @@ msgstr "उपयोग"
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} का उपयोग करें"
 
-#: src/pages/ModelSettingsOverlay.tsx:490
+#: src/pages/ModelSettingsOverlay.tsx:494
 #: src/pages/Onboarding.tsx:454
 msgid "Use a found model"
 msgstr "मिला हुआ मॉडल उपयोग करें"
@@ -3593,7 +3607,7 @@ msgstr "मिला हुआ मॉडल उपयोग करें"
 msgid "Use default guidance"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:725
+#: src/pages/ModelSettingsOverlay.tsx:729
 msgid "Use this model"
 msgstr "यह मॉडल उपयोग करें"
 
@@ -3606,16 +3620,16 @@ msgid "Verifying…"
 msgstr "पुष्टि की जा रही है…"
 
 #: src/pages/SettingsOverlay.tsx:95
-#: src/pages/Shell.tsx:4916
-#: src/pages/Shell.tsx:4917
+#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:4931
 #: src/pages/shell/bot-panel.tsx:482
-#: src/pages/VoiceSettingsOverlay.tsx:150
-#: src/pages/VoiceSettingsOverlay.tsx:249
+#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Voice"
 msgstr "आवाज़"
 
-#: src/pages/ModelSettingsOverlay.tsx:594
-#: src/pages/ModelSettingsOverlay.tsx:616
+#: src/pages/ModelSettingsOverlay.tsx:598
+#: src/pages/ModelSettingsOverlay.tsx:620
 #: src/pages/Onboarding.tsx:525
 #: src/pages/Onboarding.tsx:547
 msgid "Waiting for sign-in…"
@@ -3687,8 +3701,8 @@ msgstr ""
 msgid "Working…"
 msgstr "काम चल रहा है…"
 
-#: src/pages/Shell.tsx:1616
-#: src/pages/Shell.tsx:2393
+#: src/pages/Shell.tsx:1626
+#: src/pages/Shell.tsx:2403
 msgid "You"
 msgstr "आप"
 
@@ -3700,7 +3714,7 @@ msgstr "अगर यह अपने आप रीडायरेक्ट न 
 msgid "You can close this window."
 msgstr "आप यह विंडो बंद कर सकते हैं।"
 
-#: src/pages/Shell.tsx:3901
+#: src/pages/Shell.tsx:3915
 msgid "You have control"
 msgstr "नियंत्रण आपके पास है"
 

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -13,22 +13,22 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2720
+#: src/pages/Shell.tsx:2730
 msgid " (unread)"
 msgstr " (읽지 않음)"
 
 #. placeholder {0}: group.entries.length
-#: src/pages/ModelSettingsOverlay.tsx:382
+#: src/pages/ModelSettingsOverlay.tsx:386
 msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {모델 #개} other {모델 #개}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1822
+#: src/pages/Shell.tsx:1832
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (첨부 파일 최대 {ATTACHMENT_MAX_COUNT}개)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1826
+#: src/pages/Shell.tsx:1836
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB 초과)"
 
@@ -80,11 +80,11 @@ msgid "{0} will still respond to direct mentions."
 msgstr ""
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3245
+#: src/pages/Shell.tsx:3255
 msgid "{0}'s screen"
 msgstr "{0}의 화면"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "{botName}’s computer"
 msgstr "{botName}의 컴퓨터"
 
@@ -132,12 +132,12 @@ msgstr "{title}, {label}"
 msgid "{toolCount, plural, one {# tool} other {# tools}}"
 msgstr ""
 
-#: src/pages/Shell.tsx:4072
+#: src/pages/Shell.tsx:4086
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} 작업 중"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4711
+#: src/pages/Shell.tsx:4725
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "About spaces"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:301
+#: src/components/integrations/IntegrationSetup.tsx:310
 msgid "Access token"
 msgstr ""
 
@@ -188,7 +188,7 @@ msgstr "작업 실행 전 확인"
 msgid "Actions for {0}"
 msgstr "{0} 작업 메뉴"
 
-#: src/pages/Shell.tsx:3619
+#: src/pages/Shell.tsx:3629
 msgid "Actions for space"
 msgstr ""
 
@@ -196,12 +196,12 @@ msgstr ""
 msgid "Active"
 msgstr "활성"
 
-#: src/pages/ModelSettingsOverlay.tsx:337
+#: src/pages/ModelSettingsOverlay.tsx:341
 msgid "Active model"
 msgstr "현재 모델"
 
-#: src/pages/Shell.tsx:2440
-#: src/pages/Shell.tsx:2442
+#: src/pages/Shell.tsx:2450
+#: src/pages/Shell.tsx:2452
 msgid "Activity"
 msgstr "활동"
 
@@ -215,11 +215,11 @@ msgstr "추가"
 msgid "Add a model in Settings to use this."
 msgstr "이 기능을 사용하려면 설정에서 모델을 추가하세요."
 
-#: src/pages/Shell.tsx:3407
+#: src/pages/Shell.tsx:3417
 msgid "Add a run time for this one-shot."
 msgstr "이 일회성 실행의 시간을 추가하세요."
 
-#: src/pages/Shell.tsx:3385
+#: src/pages/Shell.tsx:3395
 msgid "Add a schedule, webhook, GitHub, or message trigger"
 msgstr ""
 
@@ -259,7 +259,7 @@ msgstr "GraphQL 엔드포인트 추가"
 msgid "Add item"
 msgstr "항목 추가"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/PluginsOverlay.tsx:951
 msgid "Add MCP server"
 msgstr "MCP 서버 추가"
@@ -277,12 +277,12 @@ msgstr "원격 MCP 서버 추가"
 msgid "Add server"
 msgstr "서버 추가"
 
-#: src/components/integrations/IntegrationSetup.tsx:269
+#: src/components/integrations/IntegrationSetup.tsx:278
 msgid "Add server URL"
 msgstr ""
 
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Add thumbs-up"
 msgstr "좋아요 추가"
 
@@ -311,7 +311,7 @@ msgstr "추가 중…"
 
 #: src/pages/AccountSettingsOverlay.tsx:166
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/ModelSettingsOverlay.tsx:502
+#: src/pages/ModelSettingsOverlay.tsx:506
 #: src/pages/Onboarding.tsx:461
 #: src/pages/PluginsOverlay.tsx:836
 #: src/pages/RoutineSchedule.tsx:43
@@ -323,7 +323,7 @@ msgstr "고급 설정"
 msgid "Advanced..."
 msgstr "고급..."
 
-#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3039
 msgid "Agent computer"
 msgstr "Agent 컴퓨터"
 
@@ -405,15 +405,15 @@ msgid "API is back, but the update did not finish. Check the host logs."
 msgstr "API가 다시 작동하지만 업데이트가 완료되지 않았습니다. 호스트 로그를 확인하세요."
 
 #: src/components/AskCard.tsx:44
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 #: src/lib/localized-provider-hint.ts:9
-#: src/pages/ModelSettingsOverlay.tsx:644
-#: src/pages/ModelSettingsOverlay.tsx:647
-#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:648
+#: src/pages/ModelSettingsOverlay.tsx:651
+#: src/pages/ModelSettingsOverlay.tsx:670
 #: src/pages/Onboarding.tsx:563
 #: src/pages/Onboarding.tsx:566
 #: src/pages/Onboarding.tsx:580
-#: src/pages/VoiceSettingsOverlay.tsx:219
+#: src/pages/VoiceSettingsOverlay.tsx:223
 msgid "API key"
 msgstr "API 키"
 
@@ -444,15 +444,15 @@ msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 �
 msgid "Archive"
 msgstr "보관"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5431
 msgid "archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:2789
+#: src/pages/Shell.tsx:2799
 msgid "Archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5442
 msgid "Archived. Chat, memory, and files kept."
 msgstr "보관되었습니다. 대화, 기억, 파일은 유지됩니다."
 
@@ -491,7 +491,7 @@ msgstr "결제하기 전에 확인"
 msgid "Ask before sending external email"
 msgstr "외부 이메일을 보내기 전에 확인"
 
-#: src/components/integrations/IntegrationSetup.tsx:219
+#: src/components/integrations/IntegrationSetup.tsx:228
 msgid "Ask the server owner to configure this provider."
 msgstr ""
 
@@ -506,15 +506,15 @@ msgstr "{0}에"
 msgid "at {timeSelect}"
 msgstr "{timeSelect}에"
 
-#: src/pages/Shell.tsx:4791
+#: src/pages/Shell.tsx:4805
 msgid "Attach file"
 msgstr "파일 첨부"
 
-#: src/pages/Shell.tsx:5023
+#: src/pages/Shell.tsx:5037
 msgid "Attachment"
 msgstr "첨부 파일"
 
-#: src/pages/ModelSettingsOverlay.tsx:577
+#: src/pages/ModelSettingsOverlay.tsx:581
 #: src/pages/Onboarding.tsx:512
 msgid "Authorization code or callback URL"
 msgstr "인증 코드 또는 돌아온 페이지 주소"
@@ -567,23 +567,23 @@ msgstr "서버 주소"
 msgid "Bearer token"
 msgstr "Bearer 토큰"
 
-#: src/pages/Shell.tsx:5644
+#: src/pages/Shell.tsx:5658
 msgid "Booting live desktop…"
 msgstr "라이브 데스크톱 시작 중…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3877
 msgid "Booting up {0}’s computer"
 msgstr "{0}의 컴퓨터를 켜는 중"
 
-#: src/pages/Shell.tsx:5292
-#: src/pages/Shell.tsx:5293
-#: src/pages/Shell.tsx:5421
+#: src/pages/Shell.tsx:5306
+#: src/pages/Shell.tsx:5307
+#: src/pages/Shell.tsx:5435
 msgid "bot"
 msgstr "Bot"
 
 #: src/pages/IntegrationSetup.tsx:51
-#: src/pages/Shell.tsx:1617
+#: src/pages/Shell.tsx:1627
 msgid "Bot"
 msgstr "봇"
 
@@ -592,11 +592,11 @@ msgstr "봇"
 msgid "Bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:3971
+#: src/pages/Shell.tsx:3985
 msgid "Bot screen"
 msgstr "Bot 화면"
 
-#: src/pages/Shell.tsx:3208
+#: src/pages/Shell.tsx:3218
 msgid "Bot screen preview"
 msgstr "Bot 화면 미리보기"
 
@@ -608,7 +608,7 @@ msgstr "연결할 Bot"
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first."
 msgstr "Bot은 기본적으로 묻지 않고 작업합니다. 먼저 확인하고 싶은 작업만 예외로 추가하세요."
 
-#: src/pages/Shell.tsx:4073
+#: src/pages/Shell.tsx:4087
 msgid "Bots are working"
 msgstr "봇 작업 중"
 
@@ -620,7 +620,7 @@ msgstr ""
 msgid "Call"
 msgstr "통화"
 
-#: src/App.tsx:152
+#: src/App.tsx:159
 msgid "Can't reach the server."
 msgstr "서버에 연결할 수 없습니다."
 
@@ -648,7 +648,7 @@ msgstr "새 Bot 만들기 취소"
 msgid "Cancel new group"
 msgstr "새 그룹 만들기 취소"
 
-#: src/pages/Shell.tsx:4649
+#: src/pages/Shell.tsx:4663
 msgid "Cancel reply"
 msgstr "답장 취소"
 
@@ -685,7 +685,7 @@ msgstr "채팅 앱"
 msgid "Chat apps, group channels, and agent connections."
 msgstr "채팅 앱, 그룹 채널 및 Agent 연결을 관리합니다."
 
-#: src/pages/Shell.tsx:4966
+#: src/pages/Shell.tsx:4980
 msgid "Chat Settings"
 msgstr "채팅 설정"
 
@@ -699,8 +699,8 @@ msgstr "확인 실패"
 msgid "Check for updates"
 msgstr "업데이트 확인"
 
-#: src/pages/Shell.tsx:3420
-#: src/pages/Shell.tsx:3432
+#: src/pages/Shell.tsx:3430
+#: src/pages/Shell.tsx:3442
 msgid "Check in."
 msgstr "확인해 주세요."
 
@@ -725,7 +725,7 @@ msgstr "Bot 선택…"
 msgid "Choose a new password"
 msgstr "새 비밀번호 선택"
 
-#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:312
 msgid "Choose which connected model Rakazo uses."
 msgstr "Rakazo에서 기본으로 사용할 연결된 모델을 선택하세요."
 
@@ -747,11 +747,11 @@ msgstr "대화 내용 비우기"
 msgid "Clearing…"
 msgstr "비우는 중…"
 
-#: src/components/integrations/IntegrationSetup.tsx:167
+#: src/components/integrations/IntegrationSetup.tsx:172
 msgid "Client ID"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 msgid "Client secret"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr "닫기"
 msgid "Close chart"
 msgstr "차트 닫기"
 
-#: src/pages/Shell.tsx:3950
+#: src/pages/Shell.tsx:3964
 msgid "Close computer"
 msgstr "컴퓨터 닫기"
 
@@ -784,7 +784,7 @@ msgstr "앱·도구 연동 닫기"
 msgid "Close MCP servers"
 msgstr "MCP 서버 설정 닫기"
 
-#: src/pages/MemorySettingsOverlay.tsx:164
+#: src/pages/MemorySettingsOverlay.tsx:168
 #: src/pages/SettingsOverlay.tsx:109
 msgid "Close memory settings"
 msgstr "기억 설정 닫기"
@@ -793,16 +793,16 @@ msgstr "기억 설정 닫기"
 msgid "Close messaging settings"
 msgstr "메시징 설정 닫기"
 
-#: src/pages/ModelSettingsOverlay.tsx:324
+#: src/pages/ModelSettingsOverlay.tsx:328
 #: src/pages/SettingsOverlay.tsx:107
 msgid "Close model settings"
 msgstr "AI 모델 설정 닫기"
 
-#: src/pages/Shell.tsx:2418
+#: src/pages/Shell.tsx:2428
 msgid "Close navigation"
 msgstr "메뉴 닫기"
 
-#: src/pages/Shell.tsx:3186
+#: src/pages/Shell.tsx:3196
 msgid "Close panel"
 msgstr "패널 닫기"
 
@@ -815,7 +815,7 @@ msgid "Close user settings"
 msgstr "계정 설정 닫기"
 
 #: src/pages/SettingsOverlay.tsx:111
-#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:158
 msgid "Close voice settings"
 msgstr "음성 설정 닫기"
 
@@ -828,7 +828,7 @@ msgid "Code"
 msgstr "코드"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2590
+#: src/pages/Shell.tsx:2600
 msgid "Collapse {0}"
 msgstr "{0} 접기"
 
@@ -855,24 +855,24 @@ msgid "Complete"
 msgstr "완료"
 
 #: src/pages/SettingsOverlay.tsx:97
-#: src/pages/Shell.tsx:5578
+#: src/pages/Shell.tsx:5592
 #: src/pages/shell/bot-panel.tsx:57
 msgid "Computer"
 msgstr "컴퓨터"
 
-#: src/pages/Shell.tsx:5647
+#: src/pages/Shell.tsx:5661
 msgid "Computer failed to boot"
 msgstr "컴퓨터를 시작하지 못했습니다"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4008
 msgid "Computer is asleep"
 msgstr "컴퓨터가 절전 상태입니다"
 
-#: src/pages/Shell.tsx:5646
+#: src/pages/Shell.tsx:5660
 msgid "Computer is asleep. Open it to wake."
 msgstr "컴퓨터가 절전 상태입니다. 열어 깨우세요."
 
-#: src/pages/Shell.tsx:5648
+#: src/pages/Shell.tsx:5662
 msgid "Computer is stopped"
 msgstr "컴퓨터가 중지됨"
 
@@ -884,7 +884,7 @@ msgstr "컴퓨터"
 msgid "Computers are off. Set SANDBOX_PROVIDER=docker with SANDBOX_SUPERVISOR_TOKEN, or set SANDBOX_PROVIDER to e2b, daytona, or box with its API key. Recreate the stack after changing .env."
 msgstr "컴퓨터가 꺼져 있습니다. SANDBOX_PROVIDER=docker와 SANDBOX_SUPERVISOR_TOKEN을 설정하거나, SANDBOX_PROVIDER를 e2b, daytona, box 중 하나로 두고 해당 API 키를 넣으세요. .env 변경 후 스택을 다시 만드세요."
 
-#: src/pages/ModelSettingsOverlay.tsx:344
+#: src/pages/ModelSettingsOverlay.tsx:348
 msgid "Configured by deployment"
 msgstr "서버에서 설정됨"
 
@@ -902,12 +902,12 @@ msgstr "삭제 확인"
 msgid "Confirm password"
 msgstr "비밀번호 확인"
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:258
-#: src/components/integrations/IntegrationSetup.tsx:282
-#: src/components/integrations/IntegrationSetup.tsx:315
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:267
+#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:324
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
-#: src/pages/VoiceSettingsOverlay.tsx:241
+#: src/pages/VoiceSettingsOverlay.tsx:245
 msgid "Connect"
 msgstr "연결"
 
@@ -915,7 +915,7 @@ msgstr "연결"
 msgid "Connect a model"
 msgstr "AI 모델 연결"
 
-#: src/pages/ModelSettingsOverlay.tsx:697
+#: src/pages/ModelSettingsOverlay.tsx:701
 msgid "Connect API key"
 msgstr "API 키 연결"
 
@@ -931,7 +931,7 @@ msgstr "MCP 서버 ‘{name}’ 연결"
 msgid "Connect OAuth"
 msgstr "OAuth 연결"
 
-#: src/pages/ModelSettingsOverlay.tsx:547
+#: src/pages/ModelSettingsOverlay.tsx:551
 msgid "Connect this provider to use it as your personal model."
 msgstr "이 AI 서비스를 연결하면 내 기본 모델로 사용할 수 있습니다."
 
@@ -939,30 +939,30 @@ msgstr "이 AI 서비스를 연결하면 내 기본 모델로 사용할 수 있�
 msgid "Connect Treg"
 msgstr "Treg 연결"
 
-#: src/components/integrations/IntegrationSetup.tsx:159
-#: src/components/integrations/IntegrationSetup.tsx:258
+#: src/components/integrations/IntegrationSetup.tsx:164
+#: src/components/integrations/IntegrationSetup.tsx:267
 #: src/pages/McpOAuthCallback.tsx:54
-#: src/pages/MemorySettingsOverlay.tsx:187
-#: src/pages/ModelSettingsOverlay.tsx:389
+#: src/pages/MemorySettingsOverlay.tsx:191
+#: src/pages/ModelSettingsOverlay.tsx:393
 #: src/pages/shell/message-cards.tsx:187
-#: src/pages/VoiceSettingsOverlay.tsx:198
+#: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "연결됨"
 
 #. placeholder {0}: credential.label
-#: src/pages/ModelSettingsOverlay.tsx:538
+#: src/pages/ModelSettingsOverlay.tsx:542
 msgid "Connected · {0}"
 msgstr "연결됨 · {0}"
 
 #. placeholder {0}: selected.name
-#: src/pages/VoiceSettingsOverlay.tsx:102
+#: src/pages/VoiceSettingsOverlay.tsx:106
 msgid "Connected {0}."
 msgstr "{0}에 연결했습니다."
 
 #. placeholder {0}: selected.label
 #. placeholder {0}: selectedLabelRef.current ?? "this model"
-#: src/pages/ModelSettingsOverlay.tsx:82
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:84
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Connected and using {0}."
 msgstr "{0}에 연결하고 기본 모델로 설정했습니다."
 
@@ -970,12 +970,12 @@ msgstr "{0}에 연결하고 기본 모델로 설정했습니다."
 msgid "Connected. Its tools are available from your next message."
 msgstr "연결되었습니다. 다음 메시지부터 이 도구를 사용할 수 있습니다."
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/McpServersOverlay.tsx:38
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
 #: src/pages/shell/message-cards.tsx:360
-#: src/pages/VoiceSettingsOverlay.tsx:237
+#: src/pages/VoiceSettingsOverlay.tsx:241
 msgid "Connecting…"
 msgstr "연결 중…"
 
@@ -984,7 +984,7 @@ msgstr "연결 중…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "{0} 연결이 아직 진행 중입니다. 이 창을 닫고 나중에 다시 확인할 수 있습니다."
 
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/Onboarding.tsx:604
 #: src/pages/Onboarding.tsx:667
 msgid "Continue"
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Continue with email"
 msgstr "이메일로 계속하기"
 
-#: src/pages/Shell.tsx:5109
+#: src/pages/Shell.tsx:5123
 msgid "Copy"
 msgstr "복사"
 
@@ -1022,7 +1022,7 @@ msgstr "앱 인증을 완료하지 못했습니다."
 msgid "Could not change password"
 msgstr "비밀번호를 변경할 수 없습니다"
 
-#: src/pages/ModelSettingsOverlay.tsx:245
+#: src/pages/ModelSettingsOverlay.tsx:247
 msgid "Could not change the default model"
 msgstr "기본 모델을 변경하지 못했습니다."
 
@@ -1046,30 +1046,30 @@ msgstr "OAuth 인증을 완료하지 못했습니다."
 msgid "Could not complete the update. Try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:76
+#: src/components/integrations/IntegrationSetup.tsx:79
 #: src/pages/PluginsOverlay.tsx:264
 msgid "Could not connect"
 msgstr "연결하지 못했습니다."
 
 #. placeholder {0}: registration.name
-#: src/pages/MemorySettingsOverlay.tsx:115
+#: src/pages/MemorySettingsOverlay.tsx:119
 msgid "Could not connect {0}"
 msgstr "{0}에 연결하지 못했습니다."
 
-#: src/pages/ModelSettingsOverlay.tsx:284
+#: src/pages/ModelSettingsOverlay.tsx:286
 msgid "Could not connect this provider"
 msgstr "AI 서비스에 연결하지 못했습니다."
 
-#: src/pages/VoiceSettingsOverlay.tsx:104
+#: src/pages/VoiceSettingsOverlay.tsx:108
 msgid "Could not connect this voice provider"
 msgstr "음성 서비스에 연결하지 못했습니다."
 
-#: src/pages/Shell.tsx:875
+#: src/pages/Shell.tsx:885
 msgid "Could not connect to the computer screen"
 msgstr ""
 
 #: src/pages/Auth.tsx:99
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2368
 msgid "Could not continue"
 msgstr "계속 진행하지 못했습니다."
 
@@ -1117,7 +1117,7 @@ msgstr "스킬을 삭제하지 못했습니다"
 msgid "Could not delete space"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:129
+#: src/pages/MemorySettingsOverlay.tsx:133
 msgid "Could not disconnect memory provider"
 msgstr "기억 서비스 연결을 해제하지 못했습니다."
 
@@ -1158,7 +1158,7 @@ msgstr "확인 규칙을 불러오지 못했습니다."
 msgid "Could not load bots. Reload to try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:67
+#: src/components/integrations/IntegrationSetup.tsx:70
 #: src/pages/PluginsOverlay.tsx:143
 #: src/pages/PluginsOverlay.tsx:719
 msgid "Could not load integrations"
@@ -1168,7 +1168,7 @@ msgstr "연동 목록을 불러오지 못했습니다."
 msgid "Could not load MCP servers"
 msgstr "MCP 서버 목록을 불러오지 못했습니다."
 
-#: src/pages/ModelSettingsOverlay.tsx:129
+#: src/pages/ModelSettingsOverlay.tsx:131
 msgid "Could not load model settings"
 msgstr "AI 모델 설정을 불러오지 못했습니다."
 
@@ -1188,11 +1188,15 @@ msgstr "파일을 불러오지 못했습니다."
 msgid "Could not load update status"
 msgstr "업데이트 상태를 불러올 수 없습니다"
 
-#: src/pages/VoiceSettingsOverlay.tsx:77
+#: src/pages/VoiceSettingsOverlay.tsx:81
 msgid "Could not load voice settings"
 msgstr "음성 설정을 불러오지 못했습니다."
 
-#: src/pages/VoiceSettingsOverlay.tsx:138
+#: src/pages/LocalSettings.tsx:26
+msgid "Could not open local settings. Start the local server and create its owner account, then try again."
+msgstr ""
+
+#: src/pages/VoiceSettingsOverlay.tsx:142
 msgid "Could not play a test clip"
 msgstr "샘플 음성을 재생하지 못했습니다."
 
@@ -1202,7 +1206,7 @@ msgstr "샘플 음성을 재생하지 못했습니다."
 msgid "Could not reach the server"
 msgstr "서버에 연결할 수 없습니다"
 
-#: src/pages/ModelSettingsOverlay.tsx:229
+#: src/pages/ModelSettingsOverlay.tsx:231
 #: src/pages/Onboarding.tsx:191
 msgid "Could not reach this model server"
 msgstr "모델 서버에 연결하지 못했습니다."
@@ -1240,7 +1244,7 @@ msgstr "비밀번호를 재설정할 수 없습니다"
 msgid "Could not revoke connection"
 msgstr "연결을 해제하지 못했습니다."
 
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3496
 msgid "Could not run routine"
 msgstr "루틴을 실행할 수 없습니다"
 
@@ -1262,7 +1266,7 @@ msgstr "그룹을 저장하지 못했습니다."
 msgid "Could not save model"
 msgstr "AI 모델을 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:3457
+#: src/pages/Shell.tsx:3467
 msgid "Could not save routine"
 msgstr "자동 실행을 저장하지 못했습니다."
 
@@ -1278,7 +1282,7 @@ msgstr "스킬을 저장하지 못했습니다"
 msgid "Could not save that choice"
 msgstr "선택 내용을 저장하지 못했습니다."
 
-#: src/pages/VoiceSettingsOverlay.tsx:119
+#: src/pages/VoiceSettingsOverlay.tsx:123
 msgid "Could not save that voice"
 msgstr "목소리를 저장하지 못했습니다."
 
@@ -1310,7 +1314,7 @@ msgstr "가르치기를 시작하지 못했습니다."
 msgid "Could not submit this answer"
 msgstr "답변을 보내지 못했습니다."
 
-#: src/pages/Shell.tsx:2212
+#: src/pages/Shell.tsx:2222
 msgid "Could not take control"
 msgstr "직접 조작으로 전환하지 못했습니다."
 
@@ -1326,11 +1330,11 @@ msgstr "Bot의 서버 사용 권한을 변경하지 못했습니다."
 msgid "Could not update computer"
 msgstr "컴퓨터를 업데이트할 수 없습니다"
 
-#: src/pages/Shell.tsx:1808
+#: src/pages/Shell.tsx:1818
 msgid "Could not update reaction"
 msgstr "반응을 업데이트할 수 없습니다"
 
-#: src/pages/MemorySettingsOverlay.tsx:143
+#: src/pages/MemorySettingsOverlay.tsx:147
 msgid "Could not update the default memory scope"
 msgstr "기본 기억 범위를 변경하지 못했습니다."
 
@@ -1346,7 +1350,7 @@ msgstr "아바타를 업데이트할 수 없습니다"
 msgid "Couldn't update messaging settings"
 msgstr "메시징 설정을 업데이트할 수 없습니다"
 
-#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2481
 #: src/pages/shell/bot-panel.tsx:184
 #: src/pages/shell/dialogs.tsx:208
 msgid "Create"
@@ -1460,8 +1464,8 @@ msgstr "기본 기억 범위"
 #: src/pages/KnowledgeSection.tsx:449
 #: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:301
-#: src/pages/Shell.tsx:2825
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2835
+#: src/pages/Shell.tsx:2866
 #: src/pages/shell/dialogs.tsx:351
 #: src/pages/shell/dialogs.tsx:412
 msgid "Delete"
@@ -1469,8 +1473,8 @@ msgstr "삭제"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2822
-#: src/pages/Shell.tsx:2853
+#: src/pages/Shell.tsx:2832
+#: src/pages/Shell.tsx:2863
 msgid "Delete {0}"
 msgstr "{0} 삭제"
 
@@ -1489,11 +1493,11 @@ msgstr "그룹 삭제"
 msgid "Delete memories too"
 msgstr "기억도 함께 삭제"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3643
 msgid "Delete space"
 msgstr ""
 
-#: src/pages/Shell.tsx:5419
+#: src/pages/Shell.tsx:5433
 msgid "deleted"
 msgstr "삭제됨"
 
@@ -1511,7 +1515,7 @@ msgstr "거부됨"
 msgid "Deny"
 msgstr "거부"
 
-#: src/pages/ModelSettingsOverlay.tsx:340
+#: src/pages/ModelSettingsOverlay.tsx:344
 msgid "Deployment default"
 msgstr "서버 기본값"
 
@@ -1534,16 +1538,16 @@ msgstr ""
 msgid "Desktop update"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:40
+#: src/components/integrations/IntegrationSetup.tsx:43
 msgid "Direct MCP"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:493
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnect"
 msgstr "연결 해제"
 
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnecting…"
 msgstr "연결 해제 중…"
 
@@ -1553,7 +1557,7 @@ msgstr "연결 해제 중…"
 msgid "Dismiss"
 msgstr "닫기"
 
-#: src/pages/Shell.tsx:4629
+#: src/pages/Shell.tsx:4643
 msgid "Dismiss error"
 msgstr "오류 닫기"
 
@@ -1601,7 +1605,7 @@ msgstr "{name} 다운로드"
 msgid "Download as markdown"
 msgstr "마크다운으로 다운로드"
 
-#: src/components/integrations/IntegrationSetup.tsx:327
+#: src/components/integrations/IntegrationSetup.tsx:336
 msgid "Download Executor"
 msgstr ""
 
@@ -1617,7 +1621,7 @@ msgstr "작업 기술 초안"
 msgid "Duplicate"
 msgstr "복제"
 
-#: src/pages/Shell.tsx:5245
+#: src/pages/Shell.tsx:5259
 msgid "Earlier message"
 msgstr "이전 메시지"
 
@@ -1638,7 +1642,7 @@ msgid "Engage when... Ignore..."
 msgstr ""
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
-#: src/pages/ModelSettingsOverlay.tsx:600
+#: src/pages/ModelSettingsOverlay.tsx:604
 #: src/pages/Onboarding.tsx:531
 msgid "Enter this code at <0>{0}</0>"
 msgstr "<0>{0}</0>에서 이 코드를 입력하세요"
@@ -1687,7 +1691,7 @@ msgid "Expand"
 msgstr "펼치기"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2589
+#: src/pages/Shell.tsx:2599
 msgid "Expand {0}"
 msgstr "{0} 펼치기"
 
@@ -1716,14 +1720,14 @@ msgstr "실패"
 msgid "Failed"
 msgstr "실패"
 
-#: src/pages/Shell.tsx:1981
-#: src/pages/Shell.tsx:1983
-#: src/pages/Shell.tsx:1985
+#: src/pages/Shell.tsx:1991
+#: src/pages/Shell.tsx:1993
+#: src/pages/Shell.tsx:1995
 msgid "Failed to send message"
 msgstr "메시지를 보내지 못했습니다."
 
-#: src/pages/Shell.tsx:2018
-#: src/pages/Shell.tsx:2037
+#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2047
 msgid "Failed to stop"
 msgstr "작업을 중지하지 못했습니다."
 
@@ -1736,18 +1740,18 @@ msgstr "실패했습니다."
 msgid "Failure handling"
 msgstr "실패했을 때 처리"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Find models"
 msgstr "모델 찾기"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Finding…"
 msgstr "찾는 중…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
-#: src/pages/ModelSettingsOverlay.tsx:560
+#: src/pages/ModelSettingsOverlay.tsx:564
 #: src/pages/Onboarding.tsx:495
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "<0>{0}</0>에서 로그인을 마치세요. 마지막 페이지가 열리지 않아도 괜찮습니다. 그 페이지의 URL이나 코드를 여기에 붙여넣으세요."
@@ -1773,7 +1777,7 @@ msgstr "예상하지 못한 작업 표시"
 msgid "Forgot password?"
 msgstr "비밀번호를 잊으셨나요?"
 
-#: src/pages/ModelSettingsOverlay.tsx:1071
+#: src/pages/ModelSettingsOverlay.tsx:1075
 msgid "Free"
 msgstr "무료"
 
@@ -1786,7 +1790,7 @@ msgstr "전체 화면"
 msgid "General"
 msgstr "일반"
 
-#: src/components/integrations/IntegrationSetup.tsx:209
+#: src/components/integrations/IntegrationSetup.tsx:214
 msgid "Get credentials"
 msgstr ""
 
@@ -1801,8 +1805,8 @@ msgid "Git event"
 msgstr "Git 이벤트"
 
 #: src/pages/MessagingSettingsOverlay.tsx:204
-#: src/pages/Shell.tsx:3019
-#: src/pages/Shell.tsx:3156
+#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3166
 msgid "Group"
 msgstr "그룹"
 
@@ -1844,15 +1848,15 @@ msgstr "헤더 이름"
 msgid "Header value"
 msgstr "헤더 값"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Hear a sample"
 msgstr "샘플 듣기"
 
-#: src/pages/VoiceSettingsOverlay.tsx:131
+#: src/pages/VoiceSettingsOverlay.tsx:135
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "안녕하세요. 답변을 소리 내어 읽을 때 이런 목소리로 들립니다."
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Hide bots"
 msgstr ""
 
@@ -1881,11 +1885,11 @@ msgstr "실행 주기"
 msgid "How to check"
 msgstr "완료 확인 방법"
 
-#: src/pages/Shell.tsx:5174
+#: src/pages/Shell.tsx:5188
 msgid "I’m done"
 msgstr "조작 끝내기"
 
-#: src/pages/VoiceSettingsOverlay.tsx:136
+#: src/pages/VoiceSettingsOverlay.tsx:140
 msgid "If you heard that, voice is ready."
 msgstr "샘플이 들렸다면 음성 설정이 완료되었습니다."
 
@@ -1917,12 +1921,12 @@ msgstr "실행할 내용"
 msgid "Integration domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:133
+#: src/components/integrations/IntegrationSetup.tsx:136
 msgid "Integration options"
 msgstr ""
 
 #: src/pages/PluginsOverlay.tsx:679
-#: src/pages/Shell.tsx:2874
+#: src/pages/Shell.tsx:2884
 msgid "Integrations"
 msgstr "앱·도구 연동"
 
@@ -1952,11 +1956,11 @@ msgstr "이 Bot만 사용"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "대화, 파일, 자동 실행이 영구 삭제됩니다. 이 Bot이 만든 다른 Bot은 목록에 남습니다."
 
-#: src/pages/Shell.tsx:4289
+#: src/pages/Shell.tsx:4303
 msgid "Jump to latest"
 msgstr "최신 메시지로 이동"
 
-#: src/pages/Shell.tsx:5240
+#: src/pages/Shell.tsx:5254
 msgid "Jump to replied message"
 msgstr "답장한 메시지로 이동"
 
@@ -2014,7 +2018,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "듣는 중…"
 
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Load earlier messages"
 msgstr "이전 메시지 불러오기"
 
@@ -2026,12 +2030,12 @@ msgstr "활동을 불러오는 중…"
 msgid "Loading integrations…"
 msgstr "연동 목록을 불러오는 중…"
 
-#: src/pages/MemorySettingsOverlay.tsx:182
+#: src/pages/MemorySettingsOverlay.tsx:186
 msgid "Loading memory settings…"
 msgstr "기억 설정을 불러오는 중…"
 
-#: src/pages/ModelSettingsOverlay.tsx:306
-#: src/pages/ModelSettingsOverlay.tsx:733
+#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:737
 msgid "Loading model catalog…"
 msgstr "모델 목록을 불러오는 중…"
 
@@ -2047,15 +2051,15 @@ msgstr "확인 규칙을 불러오는 중…"
 msgid "Loading tools…"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:210
+#: src/pages/VoiceSettingsOverlay.tsx:214
 msgid "Loading voice providers…"
 msgstr "음성 서비스를 불러오는 중…"
 
-#: src/App.tsx:58
+#: src/App.tsx:65
 #: src/pages/IntegrationSetup.tsx:72
 #: src/pages/Onboarding.tsx:282
 #: src/pages/PeerMessagesOverlay.tsx:98
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Loading…"
 msgstr "불러오는 중…"
 
@@ -2067,7 +2071,11 @@ msgstr "로컬"
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "로컬 접근을 허용하면 Bot이 묻지 않고 명령을 실행할 수 있습니다. 공유 서버나 공개 서버에서는 허용하지 마세요."
 
-#: src/pages/Shell.tsx:2932
+#: src/pages/LocalSettings.tsx:22
+msgid "Local Server Settings"
+msgstr ""
+
+#: src/pages/Shell.tsx:2942
 msgid "Log out"
 msgstr "로그아웃"
 
@@ -2083,8 +2091,8 @@ msgstr "MCP 서버 관리"
 msgid "Manage messaging settings"
 msgstr "메시징 설정 관리"
 
-#: src/pages/MemorySettingsOverlay.tsx:159
-#: src/pages/MemorySettingsOverlay.tsx:173
+#: src/pages/MemorySettingsOverlay.tsx:163
+#: src/pages/MemorySettingsOverlay.tsx:177
 msgid "Manage the Space semantic memory provider."
 msgstr "작업공간에서 사용할 장기 기억 서비스를 관리합니다."
 
@@ -2125,7 +2133,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "참여 Bot ({GROUP_MEMBER_MIN}~{GROUP_MEMBER_MAX}개 선택)"
 
 #: src/pages/KnowledgeSection.tsx:39
-#: src/pages/MemorySettingsOverlay.tsx:155
+#: src/pages/MemorySettingsOverlay.tsx:159
 #: src/pages/SettingsOverlay.tsx:94
 msgid "Memory"
 msgstr "기억"
@@ -2134,7 +2142,7 @@ msgstr "기억"
 msgid "Memory scope"
 msgstr "기억 사용 범위"
 
-#: src/pages/Shell.tsx:4697
+#: src/pages/Shell.tsx:4711
 msgid "Mentions"
 msgstr "멘션"
 
@@ -2142,8 +2150,8 @@ msgstr "멘션"
 msgid "Mentions only"
 msgstr ""
 
-#: src/pages/Shell.tsx:4898
-#: src/pages/Shell.tsx:5025
+#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:5039
 msgid "Message"
 msgstr "메시지"
 
@@ -2152,12 +2160,12 @@ msgstr "메시지"
 msgid "Message"
 msgstr "메시지"
 
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4898
+#: src/pages/Shell.tsx:4908
+#: src/pages/Shell.tsx:4912
 msgid "Message {activeName}"
 msgstr "{activeName}에게 메시지 보내기"
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4623
 msgid "Message composer"
 msgstr "메시지 작성기"
 
@@ -2166,15 +2174,15 @@ msgstr "메시지 작성기"
 msgid "Message event"
 msgstr ""
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Message from {peer}"
 msgstr "{peer}의 메시지"
 
-#: src/pages/Shell.tsx:4895
+#: src/pages/Shell.tsx:4909
 msgid "Message…"
 msgstr "메시지를 입력하세요"
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Messaged {peer}"
 msgstr "{peer}에게 메시지 보냄"
 
@@ -2195,8 +2203,8 @@ msgstr "최소"
 msgid "Minimize"
 msgstr "최소화"
 
-#: src/pages/Shell.tsx:2461
-#: src/pages/Shell.tsx:2462
+#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2472
 msgid "Minimize bots"
 msgstr ""
 
@@ -2208,9 +2216,9 @@ msgstr "분"
 msgid "minutes"
 msgstr "분"
 
-#: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/ModelSettingsOverlay.tsx:509
-#: src/pages/ModelSettingsOverlay.tsx:959
+#: src/pages/ModelSettingsOverlay.tsx:448
+#: src/pages/ModelSettingsOverlay.tsx:513
+#: src/pages/ModelSettingsOverlay.tsx:963
 #: src/pages/Onboarding.tsx:420
 #: src/pages/Onboarding.tsx:468
 #: src/pages/Onboarding.tsx:476
@@ -2218,12 +2226,12 @@ msgstr "분"
 msgid "Model"
 msgstr "모델"
 
-#: src/pages/ModelSettingsOverlay.tsx:478
+#: src/pages/ModelSettingsOverlay.tsx:482
 #: src/pages/Onboarding.tsx:442
 msgid "Model id"
 msgstr "모델 ID"
 
-#: src/pages/ModelSettingsOverlay.tsx:995
+#: src/pages/ModelSettingsOverlay.tsx:999
 msgid "Model options"
 msgstr "모델 선택지"
 
@@ -2235,16 +2243,21 @@ msgstr ""
 msgid "Model spend uses your provider keys."
 msgstr "모델 사용 비용은 연결한 서비스의 API 키로 청구됩니다."
 
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Model updated."
 msgstr "모델이 변경되었습니다."
 
-#: src/pages/ModelSettingsOverlay.tsx:317
+#: src/pages/LocalSettings.tsx:36
+#: src/pages/ModelSettingsOverlay.tsx:321
 #: src/pages/SettingsOverlay.tsx:93
 msgid "Models"
 msgstr "AI 모델"
 
-#: src/pages/ModelSettingsOverlay.tsx:457
+#: src/pages/ModelSettingsOverlay.tsx:310
+msgid "Models for the server owner’s default space."
+msgstr ""
+
+#: src/pages/ModelSettingsOverlay.tsx:461
 #: src/pages/Onboarding.tsx:426
 msgid "Models from server"
 msgstr "서버에서 찾은 모델"
@@ -2253,7 +2266,7 @@ msgstr "서버에서 찾은 모델"
 msgid "Monthly"
 msgstr "매월"
 
-#: src/pages/Shell.tsx:5082
+#: src/pages/Shell.tsx:5096
 msgid "More"
 msgstr ""
 
@@ -2303,7 +2316,7 @@ msgstr "입력 필요"
 msgid "Needs takeover"
 msgstr "인수 필요"
 
-#: src/pages/Shell.tsx:3897
+#: src/pages/Shell.tsx:3911
 msgid "Needs you"
 msgstr ""
 
@@ -2381,7 +2394,7 @@ msgstr "이미 종료된 요청입니다"
 msgid "No managed app catalog is configured on this deployment."
 msgstr "이 서버에는 관리형 앱 목록이 설정되지 않았습니다."
 
-#: src/pages/ModelSettingsOverlay.tsx:1023
+#: src/pages/ModelSettingsOverlay.tsx:1027
 msgid "No matching models"
 msgstr "일치하는 모델 없음"
 
@@ -2397,7 +2410,7 @@ msgstr "아직 연결된 MCP 서버가 없습니다."
 msgid "No messages with {peerBotName} yet."
 msgstr "{peerBotName}와의 메시지가 아직 없습니다."
 
-#: src/pages/ModelSettingsOverlay.tsx:737
+#: src/pages/ModelSettingsOverlay.tsx:741
 msgid "No model catalog is available."
 msgstr "사용 가능한 모델 목록이 없습니다."
 
@@ -2405,11 +2418,11 @@ msgstr "사용 가능한 모델 목록이 없습니다."
 msgid "No providers found"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:397
+#: src/pages/ModelSettingsOverlay.tsx:401
 msgid "No providers found."
 msgstr "검색된 AI 서비스가 없습니다."
 
-#: src/components/integrations/IntegrationSetup.tsx:264
+#: src/components/integrations/IntegrationSetup.tsx:273
 msgid "No remote MCP servers found"
 msgstr ""
 
@@ -2442,7 +2455,7 @@ msgstr "트리거 없음"
 msgid "None yet"
 msgstr "아직 없음"
 
-#: src/pages/ModelSettingsOverlay.tsx:540
+#: src/pages/ModelSettingsOverlay.tsx:544
 msgid "Not connected"
 msgstr "연결되지 않음"
 
@@ -2463,7 +2476,7 @@ msgid "Now"
 msgstr "지금"
 
 #. placeholder {0}: selected.label
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Now using {0}."
 msgstr "이제 {0} 모델을 사용합니다."
 
@@ -2496,26 +2509,26 @@ msgstr "매월 1일 {0}에"
 msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
 msgstr ""
 
-#: src/pages/Shell.tsx:3671
+#: src/pages/Shell.tsx:3681
 msgid "Only empty spaces can be deleted. Delete its bots and groups first."
 msgstr ""
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3234
-#: src/pages/Shell.tsx:3239
+#: src/pages/Shell.tsx:3244
+#: src/pages/Shell.tsx:3249
 msgid "Open"
 msgstr "열기"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2597
 msgid "Open {0}"
 msgstr "{0} 열기"
 
-#: src/pages/Shell.tsx:3202
+#: src/pages/Shell.tsx:3212
 msgid "Open in full window"
 msgstr "전체 창으로 열기"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3001
 msgid "Open navigation"
 msgstr "메뉴 열기"
 
@@ -2523,20 +2536,20 @@ msgstr "메뉴 열기"
 msgid "Open work"
 msgstr "진행 중인 작업"
 
-#: src/pages/ModelSettingsOverlay.tsx:417
+#: src/pages/ModelSettingsOverlay.tsx:421
 #: src/pages/Onboarding.tsx:395
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI 호환 서버 주소"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5444
 msgid "Opened its thread."
 msgstr "대화가 만들어졌습니다."
 
-#: src/App.tsx:195
+#: src/App.tsx:202
 msgid "Opening your Space…"
 msgstr "작업공간을 여는 중…"
 
-#: src/pages/ModelSettingsOverlay.tsx:650
+#: src/pages/ModelSettingsOverlay.tsx:654
 #: src/pages/Onboarding.tsx:569
 msgid "Optional"
 msgstr "선택 사항"
@@ -2549,7 +2562,7 @@ msgstr "필요할 때만 쓰는 세부 설정"
 msgid "Optional header value"
 msgstr "선택 사항인 헤더 값"
 
-#: src/pages/ModelSettingsOverlay.tsx:664
+#: src/pages/ModelSettingsOverlay.tsx:668
 msgid "Or connect an API key"
 msgstr "또는 API 키 연결"
 
@@ -2565,7 +2578,7 @@ msgstr "자연스럽게"
 msgid "Organization API key"
 msgstr "조직 API 키"
 
-#: src/pages/ModelSettingsOverlay.tsx:465
+#: src/pages/ModelSettingsOverlay.tsx:469
 #: src/pages/Onboarding.tsx:435
 msgid "Other model…"
 msgstr "다른 모델 직접 입력…"
@@ -2600,16 +2613,16 @@ msgstr "비밀번호가 업데이트되었습니다"
 msgid "Passwords do not match"
 msgstr "비밀번호가 일치하지 않습니다"
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste a replacement key"
 msgstr "새 API 키를 붙여넣으세요"
 
-#: src/pages/ModelSettingsOverlay.tsx:428
+#: src/pages/ModelSettingsOverlay.tsx:432
 #: src/pages/Onboarding.tsx:406
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "서버의 OpenAI 호환 주소를 붙여넣으세요. 필요하면 Rakazo가 /v1을 추가합니다."
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste your API key"
 msgstr "API 키를 붙여넣으세요"
 
@@ -2617,7 +2630,7 @@ msgstr "API 키를 붙여넣으세요"
 msgid "Paused"
 msgstr "일시 중지됨"
 
-#: src/pages/ModelSettingsOverlay.tsx:534
+#: src/pages/ModelSettingsOverlay.tsx:538
 msgid "Personal credential"
 msgstr "내 인증 정보"
 
@@ -2625,7 +2638,7 @@ msgstr "내 인증 정보"
 msgid "Pin"
 msgstr "고정"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Playing…"
 msgstr "재생 중…"
 
@@ -2642,17 +2655,17 @@ msgstr "{0} 미리보기"
 msgid "Private"
 msgstr "Bot 전용"
 
-#: src/components/integrations/IntegrationSetup.tsx:177
+#: src/components/integrations/IntegrationSetup.tsx:182
 msgid "Project ID"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:215
+#: src/pages/MemorySettingsOverlay.tsx:219
 #: src/pages/Onboarding.tsx:292
 msgid "Provider"
 msgstr "서비스"
 
-#: src/pages/ModelSettingsOverlay.tsx:352
-#: src/pages/VoiceSettingsOverlay.tsx:166
+#: src/pages/ModelSettingsOverlay.tsx:356
+#: src/pages/VoiceSettingsOverlay.tsx:170
 msgid "Providers"
 msgstr "서비스"
 
@@ -2684,7 +2697,7 @@ msgstr "최근"
 msgid "Reconnect OAuth"
 msgstr "OAuth 다시 연결"
 
-#: src/App.tsx:150
+#: src/App.tsx:157
 #: src/components/ComputerUpdateProgress.tsx:54
 msgid "Reconnecting"
 msgstr "다시 연결 중"
@@ -2747,7 +2760,7 @@ msgstr "화면 새로고침"
 msgid "Refreshing…"
 msgstr "새로고침 중…"
 
-#: src/pages/Shell.tsx:5164
+#: src/pages/Shell.tsx:5178
 msgid "Release"
 msgstr "제어권 돌려주기"
 
@@ -2767,7 +2780,7 @@ msgid "Remove"
 msgstr "삭제"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4683
+#: src/pages/Shell.tsx:4697
 msgid "Remove {0}"
 msgstr "{0} 삭제"
 
@@ -2776,7 +2789,7 @@ msgid "Remove Git event"
 msgstr ""
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4845
 msgid "Remove mention {0}"
 msgstr "{0} 멘션 삭제"
 
@@ -2789,13 +2802,13 @@ msgid "Remove schedule"
 msgstr "일정 제거"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4824
 msgid "Remove skill {0}"
 msgstr "작업 기술 {0} 삭제"
 
-#: src/pages/Shell.tsx:4262
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:4276
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Remove thumbs-up"
 msgstr "좋아요 제거"
 
@@ -2803,7 +2816,7 @@ msgstr "좋아요 제거"
 msgid "Remove webhook"
 msgstr "웹훅 제거"
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5443
 msgid "Removed with chat, computer, and memory."
 msgstr "대화, 컴퓨터, 기억과 함께 삭제되었습니다."
 
@@ -2822,21 +2835,21 @@ msgstr "삭제 중…"
 msgid "Reopen"
 msgstr "다시 열기"
 
-#: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/ModelSettingsOverlay.tsx:695
+#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:699
 msgid "Replace API key"
 msgstr "API 키 교체"
 
-#: src/pages/VoiceSettingsOverlay.tsx:239
+#: src/pages/VoiceSettingsOverlay.tsx:243
 msgid "Replace key"
 msgstr "키 교체"
 
-#: src/pages/Shell.tsx:5074
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5088
+#: src/pages/Shell.tsx:5119
 msgid "Reply"
 msgstr "답장"
 
-#: src/pages/Shell.tsx:4646
+#: src/pages/Shell.tsx:4660
 msgid "Replying to {replyName}"
 msgstr "{replyName}에게 답장"
 
@@ -2870,8 +2883,8 @@ msgstr "재설정 중…"
 msgid "Restart to update"
 msgstr ""
 
-#: src/pages/Shell.tsx:2816
-#: src/pages/Shell.tsx:2847
+#: src/pages/Shell.tsx:2826
+#: src/pages/Shell.tsx:2857
 msgid "Restore"
 msgstr "복원"
 
@@ -2883,12 +2896,12 @@ msgstr "마지막으로 저장된 작업 공간을 복원합니다. 컴퓨터에
 msgid "Restoring your workspace"
 msgstr ""
 
-#: src/App.tsx:164
+#: src/App.tsx:171
 #: src/pages/PeerMessagesOverlay.tsx:109
 msgid "Retry now"
 msgstr "지금 다시 시도"
 
-#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2398
 msgid "Retry screen"
 msgstr ""
 
@@ -2918,8 +2931,8 @@ msgid "Rotate key"
 msgstr "key 교체"
 
 #: src/pages/RoutineEditor.tsx:265
-#: src/pages/Shell.tsx:3419
-#: src/pages/Shell.tsx:3431
+#: src/pages/Shell.tsx:3429
+#: src/pages/Shell.tsx:3441
 msgid "Routine"
 msgstr "자동 실행"
 
@@ -2936,7 +2949,7 @@ msgstr "실행 시간"
 msgid "Run history"
 msgstr "실행 기록"
 
-#: src/pages/Shell.tsx:3412
+#: src/pages/Shell.tsx:3422
 msgid "Run time must be in the future."
 msgstr "실행 시간은 미래여야 합니다."
 
@@ -2966,7 +2979,7 @@ msgstr ""
 #: src/pages/GroupPanel.tsx:236
 #: src/pages/KnowledgeSection.tsx:203
 #: src/pages/KnowledgeSection.tsx:422
-#: src/pages/ModelSettingsOverlay.tsx:693
+#: src/pages/ModelSettingsOverlay.tsx:697
 #: src/pages/RoutineEditor.tsx:489
 #: src/pages/shell/bot-panel.tsx:539
 msgid "Save"
@@ -2983,7 +2996,7 @@ msgstr "저장됨"
 msgid "Saved, but list refresh failed"
 msgstr "저장했지만 목록을 새로고침하지 못했습니다."
 
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Saved."
 msgstr "저장되었습니다."
 
@@ -3002,7 +3015,7 @@ msgstr ""
 #: src/components/AskCard.tsx:157
 #: src/components/teach/SkillDraftCard.tsx:142
 #: src/pages/GroupPanel.tsx:236
-#: src/pages/ModelSettingsOverlay.tsx:691
+#: src/pages/ModelSettingsOverlay.tsx:695
 #: src/pages/RoutineEditor.tsx:489
 msgid "Saving…"
 msgstr "저장 중…"
@@ -3016,15 +3029,15 @@ msgstr "말씀하세요. 잠시 멈추면 자동으로 전송됩니다."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "예 또는 아니요로 답하거나 문장으로 답해 주세요."
 
-#: src/pages/ModelSettingsOverlay.tsx:984
+#: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
-#: src/pages/Shell.tsx:2530
+#: src/pages/Shell.tsx:2540
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "검색"
 
-#: src/components/integrations/IntegrationSetup.tsx:241
-#: src/components/integrations/IntegrationSetup.tsx:242
+#: src/components/integrations/IntegrationSetup.tsx:250
+#: src/components/integrations/IntegrationSetup.tsx:251
 #: src/pages/PluginsOverlay.tsx:696
 #: src/pages/PluginsOverlay.tsx:697
 msgid "Search apps"
@@ -3038,11 +3051,11 @@ msgstr ""
 msgid "Search by domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:247
+#: src/components/integrations/IntegrationSetup.tsx:256
 msgid "Search integrations.sh"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:979
+#: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr "모델 검색"
 
@@ -3051,8 +3064,8 @@ msgstr "모델 검색"
 msgid "Search or create Bots"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:355
-#: src/pages/ModelSettingsOverlay.tsx:361
+#: src/pages/ModelSettingsOverlay.tsx:359
+#: src/pages/ModelSettingsOverlay.tsx:365
 msgid "Search providers"
 msgstr "AI 서비스 검색"
 
@@ -3066,7 +3079,7 @@ msgstr "AI 서비스 또는 모델 검색"
 msgid "Searching…"
 msgstr "검색 중…"
 
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3030
 msgid "Select a bot"
 msgstr "대화할 Bot을 선택하세요"
 
@@ -3074,8 +3087,8 @@ msgstr "대화할 Bot을 선택하세요"
 msgid "Selected"
 msgstr ""
 
-#: src/pages/Shell.tsx:4929
-#: src/pages/Shell.tsx:4950
+#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4964
 msgid "Send"
 msgstr "보내기"
 
@@ -3105,8 +3118,9 @@ msgstr "보내는 중…"
 msgid "Sentry alert"
 msgstr "Sentry 알림"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/AccountSettingsOverlay.tsx:158
+#: src/pages/LocalSettings.tsx:42
 msgid "Server integrations"
 msgstr ""
 
@@ -3114,33 +3128,33 @@ msgstr ""
 msgid "Server name"
 msgstr "서버 이름"
 
-#: src/components/integrations/IntegrationSetup.tsx:273
-#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:282
+#: src/components/integrations/IntegrationSetup.tsx:300
 #: src/pages/McpServersOverlay.tsx:329
-#: src/pages/ModelSettingsOverlay.tsx:412
+#: src/pages/ModelSettingsOverlay.tsx:416
 #: src/pages/Onboarding.tsx:390
 msgid "Server URL"
 msgstr "서버 URL"
 
 #: src/pages/MessagingSettingsOverlay.tsx:361
 #: src/pages/SettingsOverlay.tsx:103
-#: src/pages/SettingsOverlay.tsx:151
-#: src/pages/Shell.tsx:2896
-#: src/pages/Shell.tsx:2903
-#: src/pages/Shell.tsx:3152
+#: src/pages/SettingsOverlay.tsx:158
+#: src/pages/Shell.tsx:2906
+#: src/pages/Shell.tsx:2913
+#: src/pages/Shell.tsx:3162
 msgid "Settings"
 msgstr "설정"
 
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4982
 msgid "Settings: General"
 msgstr "설정: 일반"
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4984
 msgid "Settings: Usage"
 msgstr "설정: 사용량"
 
-#: src/components/integrations/IntegrationSetup.tsx:319
-#: src/pages/ModelSettingsOverlay.tsx:425
+#: src/components/integrations/IntegrationSetup.tsx:328
+#: src/pages/ModelSettingsOverlay.tsx:429
 #: src/pages/Onboarding.tsx:403
 msgid "Setup help"
 msgstr "설정 도움말"
@@ -3158,11 +3172,11 @@ msgstr "공유 문서"
 msgid "Show all providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Show bots"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show computer"
 msgstr "컴퓨터 보기"
 
@@ -3178,14 +3192,14 @@ msgstr "비밀번호 표시"
 msgid "Show popular providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show settings"
 msgstr "설정 보기"
 
 #: src/lib/localized-provider-hint.ts:7
 #: src/pages/Auth.tsx:230
 #: src/pages/Auth.tsx:288
-#: src/pages/ModelSettingsOverlay.tsx:632
+#: src/pages/ModelSettingsOverlay.tsx:636
 #: src/pages/Onboarding.tsx:152
 msgid "Sign in"
 msgstr "로그인"
@@ -3200,7 +3214,7 @@ msgid "Sign up"
 msgstr "가입하기"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4758
 msgid "Skill {0}"
 msgstr "작업 기술 {0}"
 
@@ -3208,8 +3222,8 @@ msgstr "작업 기술 {0}"
 msgid "Skills"
 msgstr "스킬"
 
-#: src/components/integrations/IntegrationSetup.tsx:355
-#: src/pages/Shell.tsx:5171
+#: src/components/integrations/IntegrationSetup.tsx:364
+#: src/pages/Shell.tsx:5185
 msgid "Skip"
 msgstr "건너뛰기"
 
@@ -3218,7 +3232,7 @@ msgid "Skip or deploy key"
 msgstr "건너뛰거나 배포 키"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1842
+#: src/pages/Shell.tsx:1852
 msgid "Skipped {0}"
 msgstr "{0} 건너뜀"
 
@@ -3250,21 +3264,21 @@ msgstr "Space: 끼어들기 · Esc: 통화 종료"
 msgid "Spaces"
 msgstr ""
 
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Speak"
 msgstr "읽기"
 
-#: src/pages/VoiceSettingsOverlay.tsx:190
+#: src/pages/VoiceSettingsOverlay.tsx:194
 msgid "Speak + transcribe"
 msgstr "음성 출력·받아쓰기"
 
-#: src/pages/VoiceSettingsOverlay.tsx:192
+#: src/pages/VoiceSettingsOverlay.tsx:196
 msgid "Speak only"
 msgstr "음성 출력만"
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Speak this reply"
 msgstr "이 답변 읽기"
 
@@ -3281,7 +3295,7 @@ msgid "Starting"
 msgstr "시작 중"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
-#: src/pages/ModelSettingsOverlay.tsx:630
+#: src/pages/ModelSettingsOverlay.tsx:634
 #: src/pages/Onboarding.tsx:554
 msgid "Starting…"
 msgstr "시작하는 중…"
@@ -3290,11 +3304,11 @@ msgstr "시작하는 중…"
 msgid "Steps"
 msgstr "실행 단계"
 
-#: src/pages/Shell.tsx:3912
-#: src/pages/Shell.tsx:3917
-#: src/pages/Shell.tsx:4939
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:3926
+#: src/pages/Shell.tsx:3931
+#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Stop"
 msgstr "중지"
 
@@ -3302,8 +3316,8 @@ msgstr "중지"
 msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
 msgstr ""
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Stop speaking"
 msgstr "읽기 중지"
 
@@ -3321,20 +3335,20 @@ msgstr "중지되었습니다."
 msgid "Stored encrypted"
 msgstr "암호화해 저장"
 
-#: src/pages/ModelSettingsOverlay.tsx:545
+#: src/pages/ModelSettingsOverlay.tsx:549
 msgid "Stored securely. Never shown here."
 msgstr "안전하게 저장됩니다. 이 화면에 표시되지 않습니다."
 
-#: src/pages/Shell.tsx:5383
+#: src/pages/Shell.tsx:5397
 msgid "subagent"
 msgstr "보조 에이전트"
 
-#: src/pages/ModelSettingsOverlay.tsx:590
+#: src/pages/ModelSettingsOverlay.tsx:594
 #: src/pages/Onboarding.tsx:521
 msgid "Submit"
 msgstr "확인"
 
-#: src/pages/ModelSettingsOverlay.tsx:503
+#: src/pages/ModelSettingsOverlay.tsx:507
 #: src/pages/Onboarding.tsx:462
 msgid "Supports thinking"
 msgstr "사고 모드 지원"
@@ -3343,7 +3357,7 @@ msgstr "사고 모드 지원"
 msgid "Switch bot"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:723
+#: src/pages/ModelSettingsOverlay.tsx:727
 msgid "Switching…"
 msgstr "전환 중…"
 
@@ -3356,7 +3370,7 @@ msgstr "시스템"
 msgid "Teach a task"
 msgstr "작업 가르치기"
 
-#: src/pages/Shell.tsx:3076
+#: src/pages/Shell.tsx:3086
 msgid "Teaching in progress. Stop teaching before sending a new message."
 msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼저 가르치기를 종료하세요."
 
@@ -3364,7 +3378,7 @@ msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼�
 msgid "Team"
 msgstr "팀 공용"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "Team Computer"
 msgstr "팀 컴퓨터"
 
@@ -3394,7 +3408,7 @@ msgstr "테스트 실행"
 msgid "The API did not come back. Refresh this page."
 msgstr "API가 다시 작동하지 않습니다. 이 페이지를 새로 고침하세요."
 
-#: src/pages/MemorySettingsOverlay.tsx:241
+#: src/pages/MemorySettingsOverlay.tsx:245
 msgid "The selected memory provider is not available in this build."
 msgstr "선택한 기억 서비스는 현재 빌드에서 사용할 수 없습니다."
 
@@ -3402,7 +3416,7 @@ msgstr "선택한 기억 서비스는 현재 빌드에서 사용할 수 없습�
 msgid "Thinking"
 msgstr "생각 깊이"
 
-#: src/pages/Shell.tsx:5632
+#: src/pages/Shell.tsx:5646
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "이 Bot은 별도 Linux 화면이 아니라 현재 컴퓨터에서 실행됩니다. 터미널과 파일 작업은 홈 폴더를 사용합니다."
 
@@ -3455,7 +3469,7 @@ msgstr "이 서버는 이미 연결되어 있습니다. 다시 인증하려면 �
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools. A popup will open."
 msgstr "이 서버는 브라우저 로그인이 필요합니다. 인증을 누르면 새 창이 열리고, 완료 후 Bot이 도구를 사용할 수 있습니다."
 
-#: src/pages/ModelSettingsOverlay.tsx:705
+#: src/pages/ModelSettingsOverlay.tsx:709
 msgid "This subscription sign-in is not available in Rakazo yet. Use a deployment credential or choose another provider."
 msgstr "이 구독 로그인 방식은 아직 Rakazo에서 지원되지 않습니다. 서버에 설정된 인증 정보를 사용하거나 다른 서비스를 선택하세요."
 
@@ -3514,7 +3528,7 @@ msgid "Unpin"
 msgstr "고정 해제"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1920
+#: src/pages/Shell.tsx:1930
 msgid "Unsupported file type: {0}"
 msgstr "지원하지 않는 파일 형식: {0}"
 
@@ -3574,8 +3588,8 @@ msgstr "업데이트 중…"
 
 #: src/pages/AccountSettingsOverlay.tsx:199
 #: src/pages/SettingsOverlay.tsx:96
-#: src/pages/Shell.tsx:2908
-#: src/pages/Shell.tsx:2919
+#: src/pages/Shell.tsx:2918
+#: src/pages/Shell.tsx:2929
 msgid "Usage"
 msgstr "사용량"
 
@@ -3583,7 +3597,7 @@ msgstr "사용량"
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} 사용"
 
-#: src/pages/ModelSettingsOverlay.tsx:490
+#: src/pages/ModelSettingsOverlay.tsx:494
 #: src/pages/Onboarding.tsx:454
 msgid "Use a found model"
 msgstr "찾은 모델 중에서 선택"
@@ -3593,7 +3607,7 @@ msgstr "찾은 모델 중에서 선택"
 msgid "Use default guidance"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:725
+#: src/pages/ModelSettingsOverlay.tsx:729
 msgid "Use this model"
 msgstr "이 모델 사용"
 
@@ -3606,16 +3620,16 @@ msgid "Verifying…"
 msgstr "확인 중…"
 
 #: src/pages/SettingsOverlay.tsx:95
-#: src/pages/Shell.tsx:4916
-#: src/pages/Shell.tsx:4917
+#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:4931
 #: src/pages/shell/bot-panel.tsx:482
-#: src/pages/VoiceSettingsOverlay.tsx:150
-#: src/pages/VoiceSettingsOverlay.tsx:249
+#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Voice"
 msgstr "음성"
 
-#: src/pages/ModelSettingsOverlay.tsx:594
-#: src/pages/ModelSettingsOverlay.tsx:616
+#: src/pages/ModelSettingsOverlay.tsx:598
+#: src/pages/ModelSettingsOverlay.tsx:620
 #: src/pages/Onboarding.tsx:525
 #: src/pages/Onboarding.tsx:547
 msgid "Waiting for sign-in…"
@@ -3687,8 +3701,8 @@ msgstr ""
 msgid "Working…"
 msgstr "처리 중…"
 
-#: src/pages/Shell.tsx:1616
-#: src/pages/Shell.tsx:2393
+#: src/pages/Shell.tsx:1626
+#: src/pages/Shell.tsx:2403
 msgid "You"
 msgstr "나"
 
@@ -3700,7 +3714,7 @@ msgstr "자동으로 이동하지 않으면 이 탭을 닫아도 됩니다."
 msgid "You can close this window."
 msgstr "이 창을 닫아도 됩니다."
 
-#: src/pages/Shell.tsx:3901
+#: src/pages/Shell.tsx:3915
 msgid "You have control"
 msgstr "직접 조작 중"
 

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -13,22 +13,22 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/pages/Shell.tsx:2720
+#: src/pages/Shell.tsx:2730
 msgid " (unread)"
 msgstr " (não lido)"
 
 #. placeholder {0}: group.entries.length
-#: src/pages/ModelSettingsOverlay.tsx:382
+#: src/pages/ModelSettingsOverlay.tsx:386
 msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# modelo} other {# modelos}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1822
+#: src/pages/Shell.tsx:1832
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (máx. anexos {ATTACHMENT_MAX_COUNT})"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1826
+#: src/pages/Shell.tsx:1836
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (acima de 10 MiB)"
 
@@ -80,11 +80,11 @@ msgid "{0} will still respond to direct mentions."
 msgstr ""
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3245
+#: src/pages/Shell.tsx:3255
 msgid "{0}'s screen"
 msgstr ""
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "{botName}’s computer"
 msgstr "Computador do {botName}"
 
@@ -132,12 +132,12 @@ msgstr "{title}, {label}"
 msgid "{toolCount, plural, one {# tool} other {# tools}}"
 msgstr ""
 
-#: src/pages/Shell.tsx:4072
+#: src/pages/Shell.tsx:4086
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} está trabalhando"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4711
+#: src/pages/Shell.tsx:4725
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "About spaces"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:301
+#: src/components/integrations/IntegrationSetup.tsx:310
 msgid "Access token"
 msgstr ""
 
@@ -188,7 +188,7 @@ msgstr "Confirmações de ação"
 msgid "Actions for {0}"
 msgstr "Ações para {0}"
 
-#: src/pages/Shell.tsx:3619
+#: src/pages/Shell.tsx:3629
 msgid "Actions for space"
 msgstr ""
 
@@ -196,12 +196,12 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:337
+#: src/pages/ModelSettingsOverlay.tsx:341
 msgid "Active model"
 msgstr "Modelo ativo"
 
-#: src/pages/Shell.tsx:2440
-#: src/pages/Shell.tsx:2442
+#: src/pages/Shell.tsx:2450
+#: src/pages/Shell.tsx:2452
 msgid "Activity"
 msgstr "Atividade"
 
@@ -215,11 +215,11 @@ msgstr "Adicionar"
 msgid "Add a model in Settings to use this."
 msgstr ""
 
-#: src/pages/Shell.tsx:3407
+#: src/pages/Shell.tsx:3417
 msgid "Add a run time for this one-shot."
 msgstr ""
 
-#: src/pages/Shell.tsx:3385
+#: src/pages/Shell.tsx:3395
 msgid "Add a schedule, webhook, GitHub, or message trigger"
 msgstr ""
 
@@ -259,7 +259,7 @@ msgstr "Adicionar endpoint GraphQL"
 msgid "Add item"
 msgstr "Adicionar item"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/PluginsOverlay.tsx:951
 msgid "Add MCP server"
 msgstr "Adicionar servidor MCP"
@@ -277,12 +277,12 @@ msgstr "Adicionar servidor MCP remoto"
 msgid "Add server"
 msgstr "Adicionar servidor"
 
-#: src/components/integrations/IntegrationSetup.tsx:269
+#: src/components/integrations/IntegrationSetup.tsx:278
 msgid "Add server URL"
 msgstr ""
 
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Add thumbs-up"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr "Adicionando"
 
 #: src/pages/AccountSettingsOverlay.tsx:166
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/ModelSettingsOverlay.tsx:502
+#: src/pages/ModelSettingsOverlay.tsx:506
 #: src/pages/Onboarding.tsx:461
 #: src/pages/PluginsOverlay.tsx:836
 #: src/pages/RoutineSchedule.tsx:43
@@ -323,7 +323,7 @@ msgstr "Avançado"
 msgid "Advanced..."
 msgstr ""
 
-#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3039
 msgid "Agent computer"
 msgstr "Computador do agente"
 
@@ -405,15 +405,15 @@ msgid "API is back, but the update did not finish. Check the host logs."
 msgstr ""
 
 #: src/components/AskCard.tsx:44
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 #: src/lib/localized-provider-hint.ts:9
-#: src/pages/ModelSettingsOverlay.tsx:644
-#: src/pages/ModelSettingsOverlay.tsx:647
-#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:648
+#: src/pages/ModelSettingsOverlay.tsx:651
+#: src/pages/ModelSettingsOverlay.tsx:670
 #: src/pages/Onboarding.tsx:563
 #: src/pages/Onboarding.tsx:566
 #: src/pages/Onboarding.tsx:580
-#: src/pages/VoiceSettingsOverlay.tsx:219
+#: src/pages/VoiceSettingsOverlay.tsx:223
 msgid "API key"
 msgstr "Chave de API"
 
@@ -444,15 +444,15 @@ msgstr "Aprove este servidor para permitir que seu agente use suas ferramentas."
 msgid "Archive"
 msgstr "Arquivar"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5431
 msgid "archived"
 msgstr "arquivado"
 
-#: src/pages/Shell.tsx:2789
+#: src/pages/Shell.tsx:2799
 msgid "Archived"
 msgstr "Arquivado"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5442
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Arquivado. Chat, memória e arquivos mantidos."
 
@@ -491,7 +491,7 @@ msgstr "Perguntar antes de comprar"
 msgid "Ask before sending external email"
 msgstr "Perguntar antes de enviar e-mail externo"
 
-#: src/components/integrations/IntegrationSetup.tsx:219
+#: src/components/integrations/IntegrationSetup.tsx:228
 msgid "Ask the server owner to configure this provider."
 msgstr ""
 
@@ -506,15 +506,15 @@ msgstr "em {0}"
 msgid "at {timeSelect}"
 msgstr "em {timeSelect}"
 
-#: src/pages/Shell.tsx:4791
+#: src/pages/Shell.tsx:4805
 msgid "Attach file"
 msgstr "Escolher arquivo"
 
-#: src/pages/Shell.tsx:5023
+#: src/pages/Shell.tsx:5037
 msgid "Attachment"
 msgstr "Anexo"
 
-#: src/pages/ModelSettingsOverlay.tsx:577
+#: src/pages/ModelSettingsOverlay.tsx:581
 #: src/pages/Onboarding.tsx:512
 msgid "Authorization code or callback URL"
 msgstr "Código de autorização ou URL de retorno de chamada"
@@ -567,23 +567,23 @@ msgstr "URL Base"
 msgid "Bearer token"
 msgstr "Token portador"
 
-#: src/pages/Shell.tsx:5644
+#: src/pages/Shell.tsx:5658
 msgid "Booting live desktop…"
 msgstr "Iniciando a área de trabalho ao vivo..."
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3877
 msgid "Booting up {0}’s computer"
 msgstr "Inicializando o computador do {0}"
 
-#: src/pages/Shell.tsx:5292
-#: src/pages/Shell.tsx:5293
-#: src/pages/Shell.tsx:5421
+#: src/pages/Shell.tsx:5306
+#: src/pages/Shell.tsx:5307
+#: src/pages/Shell.tsx:5435
 msgid "bot"
 msgstr "bot"
 
 #: src/pages/IntegrationSetup.tsx:51
-#: src/pages/Shell.tsx:1617
+#: src/pages/Shell.tsx:1627
 msgid "Bot"
 msgstr "Bot"
 
@@ -592,11 +592,11 @@ msgstr "Bot"
 msgid "Bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:3971
+#: src/pages/Shell.tsx:3985
 msgid "Bot screen"
 msgstr "Tela do bot"
 
-#: src/pages/Shell.tsx:3208
+#: src/pages/Shell.tsx:3218
 msgid "Bot screen preview"
 msgstr "Pré-visualização da tela"
 
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first."
 msgstr "Os bots agem sem perguntar por padrão. Adicione uma exceção apenas quando quiser analisar um tipo de ação primeiro."
 
-#: src/pages/Shell.tsx:4073
+#: src/pages/Shell.tsx:4087
 msgid "Bots are working"
 msgstr "Bots estão trabalhando"
 
@@ -620,7 +620,7 @@ msgstr ""
 msgid "Call"
 msgstr "Ligar"
 
-#: src/App.tsx:152
+#: src/App.tsx:159
 msgid "Can't reach the server."
 msgstr "Não é possível acessar o servidor."
 
@@ -648,7 +648,7 @@ msgstr "Cancelar novo bot"
 msgid "Cancel new group"
 msgstr "Cancelar novo grupo"
 
-#: src/pages/Shell.tsx:4649
+#: src/pages/Shell.tsx:4663
 msgid "Cancel reply"
 msgstr "cancelar resposta"
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Chat apps, group channels, and agent connections."
 msgstr ""
 
-#: src/pages/Shell.tsx:4966
+#: src/pages/Shell.tsx:4980
 msgid "Chat Settings"
 msgstr "Configurações do chat"
 
@@ -699,8 +699,8 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: src/pages/Shell.tsx:3420
-#: src/pages/Shell.tsx:3432
+#: src/pages/Shell.tsx:3430
+#: src/pages/Shell.tsx:3442
 msgid "Check in."
 msgstr "Acompanhamento"
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Choose a new password"
 msgstr "Escolha uma nova senha"
 
-#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:312
 msgid "Choose which connected model Rakazo uses."
 msgstr "Escolha qual modelo conectado a Rakazo usa."
 
@@ -747,11 +747,11 @@ msgstr "Limpar conversa"
 msgid "Clearing…"
 msgstr "Limpeza"
 
-#: src/components/integrations/IntegrationSetup.tsx:167
+#: src/components/integrations/IntegrationSetup.tsx:172
 msgid "Client ID"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 msgid "Client secret"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr "Fechar"
 msgid "Close chart"
 msgstr "Fechar gráfico"
 
-#: src/pages/Shell.tsx:3950
+#: src/pages/Shell.tsx:3964
 msgid "Close computer"
 msgstr "Fechar computador"
 
@@ -784,7 +784,7 @@ msgstr "Fechar integrações"
 msgid "Close MCP servers"
 msgstr "Fechar servidores MCP"
 
-#: src/pages/MemorySettingsOverlay.tsx:164
+#: src/pages/MemorySettingsOverlay.tsx:168
 #: src/pages/SettingsOverlay.tsx:109
 msgid "Close memory settings"
 msgstr "Fechar configurações de memória"
@@ -793,16 +793,16 @@ msgstr "Fechar configurações de memória"
 msgid "Close messaging settings"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:324
+#: src/pages/ModelSettingsOverlay.tsx:328
 #: src/pages/SettingsOverlay.tsx:107
 msgid "Close model settings"
 msgstr "Fechar configurações do modelo"
 
-#: src/pages/Shell.tsx:2418
+#: src/pages/Shell.tsx:2428
 msgid "Close navigation"
 msgstr "Fechar navegação"
 
-#: src/pages/Shell.tsx:3186
+#: src/pages/Shell.tsx:3196
 msgid "Close panel"
 msgstr "Fechar painel"
 
@@ -815,7 +815,7 @@ msgid "Close user settings"
 msgstr "Fechar configurações do usuário"
 
 #: src/pages/SettingsOverlay.tsx:111
-#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:158
 msgid "Close voice settings"
 msgstr "Fechar configurações de voz"
 
@@ -828,7 +828,7 @@ msgid "Code"
 msgstr "Código"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2590
+#: src/pages/Shell.tsx:2600
 msgid "Collapse {0}"
 msgstr ""
 
@@ -855,24 +855,24 @@ msgid "Complete"
 msgstr "Concluir"
 
 #: src/pages/SettingsOverlay.tsx:97
-#: src/pages/Shell.tsx:5578
+#: src/pages/Shell.tsx:5592
 #: src/pages/shell/bot-panel.tsx:57
 msgid "Computer"
 msgstr "Computador"
 
-#: src/pages/Shell.tsx:5647
+#: src/pages/Shell.tsx:5661
 msgid "Computer failed to boot"
 msgstr "Falha ao inicializar o computador"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4008
 msgid "Computer is asleep"
 msgstr "O computador está dormindo"
 
-#: src/pages/Shell.tsx:5646
+#: src/pages/Shell.tsx:5660
 msgid "Computer is asleep. Open it to wake."
 msgstr ""
 
-#: src/pages/Shell.tsx:5648
+#: src/pages/Shell.tsx:5662
 msgid "Computer is stopped"
 msgstr "O computador está parado"
 
@@ -884,7 +884,7 @@ msgstr "Computadores"
 msgid "Computers are off. Set SANDBOX_PROVIDER=docker with SANDBOX_SUPERVISOR_TOKEN, or set SANDBOX_PROVIDER to e2b, daytona, or box with its API key. Recreate the stack after changing .env."
 msgstr "Computadores estão desligados. Defina SANDBOX_PROVIDER=docker com SANDBOX_SUPERVISOR_TOKEN, ou SANDBOX_PROVIDER como e2b, daytona ou box com a chave de API. Recrie o stack após alterar o .env."
 
-#: src/pages/ModelSettingsOverlay.tsx:344
+#: src/pages/ModelSettingsOverlay.tsx:348
 msgid "Configured by deployment"
 msgstr "Configurado por implantação"
 
@@ -902,12 +902,12 @@ msgstr "Confirmar exclusão"
 msgid "Confirm password"
 msgstr "Confirmar senha"
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:258
-#: src/components/integrations/IntegrationSetup.tsx:282
-#: src/components/integrations/IntegrationSetup.tsx:315
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:267
+#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:324
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
-#: src/pages/VoiceSettingsOverlay.tsx:241
+#: src/pages/VoiceSettingsOverlay.tsx:245
 msgid "Connect"
 msgstr "Conectar"
 
@@ -915,7 +915,7 @@ msgstr "Conectar"
 msgid "Connect a model"
 msgstr "Conectar um modelo"
 
-#: src/pages/ModelSettingsOverlay.tsx:697
+#: src/pages/ModelSettingsOverlay.tsx:701
 msgid "Connect API key"
 msgstr "Conecte-se com a chave API"
 
@@ -931,7 +931,7 @@ msgstr "Conecte o servidor MCP “{name}”"
 msgid "Connect OAuth"
 msgstr "Conectar OAuth"
 
-#: src/pages/ModelSettingsOverlay.tsx:547
+#: src/pages/ModelSettingsOverlay.tsx:551
 msgid "Connect this provider to use it as your personal model."
 msgstr "Conecte este provedor para usá-lo como seu modelo pessoal."
 
@@ -939,30 +939,30 @@ msgstr "Conecte este provedor para usá-lo como seu modelo pessoal."
 msgid "Connect Treg"
 msgstr "Conectar Treg"
 
-#: src/components/integrations/IntegrationSetup.tsx:159
-#: src/components/integrations/IntegrationSetup.tsx:258
+#: src/components/integrations/IntegrationSetup.tsx:164
+#: src/components/integrations/IntegrationSetup.tsx:267
 #: src/pages/McpOAuthCallback.tsx:54
-#: src/pages/MemorySettingsOverlay.tsx:187
-#: src/pages/ModelSettingsOverlay.tsx:389
+#: src/pages/MemorySettingsOverlay.tsx:191
+#: src/pages/ModelSettingsOverlay.tsx:393
 #: src/pages/shell/message-cards.tsx:187
-#: src/pages/VoiceSettingsOverlay.tsx:198
+#: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Conectado"
 
 #. placeholder {0}: credential.label
-#: src/pages/ModelSettingsOverlay.tsx:538
+#: src/pages/ModelSettingsOverlay.tsx:542
 msgid "Connected · {0}"
 msgstr "Conectado · {0}"
 
 #. placeholder {0}: selected.name
-#: src/pages/VoiceSettingsOverlay.tsx:102
+#: src/pages/VoiceSettingsOverlay.tsx:106
 msgid "Connected {0}."
 msgstr "Conectado {0}."
 
 #. placeholder {0}: selected.label
 #. placeholder {0}: selectedLabelRef.current ?? "this model"
-#: src/pages/ModelSettingsOverlay.tsx:82
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:84
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Connected and using {0}."
 msgstr "Conectado e usando {0}."
 
@@ -970,12 +970,12 @@ msgstr "Conectado e usando {0}."
 msgid "Connected. Its tools are available from your next message."
 msgstr "Conectado. Suas ferramentas estão disponíveis na sua próxima mensagem."
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/McpServersOverlay.tsx:38
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
 #: src/pages/shell/message-cards.tsx:360
-#: src/pages/VoiceSettingsOverlay.tsx:237
+#: src/pages/VoiceSettingsOverlay.tsx:241
 msgid "Connecting…"
 msgstr "Conectando…"
 
@@ -984,7 +984,7 @@ msgstr "Conectando…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "A conexão com o {0} ainda está pendente. Você pode fechar isso e verificar novamente."
 
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/Onboarding.tsx:604
 #: src/pages/Onboarding.tsx:667
 msgid "Continue"
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Continue with email"
 msgstr "Continuar com e-mail"
 
-#: src/pages/Shell.tsx:5109
+#: src/pages/Shell.tsx:5123
 msgid "Copy"
 msgstr "Copiar"
 
@@ -1022,7 +1022,7 @@ msgstr "Não foi possível autorizar este aplicativo"
 msgid "Could not change password"
 msgstr "Não foi possível alterar a senha"
 
-#: src/pages/ModelSettingsOverlay.tsx:245
+#: src/pages/ModelSettingsOverlay.tsx:247
 msgid "Could not change the default model"
 msgstr "Não foi possível alterar o modelo padrão"
 
@@ -1046,30 +1046,30 @@ msgstr "Não foi possível concluir o OAuth"
 msgid "Could not complete the update. Try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:76
+#: src/components/integrations/IntegrationSetup.tsx:79
 #: src/pages/PluginsOverlay.tsx:264
 msgid "Could not connect"
 msgstr "Não foi possível conectar"
 
 #. placeholder {0}: registration.name
-#: src/pages/MemorySettingsOverlay.tsx:115
+#: src/pages/MemorySettingsOverlay.tsx:119
 msgid "Could not connect {0}"
 msgstr "Não foi possível conectar o {0}"
 
-#: src/pages/ModelSettingsOverlay.tsx:284
+#: src/pages/ModelSettingsOverlay.tsx:286
 msgid "Could not connect this provider"
 msgstr "Não foi possível conectar este provedor"
 
-#: src/pages/VoiceSettingsOverlay.tsx:104
+#: src/pages/VoiceSettingsOverlay.tsx:108
 msgid "Could not connect this voice provider"
 msgstr "Não foi possível conectar este provedor de voz"
 
-#: src/pages/Shell.tsx:875
+#: src/pages/Shell.tsx:885
 msgid "Could not connect to the computer screen"
 msgstr ""
 
 #: src/pages/Auth.tsx:99
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2368
 msgid "Could not continue"
 msgstr "Não foi possível continuar"
 
@@ -1117,7 +1117,7 @@ msgstr "Não foi possível excluir a habilidade"
 msgid "Could not delete space"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:129
+#: src/pages/MemorySettingsOverlay.tsx:133
 msgid "Could not disconnect memory provider"
 msgstr "Não foi possível desconectar o provedor de memória"
 
@@ -1158,7 +1158,7 @@ msgstr "Não foi possível carregar as regras de aprovação"
 msgid "Could not load bots. Reload to try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:67
+#: src/components/integrations/IntegrationSetup.tsx:70
 #: src/pages/PluginsOverlay.tsx:143
 #: src/pages/PluginsOverlay.tsx:719
 msgid "Could not load integrations"
@@ -1168,7 +1168,7 @@ msgstr "Não foi possível carregar as integrações"
 msgid "Could not load MCP servers"
 msgstr "Não foi possível carregar os servidores MCP"
 
-#: src/pages/ModelSettingsOverlay.tsx:129
+#: src/pages/ModelSettingsOverlay.tsx:131
 msgid "Could not load model settings"
 msgstr "Não foi possível carregar as configurações do modelo"
 
@@ -1188,11 +1188,15 @@ msgstr "Não foi possível carregar este arquivo."
 msgid "Could not load update status"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:77
+#: src/pages/VoiceSettingsOverlay.tsx:81
 msgid "Could not load voice settings"
 msgstr "Não foi possível carregar as configurações de voz"
 
-#: src/pages/VoiceSettingsOverlay.tsx:138
+#: src/pages/LocalSettings.tsx:26
+msgid "Could not open local settings. Start the local server and create its owner account, then try again."
+msgstr ""
+
+#: src/pages/VoiceSettingsOverlay.tsx:142
 msgid "Could not play a test clip"
 msgstr "Não foi possível reproduzir um clipe de teste"
 
@@ -1202,7 +1206,7 @@ msgstr "Não foi possível reproduzir um clipe de teste"
 msgid "Could not reach the server"
 msgstr "Não foi possível acessar o servidor"
 
-#: src/pages/ModelSettingsOverlay.tsx:229
+#: src/pages/ModelSettingsOverlay.tsx:231
 #: src/pages/Onboarding.tsx:191
 msgid "Could not reach this model server"
 msgstr "Não foi possível acessar este servidor modelo"
@@ -1240,7 +1244,7 @@ msgstr "Não foi possível redefinir a senha"
 msgid "Could not revoke connection"
 msgstr "Não foi possível revogar a conexão"
 
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3496
 msgid "Could not run routine"
 msgstr ""
 
@@ -1262,7 +1266,7 @@ msgstr "Não foi possível salvar o grupo"
 msgid "Could not save model"
 msgstr "Não foi possível salvar o modelo"
 
-#: src/pages/Shell.tsx:3457
+#: src/pages/Shell.tsx:3467
 msgid "Could not save routine"
 msgstr "Não foi possível salvar a rotina"
 
@@ -1278,7 +1282,7 @@ msgstr "Não foi possível salvar a habilidade"
 msgid "Could not save that choice"
 msgstr "Não foi possível salvar essa opção"
 
-#: src/pages/VoiceSettingsOverlay.tsx:119
+#: src/pages/VoiceSettingsOverlay.tsx:123
 msgid "Could not save that voice"
 msgstr "Não foi possível salvar essa voz"
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Could not submit this answer"
 msgstr "Não foi possível enviar esta resposta"
 
-#: src/pages/Shell.tsx:2212
+#: src/pages/Shell.tsx:2222
 msgid "Could not take control"
 msgstr "Não foi possível assumir o controle"
 
@@ -1326,11 +1330,11 @@ msgstr "Não foi possível atualizar o acesso do agente"
 msgid "Could not update computer"
 msgstr "Não foi possível atualizar o computador"
 
-#: src/pages/Shell.tsx:1808
+#: src/pages/Shell.tsx:1818
 msgid "Could not update reaction"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:143
+#: src/pages/MemorySettingsOverlay.tsx:147
 msgid "Could not update the default memory scope"
 msgstr "Não foi possível atualizar o escopo de memória padrão"
 
@@ -1346,7 +1350,7 @@ msgstr ""
 msgid "Couldn't update messaging settings"
 msgstr ""
 
-#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2481
 #: src/pages/shell/bot-panel.tsx:184
 #: src/pages/shell/dialogs.tsx:208
 msgid "Create"
@@ -1460,8 +1464,8 @@ msgstr "Escopo padrão"
 #: src/pages/KnowledgeSection.tsx:449
 #: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:301
-#: src/pages/Shell.tsx:2825
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2835
+#: src/pages/Shell.tsx:2866
 #: src/pages/shell/dialogs.tsx:351
 #: src/pages/shell/dialogs.tsx:412
 msgid "Delete"
@@ -1469,8 +1473,8 @@ msgstr "Excluir"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2822
-#: src/pages/Shell.tsx:2853
+#: src/pages/Shell.tsx:2832
+#: src/pages/Shell.tsx:2863
 msgid "Delete {0}"
 msgstr "Excluir {0}"
 
@@ -1489,11 +1493,11 @@ msgstr "Excluir o grupo"
 msgid "Delete memories too"
 msgstr "Excluir memórias também"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3643
 msgid "Delete space"
 msgstr ""
 
-#: src/pages/Shell.tsx:5419
+#: src/pages/Shell.tsx:5433
 msgid "deleted"
 msgstr "excluído"
 
@@ -1511,7 +1515,7 @@ msgstr "Negado"
 msgid "Deny"
 msgstr "Negar"
 
-#: src/pages/ModelSettingsOverlay.tsx:340
+#: src/pages/ModelSettingsOverlay.tsx:344
 msgid "Deployment default"
 msgstr "Padrão de implantação"
 
@@ -1534,16 +1538,16 @@ msgstr ""
 msgid "Desktop update"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:40
+#: src/components/integrations/IntegrationSetup.tsx:43
 msgid "Direct MCP"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:493
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnecting…"
 msgstr "Desconectando…"
 
@@ -1553,7 +1557,7 @@ msgstr "Desconectando…"
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/Shell.tsx:4629
+#: src/pages/Shell.tsx:4643
 msgid "Dismiss error"
 msgstr ""
 
@@ -1601,7 +1605,7 @@ msgstr "Baixar {name}"
 msgid "Download as markdown"
 msgstr "Baixar como markdown"
 
-#: src/components/integrations/IntegrationSetup.tsx:327
+#: src/components/integrations/IntegrationSetup.tsx:336
 msgid "Download Executor"
 msgstr ""
 
@@ -1617,7 +1621,7 @@ msgstr "Habilidade de rascunho"
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/pages/Shell.tsx:5245
+#: src/pages/Shell.tsx:5259
 msgid "Earlier message"
 msgstr ""
 
@@ -1638,7 +1642,7 @@ msgid "Engage when... Ignore..."
 msgstr ""
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
-#: src/pages/ModelSettingsOverlay.tsx:600
+#: src/pages/ModelSettingsOverlay.tsx:604
 #: src/pages/Onboarding.tsx:531
 msgid "Enter this code at <0>{0}</0>"
 msgstr "Digite este código em <0>{0}</0>"
@@ -1687,7 +1691,7 @@ msgid "Expand"
 msgstr "Expandir"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2589
+#: src/pages/Shell.tsx:2599
 msgid "Expand {0}"
 msgstr ""
 
@@ -1716,14 +1720,14 @@ msgstr "falhou"
 msgid "Failed"
 msgstr "Falha"
 
-#: src/pages/Shell.tsx:1981
-#: src/pages/Shell.tsx:1983
-#: src/pages/Shell.tsx:1985
+#: src/pages/Shell.tsx:1991
+#: src/pages/Shell.tsx:1993
+#: src/pages/Shell.tsx:1995
 msgid "Failed to send message"
 msgstr "Ocorreu um erro ao enviar a mensagem"
 
-#: src/pages/Shell.tsx:2018
-#: src/pages/Shell.tsx:2037
+#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2047
 msgid "Failed to stop"
 msgstr "Não foi possível parar"
 
@@ -1736,18 +1740,18 @@ msgstr "Falhou."
 msgid "Failure handling"
 msgstr "Tratamento de falhas"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Find models"
 msgstr "Encontrar modelos"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Finding…"
 msgstr "Localizando…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
-#: src/pages/ModelSettingsOverlay.tsx:560
+#: src/pages/ModelSettingsOverlay.tsx:564
 #: src/pages/Onboarding.tsx:495
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "Conclua o login em <0>{0}</0>. A página final não pode ser carregada; cole seu URL ou código aqui."
@@ -1773,7 +1777,7 @@ msgstr ""
 msgid "Forgot password?"
 msgstr "Esqueceu a senha?"
 
-#: src/pages/ModelSettingsOverlay.tsx:1071
+#: src/pages/ModelSettingsOverlay.tsx:1075
 msgid "Free"
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgstr "Tela Cheia"
 msgid "General"
 msgstr "Geral"
 
-#: src/components/integrations/IntegrationSetup.tsx:209
+#: src/components/integrations/IntegrationSetup.tsx:214
 msgid "Get credentials"
 msgstr ""
 
@@ -1801,8 +1805,8 @@ msgid "Git event"
 msgstr ""
 
 #: src/pages/MessagingSettingsOverlay.tsx:204
-#: src/pages/Shell.tsx:3019
-#: src/pages/Shell.tsx:3156
+#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3166
 msgid "Group"
 msgstr "Grupo"
 
@@ -1844,15 +1848,15 @@ msgstr "Nome do Cabeçalho"
 msgid "Header value"
 msgstr "Valor do cabeçalho"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Hear a sample"
 msgstr "Ouvir uma amostra"
 
-#: src/pages/VoiceSettingsOverlay.tsx:131
+#: src/pages/VoiceSettingsOverlay.tsx:135
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Olá, é assim que vou soar quando ler as respostas em voz alta."
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Hide bots"
 msgstr ""
 
@@ -1881,11 +1885,11 @@ msgstr "Com que frequência"
 msgid "How to check"
 msgstr "Como verificar"
 
-#: src/pages/Shell.tsx:5174
+#: src/pages/Shell.tsx:5188
 msgid "I’m done"
 msgstr "Eu terminei."
 
-#: src/pages/VoiceSettingsOverlay.tsx:136
+#: src/pages/VoiceSettingsOverlay.tsx:140
 msgid "If you heard that, voice is ready."
 msgstr "Se você ouviu isso, a voz está pronta."
 
@@ -1917,12 +1921,12 @@ msgstr "Instrução"
 msgid "Integration domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:133
+#: src/components/integrations/IntegrationSetup.tsx:136
 msgid "Integration options"
 msgstr ""
 
 #: src/pages/PluginsOverlay.tsx:679
-#: src/pages/Shell.tsx:2874
+#: src/pages/Shell.tsx:2884
 msgid "Integrations"
 msgstr "Integrações"
 
@@ -1952,11 +1956,11 @@ msgstr "Isolado"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Suas conversas, arquivos e rotinas serão excluídos permanentemente. Os bots criados ficam na sua lista."
 
-#: src/pages/Shell.tsx:4289
+#: src/pages/Shell.tsx:4303
 msgid "Jump to latest"
 msgstr "Ir para a mensagem mais recente"
 
-#: src/pages/Shell.tsx:5240
+#: src/pages/Shell.tsx:5254
 msgid "Jump to replied message"
 msgstr "Ir para a mensagem respondida"
 
@@ -2014,7 +2018,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "Ouvindo..."
 
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Load earlier messages"
 msgstr "Carregar mensagens anteriores..."
 
@@ -2026,12 +2030,12 @@ msgstr "Carregando minha atividade"
 msgid "Loading integrations…"
 msgstr "Carregando integrações…"
 
-#: src/pages/MemorySettingsOverlay.tsx:182
+#: src/pages/MemorySettingsOverlay.tsx:186
 msgid "Loading memory settings…"
 msgstr "Carregando configurações de memória..."
 
-#: src/pages/ModelSettingsOverlay.tsx:306
-#: src/pages/ModelSettingsOverlay.tsx:733
+#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:737
 msgid "Loading model catalog…"
 msgstr "Carregando catálogo de modelos..."
 
@@ -2047,15 +2051,15 @@ msgstr "Carregando regras…"
 msgid "Loading tools…"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:210
+#: src/pages/VoiceSettingsOverlay.tsx:214
 msgid "Loading voice providers…"
 msgstr "Carregando provedores de voz..."
 
-#: src/App.tsx:58
+#: src/App.tsx:65
 #: src/pages/IntegrationSetup.tsx:72
 #: src/pages/Onboarding.tsx:282
 #: src/pages/PeerMessagesOverlay.tsx:98
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Loading…"
 msgstr "Carregando..."
 
@@ -2067,7 +2071,11 @@ msgstr "Local"
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "O acesso local permite que os bots executem comandos sem perguntar. Evite usá-lo em servidores compartilhados ou públicos."
 
-#: src/pages/Shell.tsx:2932
+#: src/pages/LocalSettings.tsx:22
+msgid "Local Server Settings"
+msgstr ""
+
+#: src/pages/Shell.tsx:2942
 msgid "Log out"
 msgstr "Sair"
 
@@ -2083,8 +2091,8 @@ msgstr "Gerenciar servidores MCP"
 msgid "Manage messaging settings"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:159
-#: src/pages/MemorySettingsOverlay.tsx:173
+#: src/pages/MemorySettingsOverlay.tsx:163
+#: src/pages/MemorySettingsOverlay.tsx:177
 msgid "Manage the Space semantic memory provider."
 msgstr "Gerencie o provedor de memória semântica do espaço de trabalho."
 
@@ -2125,7 +2133,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Membros (escolha {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/KnowledgeSection.tsx:39
-#: src/pages/MemorySettingsOverlay.tsx:155
+#: src/pages/MemorySettingsOverlay.tsx:159
 #: src/pages/SettingsOverlay.tsx:94
 msgid "Memory"
 msgstr "Memória"
@@ -2134,7 +2142,7 @@ msgstr "Memória"
 msgid "Memory scope"
 msgstr "Escopo de memória"
 
-#: src/pages/Shell.tsx:4697
+#: src/pages/Shell.tsx:4711
 msgid "Mentions"
 msgstr ""
 
@@ -2142,8 +2150,8 @@ msgstr ""
 msgid "Mentions only"
 msgstr ""
 
-#: src/pages/Shell.tsx:4898
-#: src/pages/Shell.tsx:5025
+#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:5039
 msgid "Message"
 msgstr "Mensagem"
 
@@ -2152,12 +2160,12 @@ msgstr "Mensagem"
 msgid "Message"
 msgstr "Mensagem"
 
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4898
+#: src/pages/Shell.tsx:4908
+#: src/pages/Shell.tsx:4912
 msgid "Message {activeName}"
 msgstr "Mensagem {activeName}"
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4623
 msgid "Message composer"
 msgstr ""
 
@@ -2166,15 +2174,15 @@ msgstr ""
 msgid "Message event"
 msgstr ""
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Message from {peer}"
 msgstr "Mensagem de {peer}"
 
-#: src/pages/Shell.tsx:4895
+#: src/pages/Shell.tsx:4909
 msgid "Message…"
 msgstr "Mensagem…"
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Messaged {peer}"
 msgstr "Enviou mensagem para {peer}"
 
@@ -2195,8 +2203,8 @@ msgstr "Mínimo"
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: src/pages/Shell.tsx:2461
-#: src/pages/Shell.tsx:2462
+#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2472
 msgid "Minimize bots"
 msgstr ""
 
@@ -2208,9 +2216,9 @@ msgstr "minuto"
 msgid "minutes"
 msgstr "minutos"
 
-#: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/ModelSettingsOverlay.tsx:509
-#: src/pages/ModelSettingsOverlay.tsx:959
+#: src/pages/ModelSettingsOverlay.tsx:448
+#: src/pages/ModelSettingsOverlay.tsx:513
+#: src/pages/ModelSettingsOverlay.tsx:963
 #: src/pages/Onboarding.tsx:420
 #: src/pages/Onboarding.tsx:468
 #: src/pages/Onboarding.tsx:476
@@ -2218,12 +2226,12 @@ msgstr "minutos"
 msgid "Model"
 msgstr "Modelo"
 
-#: src/pages/ModelSettingsOverlay.tsx:478
+#: src/pages/ModelSettingsOverlay.tsx:482
 #: src/pages/Onboarding.tsx:442
 msgid "Model id"
 msgstr "ID do modelo"
 
-#: src/pages/ModelSettingsOverlay.tsx:995
+#: src/pages/ModelSettingsOverlay.tsx:999
 msgid "Model options"
 msgstr "Opções do modelo"
 
@@ -2235,16 +2243,21 @@ msgstr ""
 msgid "Model spend uses your provider keys."
 msgstr "O modelo de gasto usa suas chaves de provedor."
 
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Model updated."
 msgstr "Modelo Atualizado"
 
-#: src/pages/ModelSettingsOverlay.tsx:317
+#: src/pages/LocalSettings.tsx:36
+#: src/pages/ModelSettingsOverlay.tsx:321
 #: src/pages/SettingsOverlay.tsx:93
 msgid "Models"
 msgstr "Modelos"
 
-#: src/pages/ModelSettingsOverlay.tsx:457
+#: src/pages/ModelSettingsOverlay.tsx:310
+msgid "Models for the server owner’s default space."
+msgstr ""
+
+#: src/pages/ModelSettingsOverlay.tsx:461
 #: src/pages/Onboarding.tsx:426
 msgid "Models from server"
 msgstr "Modelos do servidor"
@@ -2253,7 +2266,7 @@ msgstr "Modelos do servidor"
 msgid "Monthly"
 msgstr "Mensalmente"
 
-#: src/pages/Shell.tsx:5082
+#: src/pages/Shell.tsx:5096
 msgid "More"
 msgstr ""
 
@@ -2303,7 +2316,7 @@ msgstr "Precisa de entrada"
 msgid "Needs takeover"
 msgstr "Requer assumir o controle"
 
-#: src/pages/Shell.tsx:3897
+#: src/pages/Shell.tsx:3911
 msgid "Needs you"
 msgstr ""
 
@@ -2381,7 +2394,7 @@ msgstr "Não está mais ativo"
 msgid "No managed app catalog is configured on this deployment."
 msgstr "Nenhum catálogo de aplicativos gerenciados está configurado nesta implantação."
 
-#: src/pages/ModelSettingsOverlay.tsx:1023
+#: src/pages/ModelSettingsOverlay.tsx:1027
 msgid "No matching models"
 msgstr ""
 
@@ -2397,7 +2410,7 @@ msgstr "Ainda não há servidores MCP."
 msgid "No messages with {peerBotName} yet."
 msgstr "Ainda sem mensagens com {peerBotName}."
 
-#: src/pages/ModelSettingsOverlay.tsx:737
+#: src/pages/ModelSettingsOverlay.tsx:741
 msgid "No model catalog is available."
 msgstr "Nenhum catálogo de modelos está disponível."
 
@@ -2405,11 +2418,11 @@ msgstr "Nenhum catálogo de modelos está disponível."
 msgid "No providers found"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:397
+#: src/pages/ModelSettingsOverlay.tsx:401
 msgid "No providers found."
 msgstr "Nenhum provedor encontrado"
 
-#: src/components/integrations/IntegrationSetup.tsx:264
+#: src/components/integrations/IntegrationSetup.tsx:273
 msgid "No remote MCP servers found"
 msgstr ""
 
@@ -2442,7 +2455,7 @@ msgstr ""
 msgid "None yet"
 msgstr "Nenhuma ainda"
 
-#: src/pages/ModelSettingsOverlay.tsx:540
+#: src/pages/ModelSettingsOverlay.tsx:544
 msgid "Not connected"
 msgstr "Não Conectado"
 
@@ -2463,7 +2476,7 @@ msgid "Now"
 msgstr "Agora"
 
 #. placeholder {0}: selected.label
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Now using {0}."
 msgstr "Agora usando {0}."
 
@@ -2496,26 +2509,26 @@ msgstr "no dia 1º às {0}"
 msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
 msgstr ""
 
-#: src/pages/Shell.tsx:3671
+#: src/pages/Shell.tsx:3681
 msgid "Only empty spaces can be deleted. Delete its bots and groups first."
 msgstr ""
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3234
-#: src/pages/Shell.tsx:3239
+#: src/pages/Shell.tsx:3244
+#: src/pages/Shell.tsx:3249
 msgid "Open"
 msgstr "Abrir"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2597
 msgid "Open {0}"
 msgstr ""
 
-#: src/pages/Shell.tsx:3202
+#: src/pages/Shell.tsx:3212
 msgid "Open in full window"
 msgstr "Abrir em janela cheia"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3001
 msgid "Open navigation"
 msgstr "Abrir a navegação"
 
@@ -2523,20 +2536,20 @@ msgstr "Abrir a navegação"
 msgid "Open work"
 msgstr "Trabalho aberto"
 
-#: src/pages/ModelSettingsOverlay.tsx:417
+#: src/pages/ModelSettingsOverlay.tsx:421
 #: src/pages/Onboarding.tsx:395
 msgid "OpenAI-compatible server URL"
 msgstr "URL do servidor compatível com OpenAI"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5444
 msgid "Opened its thread."
 msgstr "Abriu a conversa."
 
-#: src/App.tsx:195
+#: src/App.tsx:202
 msgid "Opening your Space…"
 msgstr "Abrindo seu espaço de trabalho..."
 
-#: src/pages/ModelSettingsOverlay.tsx:650
+#: src/pages/ModelSettingsOverlay.tsx:654
 #: src/pages/Onboarding.tsx:569
 msgid "Optional"
 msgstr "Opcional"
@@ -2549,7 +2562,7 @@ msgstr "Controles opcionais que a maioria das pessoas nunca precisa"
 msgid "Optional header value"
 msgstr "Valor de cabeçalho opcional"
 
-#: src/pages/ModelSettingsOverlay.tsx:664
+#: src/pages/ModelSettingsOverlay.tsx:668
 msgid "Or connect an API key"
 msgstr "Ou conecte uma chave de API"
 
@@ -2565,7 +2578,7 @@ msgstr ""
 msgid "Organization API key"
 msgstr "Chave da API da organização"
 
-#: src/pages/ModelSettingsOverlay.tsx:465
+#: src/pages/ModelSettingsOverlay.tsx:469
 #: src/pages/Onboarding.tsx:435
 msgid "Other model…"
 msgstr "Outro modelo..."
@@ -2600,16 +2613,16 @@ msgstr "Senha atualizada"
 msgid "Passwords do not match"
 msgstr "As senhas não coincidem"
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste a replacement key"
 msgstr "Cole uma chave de substituição"
 
-#: src/pages/ModelSettingsOverlay.tsx:428
+#: src/pages/ModelSettingsOverlay.tsx:432
 #: src/pages/Onboarding.tsx:406
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "Cole o endereço compatível com OpenAI do seu servidor. Rakazo adiciona /v1 se necessário."
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste your API key"
 msgstr "Cole sua chave API"
 
@@ -2617,7 +2630,7 @@ msgstr "Cole sua chave API"
 msgid "Paused"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:534
+#: src/pages/ModelSettingsOverlay.tsx:538
 msgid "Personal credential"
 msgstr "Senha Pessoal"
 
@@ -2625,7 +2638,7 @@ msgstr "Senha Pessoal"
 msgid "Pin"
 msgstr "Fixar"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Playing…"
 msgstr "Reproduzindo"
 
@@ -2642,17 +2655,17 @@ msgstr "Pré-visualizar {0}"
 msgid "Private"
 msgstr "Privado"
 
-#: src/components/integrations/IntegrationSetup.tsx:177
+#: src/components/integrations/IntegrationSetup.tsx:182
 msgid "Project ID"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:215
+#: src/pages/MemorySettingsOverlay.tsx:219
 #: src/pages/Onboarding.tsx:292
 msgid "Provider"
 msgstr "Provedor"
 
-#: src/pages/ModelSettingsOverlay.tsx:352
-#: src/pages/VoiceSettingsOverlay.tsx:166
+#: src/pages/ModelSettingsOverlay.tsx:356
+#: src/pages/VoiceSettingsOverlay.tsx:170
 msgid "Providers"
 msgstr "Provedores"
 
@@ -2684,7 +2697,7 @@ msgstr "Recente"
 msgid "Reconnect OAuth"
 msgstr "Reconectar OAuth"
 
-#: src/App.tsx:150
+#: src/App.tsx:157
 #: src/components/ComputerUpdateProgress.tsx:54
 msgid "Reconnecting"
 msgstr "Reconectando"
@@ -2747,7 +2760,7 @@ msgstr ""
 msgid "Refreshing…"
 msgstr ""
 
-#: src/pages/Shell.tsx:5164
+#: src/pages/Shell.tsx:5178
 msgid "Release"
 msgstr "Libere"
 
@@ -2767,7 +2780,7 @@ msgid "Remove"
 msgstr "Remover"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4683
+#: src/pages/Shell.tsx:4697
 msgid "Remove {0}"
 msgstr "Remover {0}"
 
@@ -2776,7 +2789,7 @@ msgid "Remove Git event"
 msgstr ""
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4845
 msgid "Remove mention {0}"
 msgstr "Remover menção {0}"
 
@@ -2789,13 +2802,13 @@ msgid "Remove schedule"
 msgstr ""
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4824
 msgid "Remove skill {0}"
 msgstr "Remover habilidade {0}"
 
-#: src/pages/Shell.tsx:4262
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:4276
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Remove thumbs-up"
 msgstr ""
 
@@ -2803,7 +2816,7 @@ msgstr ""
 msgid "Remove webhook"
 msgstr ""
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5443
 msgid "Removed with chat, computer, and memory."
 msgstr "Removido com chat, computador e memória."
 
@@ -2822,21 +2835,21 @@ msgstr "Removendo…"
 msgid "Reopen"
 msgstr "Reabrir"
 
-#: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/ModelSettingsOverlay.tsx:695
+#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:699
 msgid "Replace API key"
 msgstr "Substituir chave de API"
 
-#: src/pages/VoiceSettingsOverlay.tsx:239
+#: src/pages/VoiceSettingsOverlay.tsx:243
 msgid "Replace key"
 msgstr "Substituir chave"
 
-#: src/pages/Shell.tsx:5074
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5088
+#: src/pages/Shell.tsx:5119
 msgid "Reply"
 msgstr "Responder"
 
-#: src/pages/Shell.tsx:4646
+#: src/pages/Shell.tsx:4660
 msgid "Replying to {replyName}"
 msgstr "Respondendo a {replyName}"
 
@@ -2870,8 +2883,8 @@ msgstr "Redefinindo…"
 msgid "Restart to update"
 msgstr ""
 
-#: src/pages/Shell.tsx:2816
-#: src/pages/Shell.tsx:2847
+#: src/pages/Shell.tsx:2826
+#: src/pages/Shell.tsx:2857
 msgid "Restore"
 msgstr "Restaurar"
 
@@ -2883,12 +2896,12 @@ msgstr "Restaure o último espaço de trabalho salvo. O trabalho não salvo no c
 msgid "Restoring your workspace"
 msgstr ""
 
-#: src/App.tsx:164
+#: src/App.tsx:171
 #: src/pages/PeerMessagesOverlay.tsx:109
 msgid "Retry now"
 msgstr "Nova tentativa agora"
 
-#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2398
 msgid "Retry screen"
 msgstr ""
 
@@ -2918,8 +2931,8 @@ msgid "Rotate key"
 msgstr ""
 
 #: src/pages/RoutineEditor.tsx:265
-#: src/pages/Shell.tsx:3419
-#: src/pages/Shell.tsx:3431
+#: src/pages/Shell.tsx:3429
+#: src/pages/Shell.tsx:3441
 msgid "Routine"
 msgstr "Rotina"
 
@@ -2936,7 +2949,7 @@ msgstr ""
 msgid "Run history"
 msgstr ""
 
-#: src/pages/Shell.tsx:3412
+#: src/pages/Shell.tsx:3422
 msgid "Run time must be in the future."
 msgstr ""
 
@@ -2966,7 +2979,7 @@ msgstr ""
 #: src/pages/GroupPanel.tsx:236
 #: src/pages/KnowledgeSection.tsx:203
 #: src/pages/KnowledgeSection.tsx:422
-#: src/pages/ModelSettingsOverlay.tsx:693
+#: src/pages/ModelSettingsOverlay.tsx:697
 #: src/pages/RoutineEditor.tsx:489
 #: src/pages/shell/bot-panel.tsx:539
 msgid "Save"
@@ -2983,7 +2996,7 @@ msgstr "Salva"
 msgid "Saved, but list refresh failed"
 msgstr "Salvo, mas a atualização da lista falhou"
 
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Saved."
 msgstr "Salvo."
 
@@ -3002,7 +3015,7 @@ msgstr ""
 #: src/components/AskCard.tsx:157
 #: src/components/teach/SkillDraftCard.tsx:142
 #: src/pages/GroupPanel.tsx:236
-#: src/pages/ModelSettingsOverlay.tsx:691
+#: src/pages/ModelSettingsOverlay.tsx:695
 #: src/pages/RoutineEditor.tsx:489
 msgid "Saving…"
 msgstr "Salvando..."
@@ -3016,15 +3029,15 @@ msgstr "Diga alguma coisa. O silêncio manda."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "Diga sim ou não, ou responda em uma frase."
 
-#: src/pages/ModelSettingsOverlay.tsx:984
+#: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
-#: src/pages/Shell.tsx:2530
+#: src/pages/Shell.tsx:2540
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "Pesquisar"
 
-#: src/components/integrations/IntegrationSetup.tsx:241
-#: src/components/integrations/IntegrationSetup.tsx:242
+#: src/components/integrations/IntegrationSetup.tsx:250
+#: src/components/integrations/IntegrationSetup.tsx:251
 #: src/pages/PluginsOverlay.tsx:696
 #: src/pages/PluginsOverlay.tsx:697
 msgid "Search apps"
@@ -3038,11 +3051,11 @@ msgstr ""
 msgid "Search by domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:247
+#: src/components/integrations/IntegrationSetup.tsx:256
 msgid "Search integrations.sh"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:979
+#: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr ""
 
@@ -3051,8 +3064,8 @@ msgstr ""
 msgid "Search or create Bots"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:355
-#: src/pages/ModelSettingsOverlay.tsx:361
+#: src/pages/ModelSettingsOverlay.tsx:359
+#: src/pages/ModelSettingsOverlay.tsx:365
 msgid "Search providers"
 msgstr "Pesquisar provedores"
 
@@ -3066,7 +3079,7 @@ msgstr "Pesquisar fornecedores e modelos"
 msgid "Searching…"
 msgstr "Pesquisando…"
 
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3030
 msgid "Select a bot"
 msgstr "Selecione um bot"
 
@@ -3074,8 +3087,8 @@ msgstr "Selecione um bot"
 msgid "Selected"
 msgstr ""
 
-#: src/pages/Shell.tsx:4929
-#: src/pages/Shell.tsx:4950
+#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4964
 msgid "Send"
 msgstr "Enviar"
 
@@ -3105,8 +3118,9 @@ msgstr "Enviando…"
 msgid "Sentry alert"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/AccountSettingsOverlay.tsx:158
+#: src/pages/LocalSettings.tsx:42
 msgid "Server integrations"
 msgstr ""
 
@@ -3114,33 +3128,33 @@ msgstr ""
 msgid "Server name"
 msgstr "Nome do servidor"
 
-#: src/components/integrations/IntegrationSetup.tsx:273
-#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:282
+#: src/components/integrations/IntegrationSetup.tsx:300
 #: src/pages/McpServersOverlay.tsx:329
-#: src/pages/ModelSettingsOverlay.tsx:412
+#: src/pages/ModelSettingsOverlay.tsx:416
 #: src/pages/Onboarding.tsx:390
 msgid "Server URL"
 msgstr "URL do servidor"
 
 #: src/pages/MessagingSettingsOverlay.tsx:361
 #: src/pages/SettingsOverlay.tsx:103
-#: src/pages/SettingsOverlay.tsx:151
-#: src/pages/Shell.tsx:2896
-#: src/pages/Shell.tsx:2903
-#: src/pages/Shell.tsx:3152
+#: src/pages/SettingsOverlay.tsx:158
+#: src/pages/Shell.tsx:2906
+#: src/pages/Shell.tsx:2913
+#: src/pages/Shell.tsx:3162
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4982
 msgid "Settings: General"
 msgstr "Opções > Geral"
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4984
 msgid "Settings: Usage"
 msgstr "Configurações: Uso"
 
-#: src/components/integrations/IntegrationSetup.tsx:319
-#: src/pages/ModelSettingsOverlay.tsx:425
+#: src/components/integrations/IntegrationSetup.tsx:328
+#: src/pages/ModelSettingsOverlay.tsx:429
 #: src/pages/Onboarding.tsx:403
 msgid "Setup help"
 msgstr "Ajuda"
@@ -3158,11 +3172,11 @@ msgstr "Documentos compartilhados"
 msgid "Show all providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Show bots"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show computer"
 msgstr "Mostrar computador"
 
@@ -3178,14 +3192,14 @@ msgstr ""
 msgid "Show popular providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show settings"
 msgstr "Mostrar configurações"
 
 #: src/lib/localized-provider-hint.ts:7
 #: src/pages/Auth.tsx:230
 #: src/pages/Auth.tsx:288
-#: src/pages/ModelSettingsOverlay.tsx:632
+#: src/pages/ModelSettingsOverlay.tsx:636
 #: src/pages/Onboarding.tsx:152
 msgid "Sign in"
 msgstr "Entrar"
@@ -3200,7 +3214,7 @@ msgid "Sign up"
 msgstr "Cadastre-se"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4758
 msgid "Skill {0}"
 msgstr "Habilidade {0}"
 
@@ -3208,8 +3222,8 @@ msgstr "Habilidade {0}"
 msgid "Skills"
 msgstr "Habilidades"
 
-#: src/components/integrations/IntegrationSetup.tsx:355
-#: src/pages/Shell.tsx:5171
+#: src/components/integrations/IntegrationSetup.tsx:364
+#: src/pages/Shell.tsx:5185
 msgid "Skip"
 msgstr "Pular"
 
@@ -3218,7 +3232,7 @@ msgid "Skip or deploy key"
 msgstr "Ignorar ou implantar chave"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1842
+#: src/pages/Shell.tsx:1852
 msgid "Skipped {0}"
 msgstr "{0} ignorado"
 
@@ -3250,21 +3264,21 @@ msgstr "Interrupções de espaço · Esc desliga"
 msgid "Spaces"
 msgstr ""
 
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Speak"
 msgstr "Falar"
 
-#: src/pages/VoiceSettingsOverlay.tsx:190
+#: src/pages/VoiceSettingsOverlay.tsx:194
 msgid "Speak + transcribe"
 msgstr "Falar + transcrever"
 
-#: src/pages/VoiceSettingsOverlay.tsx:192
+#: src/pages/VoiceSettingsOverlay.tsx:196
 msgid "Speak only"
 msgstr "Falar apenas"
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Speak this reply"
 msgstr "Fale esta resposta"
 
@@ -3281,7 +3295,7 @@ msgid "Starting"
 msgstr "Iniciando"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
-#: src/pages/ModelSettingsOverlay.tsx:630
+#: src/pages/ModelSettingsOverlay.tsx:634
 #: src/pages/Onboarding.tsx:554
 msgid "Starting…"
 msgstr "Iniciando…"
@@ -3290,11 +3304,11 @@ msgstr "Iniciando…"
 msgid "Steps"
 msgstr "Passos"
 
-#: src/pages/Shell.tsx:3912
-#: src/pages/Shell.tsx:3917
-#: src/pages/Shell.tsx:4939
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:3926
+#: src/pages/Shell.tsx:3931
+#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Stop"
 msgstr "Parar"
 
@@ -3302,8 +3316,8 @@ msgstr "Parar"
 msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
 msgstr ""
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Stop speaking"
 msgstr "Pare de Falar"
 
@@ -3321,20 +3335,20 @@ msgstr "Interrompido."
 msgid "Stored encrypted"
 msgstr "Armazenado criptografado"
 
-#: src/pages/ModelSettingsOverlay.tsx:545
+#: src/pages/ModelSettingsOverlay.tsx:549
 msgid "Stored securely. Never shown here."
 msgstr "Armazenado com segurança. Nunca mostrado aqui."
 
-#: src/pages/Shell.tsx:5383
+#: src/pages/Shell.tsx:5397
 msgid "subagent"
 msgstr "subagente"
 
-#: src/pages/ModelSettingsOverlay.tsx:590
+#: src/pages/ModelSettingsOverlay.tsx:594
 #: src/pages/Onboarding.tsx:521
 msgid "Submit"
 msgstr "Enviar"
 
-#: src/pages/ModelSettingsOverlay.tsx:503
+#: src/pages/ModelSettingsOverlay.tsx:507
 #: src/pages/Onboarding.tsx:462
 msgid "Supports thinking"
 msgstr "Suporta raciocínio"
@@ -3343,7 +3357,7 @@ msgstr "Suporta raciocínio"
 msgid "Switch bot"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:723
+#: src/pages/ModelSettingsOverlay.tsx:727
 msgid "Switching…"
 msgstr "Alternando…"
 
@@ -3356,7 +3370,7 @@ msgstr "Sistema"
 msgid "Teach a task"
 msgstr "Ensinar uma tarefa"
 
-#: src/pages/Shell.tsx:3076
+#: src/pages/Shell.tsx:3086
 msgid "Teaching in progress. Stop teaching before sending a new message."
 msgstr "Ensino em andamento. Pare de ensinar antes de enviar uma nova mensagem."
 
@@ -3364,7 +3378,7 @@ msgstr "Ensino em andamento. Pare de ensinar antes de enviar uma nova mensagem."
 msgid "Team"
 msgstr "Equipe"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "Team Computer"
 msgstr "Computador da equipe"
 
@@ -3394,7 +3408,7 @@ msgstr ""
 msgid "The API did not come back. Refresh this page."
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:241
+#: src/pages/MemorySettingsOverlay.tsx:245
 msgid "The selected memory provider is not available in this build."
 msgstr "O provedor de memória selecionado não está disponível nesta compilação."
 
@@ -3402,7 +3416,7 @@ msgstr "O provedor de memória selecionado não está disponível nesta compila�
 msgid "Thinking"
 msgstr "Pensando"
 
-#: src/pages/Shell.tsx:5632
+#: src/pages/Shell.tsx:5646
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Este bot é executado neste computador, não em um desktop Linux. Shell e arquivos usam sua pasta inicial."
 
@@ -3455,7 +3469,7 @@ msgstr "Este servidor já está conectado. Desconecte-o primeiro para autorizar 
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools. A popup will open."
 msgstr "Este servidor usa o login do navegador. Autorize-o a permitir que seus agentes usem suas ferramentas. Um pop-up será aberto."
 
-#: src/pages/ModelSettingsOverlay.tsx:705
+#: src/pages/ModelSettingsOverlay.tsx:709
 msgid "This subscription sign-in is not available in Rakazo yet. Use a deployment credential or choose another provider."
 msgstr "Este login de assinatura ainda não está disponível no Rakazo. Use uma credencial de implantação ou escolha outro provedor."
 
@@ -3514,7 +3528,7 @@ msgid "Unpin"
 msgstr "Desafixar"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1920
+#: src/pages/Shell.tsx:1930
 msgid "Unsupported file type: {0}"
 msgstr "Tipo de arquivo não suportado: {0}"
 
@@ -3574,8 +3588,8 @@ msgstr "Atualizando…"
 
 #: src/pages/AccountSettingsOverlay.tsx:199
 #: src/pages/SettingsOverlay.tsx:96
-#: src/pages/Shell.tsx:2908
-#: src/pages/Shell.tsx:2919
+#: src/pages/Shell.tsx:2918
+#: src/pages/Shell.tsx:2929
 msgid "Usage"
 msgstr "Uso"
 
@@ -3583,7 +3597,7 @@ msgstr "Uso"
 msgid "Use {hostLabel}"
 msgstr "Usar {hostLabel}"
 
-#: src/pages/ModelSettingsOverlay.tsx:490
+#: src/pages/ModelSettingsOverlay.tsx:494
 #: src/pages/Onboarding.tsx:454
 msgid "Use a found model"
 msgstr "Usar um modelo encontrado"
@@ -3593,7 +3607,7 @@ msgstr "Usar um modelo encontrado"
 msgid "Use default guidance"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:725
+#: src/pages/ModelSettingsOverlay.tsx:729
 msgid "Use this model"
 msgstr "Use este modelo"
 
@@ -3606,16 +3620,16 @@ msgid "Verifying…"
 msgstr "Verificando…"
 
 #: src/pages/SettingsOverlay.tsx:95
-#: src/pages/Shell.tsx:4916
-#: src/pages/Shell.tsx:4917
+#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:4931
 #: src/pages/shell/bot-panel.tsx:482
-#: src/pages/VoiceSettingsOverlay.tsx:150
-#: src/pages/VoiceSettingsOverlay.tsx:249
+#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Voice"
 msgstr "Voz"
 
-#: src/pages/ModelSettingsOverlay.tsx:594
-#: src/pages/ModelSettingsOverlay.tsx:616
+#: src/pages/ModelSettingsOverlay.tsx:598
+#: src/pages/ModelSettingsOverlay.tsx:620
 #: src/pages/Onboarding.tsx:525
 #: src/pages/Onboarding.tsx:547
 msgid "Waiting for sign-in…"
@@ -3687,8 +3701,8 @@ msgstr ""
 msgid "Working…"
 msgstr "Funcionando"
 
-#: src/pages/Shell.tsx:1616
-#: src/pages/Shell.tsx:2393
+#: src/pages/Shell.tsx:1626
+#: src/pages/Shell.tsx:2403
 msgid "You"
 msgstr "Você"
 
@@ -3700,7 +3714,7 @@ msgstr "Você pode fechar esta guia se ela não for redirecionada automaticament
 msgid "You can close this window."
 msgstr "Você pode fechar esta janela."
 
-#: src/pages/Shell.tsx:3901
+#: src/pages/Shell.tsx:3915
 msgid "You have control"
 msgstr "Você tem o controle"
 

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -13,22 +13,22 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2720
+#: src/pages/Shell.tsx:2730
 msgid " (unread)"
 msgstr " (okunmadı)"
 
 #. placeholder {0}: group.entries.length
-#: src/pages/ModelSettingsOverlay.tsx:382
+#: src/pages/ModelSettingsOverlay.tsx:386
 msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# model} other {# model}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1822
+#: src/pages/Shell.tsx:1832
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (en fazla {ATTACHMENT_MAX_COUNT} ek)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1826
+#: src/pages/Shell.tsx:1836
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB üzeri)"
 
@@ -80,11 +80,11 @@ msgid "{0} will still respond to direct mentions."
 msgstr ""
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3245
+#: src/pages/Shell.tsx:3255
 msgid "{0}'s screen"
 msgstr ""
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "{botName}’s computer"
 msgstr "{botName} adlı botun bilgisayarı"
 
@@ -132,12 +132,12 @@ msgstr "{title}, {label}"
 msgid "{toolCount, plural, one {# tool} other {# tools}}"
 msgstr ""
 
-#: src/pages/Shell.tsx:4072
+#: src/pages/Shell.tsx:4086
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} çalışıyor"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4711
+#: src/pages/Shell.tsx:4725
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "About spaces"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:301
+#: src/components/integrations/IntegrationSetup.tsx:310
 msgid "Access token"
 msgstr ""
 
@@ -188,7 +188,7 @@ msgstr "İşlem onayları"
 msgid "Actions for {0}"
 msgstr "{0} için işlemler"
 
-#: src/pages/Shell.tsx:3619
+#: src/pages/Shell.tsx:3629
 msgid "Actions for space"
 msgstr ""
 
@@ -196,12 +196,12 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:337
+#: src/pages/ModelSettingsOverlay.tsx:341
 msgid "Active model"
 msgstr "Etkin model"
 
-#: src/pages/Shell.tsx:2440
-#: src/pages/Shell.tsx:2442
+#: src/pages/Shell.tsx:2450
+#: src/pages/Shell.tsx:2452
 msgid "Activity"
 msgstr "Etkinlik"
 
@@ -215,11 +215,11 @@ msgstr "Ekle"
 msgid "Add a model in Settings to use this."
 msgstr ""
 
-#: src/pages/Shell.tsx:3407
+#: src/pages/Shell.tsx:3417
 msgid "Add a run time for this one-shot."
 msgstr ""
 
-#: src/pages/Shell.tsx:3385
+#: src/pages/Shell.tsx:3395
 msgid "Add a schedule, webhook, GitHub, or message trigger"
 msgstr ""
 
@@ -259,7 +259,7 @@ msgstr "GraphQL uç noktası ekle"
 msgid "Add item"
 msgstr "Öğe ekle"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/PluginsOverlay.tsx:951
 msgid "Add MCP server"
 msgstr "MCP sunucusu ekle"
@@ -277,12 +277,12 @@ msgstr "Uzak MCP sunucusu ekle"
 msgid "Add server"
 msgstr "Sunucu ekle"
 
-#: src/components/integrations/IntegrationSetup.tsx:269
+#: src/components/integrations/IntegrationSetup.tsx:278
 msgid "Add server URL"
 msgstr ""
 
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Add thumbs-up"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr "Ekleniyor…"
 
 #: src/pages/AccountSettingsOverlay.tsx:166
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/ModelSettingsOverlay.tsx:502
+#: src/pages/ModelSettingsOverlay.tsx:506
 #: src/pages/Onboarding.tsx:461
 #: src/pages/PluginsOverlay.tsx:836
 #: src/pages/RoutineSchedule.tsx:43
@@ -323,7 +323,7 @@ msgstr "Gelişmiş"
 msgid "Advanced..."
 msgstr ""
 
-#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3039
 msgid "Agent computer"
 msgstr "Agent bilgisayarı"
 
@@ -405,15 +405,15 @@ msgid "API is back, but the update did not finish. Check the host logs."
 msgstr ""
 
 #: src/components/AskCard.tsx:44
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 #: src/lib/localized-provider-hint.ts:9
-#: src/pages/ModelSettingsOverlay.tsx:644
-#: src/pages/ModelSettingsOverlay.tsx:647
-#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:648
+#: src/pages/ModelSettingsOverlay.tsx:651
+#: src/pages/ModelSettingsOverlay.tsx:670
 #: src/pages/Onboarding.tsx:563
 #: src/pages/Onboarding.tsx:566
 #: src/pages/Onboarding.tsx:580
-#: src/pages/VoiceSettingsOverlay.tsx:219
+#: src/pages/VoiceSettingsOverlay.tsx:223
 msgid "API key"
 msgstr "API anahtarı"
 
@@ -444,15 +444,15 @@ msgstr "Agent'ının bu sunucunun araçlarını kullanabilmesi için sunucuyu on
 msgid "Archive"
 msgstr "Arşivle"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5431
 msgid "archived"
 msgstr "arşivlendi"
 
-#: src/pages/Shell.tsx:2789
+#: src/pages/Shell.tsx:2799
 msgid "Archived"
 msgstr "Arşivlendi"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5442
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Arşivlendi. Sohbet, hafıza ve dosyalar korundu."
 
@@ -491,7 +491,7 @@ msgstr "Satın almadan önce sor"
 msgid "Ask before sending external email"
 msgstr "Dışarıya e-posta göndermeden önce sor"
 
-#: src/components/integrations/IntegrationSetup.tsx:219
+#: src/components/integrations/IntegrationSetup.tsx:228
 msgid "Ask the server owner to configure this provider."
 msgstr ""
 
@@ -506,15 +506,15 @@ msgstr "saat {0}"
 msgid "at {timeSelect}"
 msgstr "saat {timeSelect}"
 
-#: src/pages/Shell.tsx:4791
+#: src/pages/Shell.tsx:4805
 msgid "Attach file"
 msgstr "Dosya ekle"
 
-#: src/pages/Shell.tsx:5023
+#: src/pages/Shell.tsx:5037
 msgid "Attachment"
 msgstr "Ek"
 
-#: src/pages/ModelSettingsOverlay.tsx:577
+#: src/pages/ModelSettingsOverlay.tsx:581
 #: src/pages/Onboarding.tsx:512
 msgid "Authorization code or callback URL"
 msgstr "Yetkilendirme kodu veya callback URL'si"
@@ -567,23 +567,23 @@ msgstr "Temel URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5644
+#: src/pages/Shell.tsx:5658
 msgid "Booting live desktop…"
 msgstr "Canlı masaüstü başlatılıyor…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3877
 msgid "Booting up {0}’s computer"
 msgstr "{0} adlı botun bilgisayarı başlatılıyor"
 
-#: src/pages/Shell.tsx:5292
-#: src/pages/Shell.tsx:5293
-#: src/pages/Shell.tsx:5421
+#: src/pages/Shell.tsx:5306
+#: src/pages/Shell.tsx:5307
+#: src/pages/Shell.tsx:5435
 msgid "bot"
 msgstr "bot"
 
 #: src/pages/IntegrationSetup.tsx:51
-#: src/pages/Shell.tsx:1617
+#: src/pages/Shell.tsx:1627
 msgid "Bot"
 msgstr "Bot"
 
@@ -592,11 +592,11 @@ msgstr "Bot"
 msgid "Bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:3971
+#: src/pages/Shell.tsx:3985
 msgid "Bot screen"
 msgstr "Bot ekranı"
 
-#: src/pages/Shell.tsx:3208
+#: src/pages/Shell.tsx:3218
 msgid "Bot screen preview"
 msgstr "Bot ekranı önizlemesi"
 
@@ -608,7 +608,7 @@ msgstr ""
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first."
 msgstr "Botlar varsayılan olarak sormadan hareket eder. Yalnızca belirli bir işlem türünü önce incelemek istediğinde istisna ekle."
 
-#: src/pages/Shell.tsx:4073
+#: src/pages/Shell.tsx:4087
 msgid "Bots are working"
 msgstr "Botlar çalışıyor"
 
@@ -620,7 +620,7 @@ msgstr ""
 msgid "Call"
 msgstr "Ara"
 
-#: src/App.tsx:152
+#: src/App.tsx:159
 msgid "Can't reach the server."
 msgstr "Sunucuya ulaşılamıyor."
 
@@ -648,7 +648,7 @@ msgstr "Yeni botu iptal et"
 msgid "Cancel new group"
 msgstr "Yeni grubu iptal et"
 
-#: src/pages/Shell.tsx:4649
+#: src/pages/Shell.tsx:4663
 msgid "Cancel reply"
 msgstr "Yanıtı iptal et"
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Chat apps, group channels, and agent connections."
 msgstr ""
 
-#: src/pages/Shell.tsx:4966
+#: src/pages/Shell.tsx:4980
 msgid "Chat Settings"
 msgstr "Sohbet Ayarları"
 
@@ -699,8 +699,8 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: src/pages/Shell.tsx:3420
-#: src/pages/Shell.tsx:3432
+#: src/pages/Shell.tsx:3430
+#: src/pages/Shell.tsx:3442
 msgid "Check in."
 msgstr "Durum bildir."
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Choose a new password"
 msgstr "Yeni bir parola seçin"
 
-#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:312
 msgid "Choose which connected model Rakazo uses."
 msgstr "Rakazo'nun hangi bağlı modeli kullanacağını seç."
 
@@ -747,11 +747,11 @@ msgstr "Sohbeti temizle"
 msgid "Clearing…"
 msgstr "Temizleniyor…"
 
-#: src/components/integrations/IntegrationSetup.tsx:167
+#: src/components/integrations/IntegrationSetup.tsx:172
 msgid "Client ID"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 msgid "Client secret"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr "Kapat"
 msgid "Close chart"
 msgstr "Grafiği kapat"
 
-#: src/pages/Shell.tsx:3950
+#: src/pages/Shell.tsx:3964
 msgid "Close computer"
 msgstr "Bilgisayarı kapat"
 
@@ -784,7 +784,7 @@ msgstr "Entegrasyonları kapat"
 msgid "Close MCP servers"
 msgstr "MCP sunucularını kapat"
 
-#: src/pages/MemorySettingsOverlay.tsx:164
+#: src/pages/MemorySettingsOverlay.tsx:168
 #: src/pages/SettingsOverlay.tsx:109
 msgid "Close memory settings"
 msgstr "Hafıza ayarlarını kapat"
@@ -793,16 +793,16 @@ msgstr "Hafıza ayarlarını kapat"
 msgid "Close messaging settings"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:324
+#: src/pages/ModelSettingsOverlay.tsx:328
 #: src/pages/SettingsOverlay.tsx:107
 msgid "Close model settings"
 msgstr "Model ayarlarını kapat"
 
-#: src/pages/Shell.tsx:2418
+#: src/pages/Shell.tsx:2428
 msgid "Close navigation"
 msgstr "Gezinmeyi kapat"
 
-#: src/pages/Shell.tsx:3186
+#: src/pages/Shell.tsx:3196
 msgid "Close panel"
 msgstr "Paneli kapat"
 
@@ -815,7 +815,7 @@ msgid "Close user settings"
 msgstr "Kullanıcı ayarlarını kapat"
 
 #: src/pages/SettingsOverlay.tsx:111
-#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:158
 msgid "Close voice settings"
 msgstr "Ses ayarlarını kapat"
 
@@ -828,7 +828,7 @@ msgid "Code"
 msgstr "Kod"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2590
+#: src/pages/Shell.tsx:2600
 msgid "Collapse {0}"
 msgstr ""
 
@@ -855,24 +855,24 @@ msgid "Complete"
 msgstr "Tamamlandı"
 
 #: src/pages/SettingsOverlay.tsx:97
-#: src/pages/Shell.tsx:5578
+#: src/pages/Shell.tsx:5592
 #: src/pages/shell/bot-panel.tsx:57
 msgid "Computer"
 msgstr "Bilgisayar"
 
-#: src/pages/Shell.tsx:5647
+#: src/pages/Shell.tsx:5661
 msgid "Computer failed to boot"
 msgstr "Bilgisayar başlatılamadı"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4008
 msgid "Computer is asleep"
 msgstr "Bilgisayar uykuda"
 
-#: src/pages/Shell.tsx:5646
+#: src/pages/Shell.tsx:5660
 msgid "Computer is asleep. Open it to wake."
 msgstr ""
 
-#: src/pages/Shell.tsx:5648
+#: src/pages/Shell.tsx:5662
 msgid "Computer is stopped"
 msgstr "Bilgisayar durduruldu"
 
@@ -884,7 +884,7 @@ msgstr "Bilgisayarlar"
 msgid "Computers are off. Set SANDBOX_PROVIDER=docker with SANDBOX_SUPERVISOR_TOKEN, or set SANDBOX_PROVIDER to e2b, daytona, or box with its API key. Recreate the stack after changing .env."
 msgstr "Bilgisayarlar kapalı. SANDBOX_PROVIDER=docker ve SANDBOX_SUPERVISOR_TOKEN ayarlayın; ya da SANDBOX_PROVIDER değerini e2b, daytona veya box yapıp API anahtarını ekleyin. .env değişince stacki yeniden oluşturun."
 
-#: src/pages/ModelSettingsOverlay.tsx:344
+#: src/pages/ModelSettingsOverlay.tsx:348
 msgid "Configured by deployment"
 msgstr "Dağıtım tarafından yapılandırıldı"
 
@@ -902,12 +902,12 @@ msgstr "Silmeyi onayla"
 msgid "Confirm password"
 msgstr "Parolayı doğrulayın"
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:258
-#: src/components/integrations/IntegrationSetup.tsx:282
-#: src/components/integrations/IntegrationSetup.tsx:315
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:267
+#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:324
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
-#: src/pages/VoiceSettingsOverlay.tsx:241
+#: src/pages/VoiceSettingsOverlay.tsx:245
 msgid "Connect"
 msgstr "Bağlan"
 
@@ -915,7 +915,7 @@ msgstr "Bağlan"
 msgid "Connect a model"
 msgstr "Model bağla"
 
-#: src/pages/ModelSettingsOverlay.tsx:697
+#: src/pages/ModelSettingsOverlay.tsx:701
 msgid "Connect API key"
 msgstr "API anahtarıyla bağlan"
 
@@ -931,7 +931,7 @@ msgstr "“{name}” MCP sunucusunu bağla"
 msgid "Connect OAuth"
 msgstr "OAuth ile bağlan"
 
-#: src/pages/ModelSettingsOverlay.tsx:547
+#: src/pages/ModelSettingsOverlay.tsx:551
 msgid "Connect this provider to use it as your personal model."
 msgstr "Kişisel modelin olarak kullanmak için bu sağlayıcıyı bağla."
 
@@ -939,30 +939,30 @@ msgstr "Kişisel modelin olarak kullanmak için bu sağlayıcıyı bağla."
 msgid "Connect Treg"
 msgstr "Treg'i bağla"
 
-#: src/components/integrations/IntegrationSetup.tsx:159
-#: src/components/integrations/IntegrationSetup.tsx:258
+#: src/components/integrations/IntegrationSetup.tsx:164
+#: src/components/integrations/IntegrationSetup.tsx:267
 #: src/pages/McpOAuthCallback.tsx:54
-#: src/pages/MemorySettingsOverlay.tsx:187
-#: src/pages/ModelSettingsOverlay.tsx:389
+#: src/pages/MemorySettingsOverlay.tsx:191
+#: src/pages/ModelSettingsOverlay.tsx:393
 #: src/pages/shell/message-cards.tsx:187
-#: src/pages/VoiceSettingsOverlay.tsx:198
+#: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Bağlandı"
 
 #. placeholder {0}: credential.label
-#: src/pages/ModelSettingsOverlay.tsx:538
+#: src/pages/ModelSettingsOverlay.tsx:542
 msgid "Connected · {0}"
 msgstr "Bağlı · {0}"
 
 #. placeholder {0}: selected.name
-#: src/pages/VoiceSettingsOverlay.tsx:102
+#: src/pages/VoiceSettingsOverlay.tsx:106
 msgid "Connected {0}."
 msgstr "{0} bağlandı."
 
 #. placeholder {0}: selected.label
 #. placeholder {0}: selectedLabelRef.current ?? "this model"
-#: src/pages/ModelSettingsOverlay.tsx:82
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:84
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Connected and using {0}."
 msgstr "Bağlandı, {0} kullanılıyor."
 
@@ -970,12 +970,12 @@ msgstr "Bağlandı, {0} kullanılıyor."
 msgid "Connected. Its tools are available from your next message."
 msgstr "Bağlandı. Araçları bir sonraki mesajından itibaren kullanılabilir."
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/McpServersOverlay.tsx:38
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
 #: src/pages/shell/message-cards.tsx:360
-#: src/pages/VoiceSettingsOverlay.tsx:237
+#: src/pages/VoiceSettingsOverlay.tsx:241
 msgid "Connecting…"
 msgstr "Bağlanıyor…"
 
@@ -984,7 +984,7 @@ msgstr "Bağlanıyor…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "{0} bağlantısı hâlâ beklemede. Bunu kapatıp daha sonra tekrar kontrol edebilirsin."
 
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/Onboarding.tsx:604
 #: src/pages/Onboarding.tsx:667
 msgid "Continue"
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Continue with email"
 msgstr "E-posta ile devam et"
 
-#: src/pages/Shell.tsx:5109
+#: src/pages/Shell.tsx:5123
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -1022,7 +1022,7 @@ msgstr "Bu uygulama yetkilendirilemedi"
 msgid "Could not change password"
 msgstr "Parola değiştirilemedi"
 
-#: src/pages/ModelSettingsOverlay.tsx:245
+#: src/pages/ModelSettingsOverlay.tsx:247
 msgid "Could not change the default model"
 msgstr "Varsayılan model değiştirilemedi"
 
@@ -1046,30 +1046,30 @@ msgstr "OAuth tamamlanamadı"
 msgid "Could not complete the update. Try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:76
+#: src/components/integrations/IntegrationSetup.tsx:79
 #: src/pages/PluginsOverlay.tsx:264
 msgid "Could not connect"
 msgstr "Bağlanılamadı"
 
 #. placeholder {0}: registration.name
-#: src/pages/MemorySettingsOverlay.tsx:115
+#: src/pages/MemorySettingsOverlay.tsx:119
 msgid "Could not connect {0}"
 msgstr "{0} bağlanamadı"
 
-#: src/pages/ModelSettingsOverlay.tsx:284
+#: src/pages/ModelSettingsOverlay.tsx:286
 msgid "Could not connect this provider"
 msgstr "Bu sağlayıcı bağlanamadı"
 
-#: src/pages/VoiceSettingsOverlay.tsx:104
+#: src/pages/VoiceSettingsOverlay.tsx:108
 msgid "Could not connect this voice provider"
 msgstr "Bu ses sağlayıcısı bağlanamadı"
 
-#: src/pages/Shell.tsx:875
+#: src/pages/Shell.tsx:885
 msgid "Could not connect to the computer screen"
 msgstr ""
 
 #: src/pages/Auth.tsx:99
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2368
 msgid "Could not continue"
 msgstr "Devam edilemedi"
 
@@ -1117,7 +1117,7 @@ msgstr "Beceri silinemedi"
 msgid "Could not delete space"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:129
+#: src/pages/MemorySettingsOverlay.tsx:133
 msgid "Could not disconnect memory provider"
 msgstr "Hafıza sağlayıcısının bağlantısı kesilemedi"
 
@@ -1158,7 +1158,7 @@ msgstr "Onay kuralları yüklenemedi"
 msgid "Could not load bots. Reload to try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:67
+#: src/components/integrations/IntegrationSetup.tsx:70
 #: src/pages/PluginsOverlay.tsx:143
 #: src/pages/PluginsOverlay.tsx:719
 msgid "Could not load integrations"
@@ -1168,7 +1168,7 @@ msgstr "Entegrasyonlar yüklenemedi"
 msgid "Could not load MCP servers"
 msgstr "MCP sunucuları yüklenemedi"
 
-#: src/pages/ModelSettingsOverlay.tsx:129
+#: src/pages/ModelSettingsOverlay.tsx:131
 msgid "Could not load model settings"
 msgstr "Model ayarları yüklenemedi"
 
@@ -1188,11 +1188,15 @@ msgstr "Bu dosya yüklenemedi."
 msgid "Could not load update status"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:77
+#: src/pages/VoiceSettingsOverlay.tsx:81
 msgid "Could not load voice settings"
 msgstr "Ses ayarları yüklenemedi"
 
-#: src/pages/VoiceSettingsOverlay.tsx:138
+#: src/pages/LocalSettings.tsx:26
+msgid "Could not open local settings. Start the local server and create its owner account, then try again."
+msgstr ""
+
+#: src/pages/VoiceSettingsOverlay.tsx:142
 msgid "Could not play a test clip"
 msgstr "Deneme sesi çalınamadı"
 
@@ -1202,7 +1206,7 @@ msgstr "Deneme sesi çalınamadı"
 msgid "Could not reach the server"
 msgstr "Sunucuya ulaşılamadı"
 
-#: src/pages/ModelSettingsOverlay.tsx:229
+#: src/pages/ModelSettingsOverlay.tsx:231
 #: src/pages/Onboarding.tsx:191
 msgid "Could not reach this model server"
 msgstr "Bu model sunucusuna ulaşılamadı"
@@ -1240,7 +1244,7 @@ msgstr "Parola sıfırlanamadı"
 msgid "Could not revoke connection"
 msgstr "Bağlantı iptal edilemedi"
 
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3496
 msgid "Could not run routine"
 msgstr ""
 
@@ -1262,7 +1266,7 @@ msgstr "Grup kaydedilemedi"
 msgid "Could not save model"
 msgstr "Model kaydedilemedi"
 
-#: src/pages/Shell.tsx:3457
+#: src/pages/Shell.tsx:3467
 msgid "Could not save routine"
 msgstr "Rutin kaydedilemedi"
 
@@ -1278,7 +1282,7 @@ msgstr "Beceri kaydedilemedi"
 msgid "Could not save that choice"
 msgstr "Bu seçim kaydedilemedi"
 
-#: src/pages/VoiceSettingsOverlay.tsx:119
+#: src/pages/VoiceSettingsOverlay.tsx:123
 msgid "Could not save that voice"
 msgstr "Bu ses kaydedilemedi"
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Could not submit this answer"
 msgstr "Bu yanıt gönderilemedi"
 
-#: src/pages/Shell.tsx:2212
+#: src/pages/Shell.tsx:2222
 msgid "Could not take control"
 msgstr "Kontrol alınamadı"
 
@@ -1326,11 +1330,11 @@ msgstr "Agent erişimi güncellenemedi"
 msgid "Could not update computer"
 msgstr ""
 
-#: src/pages/Shell.tsx:1808
+#: src/pages/Shell.tsx:1818
 msgid "Could not update reaction"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:143
+#: src/pages/MemorySettingsOverlay.tsx:147
 msgid "Could not update the default memory scope"
 msgstr "Varsayılan hafıza kapsamı güncellenemedi"
 
@@ -1346,7 +1350,7 @@ msgstr ""
 msgid "Couldn't update messaging settings"
 msgstr ""
 
-#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2481
 #: src/pages/shell/bot-panel.tsx:184
 #: src/pages/shell/dialogs.tsx:208
 msgid "Create"
@@ -1460,8 +1464,8 @@ msgstr "Varsayılan kapsam"
 #: src/pages/KnowledgeSection.tsx:449
 #: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:301
-#: src/pages/Shell.tsx:2825
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2835
+#: src/pages/Shell.tsx:2866
 #: src/pages/shell/dialogs.tsx:351
 #: src/pages/shell/dialogs.tsx:412
 msgid "Delete"
@@ -1469,8 +1473,8 @@ msgstr "Sil"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2822
-#: src/pages/Shell.tsx:2853
+#: src/pages/Shell.tsx:2832
+#: src/pages/Shell.tsx:2863
 msgid "Delete {0}"
 msgstr "{0} sil"
 
@@ -1489,11 +1493,11 @@ msgstr "Grubu sil"
 msgid "Delete memories too"
 msgstr "Hafızayı da sil"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3643
 msgid "Delete space"
 msgstr ""
 
-#: src/pages/Shell.tsx:5419
+#: src/pages/Shell.tsx:5433
 msgid "deleted"
 msgstr "silindi"
 
@@ -1511,7 +1515,7 @@ msgstr "Reddedildi"
 msgid "Deny"
 msgstr "Reddet"
 
-#: src/pages/ModelSettingsOverlay.tsx:340
+#: src/pages/ModelSettingsOverlay.tsx:344
 msgid "Deployment default"
 msgstr "Dağıtım varsayılanı"
 
@@ -1534,16 +1538,16 @@ msgstr ""
 msgid "Desktop update"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:40
+#: src/components/integrations/IntegrationSetup.tsx:43
 msgid "Direct MCP"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:493
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnect"
 msgstr "Bağlantıyı kes"
 
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnecting…"
 msgstr "Bağlantı kesiliyor…"
 
@@ -1553,7 +1557,7 @@ msgstr "Bağlantı kesiliyor…"
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/Shell.tsx:4629
+#: src/pages/Shell.tsx:4643
 msgid "Dismiss error"
 msgstr ""
 
@@ -1601,7 +1605,7 @@ msgstr "{name} indir"
 msgid "Download as markdown"
 msgstr "Markdown olarak indir"
 
-#: src/components/integrations/IntegrationSetup.tsx:327
+#: src/components/integrations/IntegrationSetup.tsx:336
 msgid "Download Executor"
 msgstr ""
 
@@ -1617,7 +1621,7 @@ msgstr "Taslak beceri"
 msgid "Duplicate"
 msgstr "Çoğalt"
 
-#: src/pages/Shell.tsx:5245
+#: src/pages/Shell.tsx:5259
 msgid "Earlier message"
 msgstr ""
 
@@ -1638,7 +1642,7 @@ msgid "Engage when... Ignore..."
 msgstr ""
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
-#: src/pages/ModelSettingsOverlay.tsx:600
+#: src/pages/ModelSettingsOverlay.tsx:604
 #: src/pages/Onboarding.tsx:531
 msgid "Enter this code at <0>{0}</0>"
 msgstr "Bu kodu <0>{0}</0> adresinde gir"
@@ -1687,7 +1691,7 @@ msgid "Expand"
 msgstr "Genişlet"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2589
+#: src/pages/Shell.tsx:2599
 msgid "Expand {0}"
 msgstr ""
 
@@ -1716,14 +1720,14 @@ msgstr "başarısız"
 msgid "Failed"
 msgstr "Başarısız"
 
-#: src/pages/Shell.tsx:1981
-#: src/pages/Shell.tsx:1983
-#: src/pages/Shell.tsx:1985
+#: src/pages/Shell.tsx:1991
+#: src/pages/Shell.tsx:1993
+#: src/pages/Shell.tsx:1995
 msgid "Failed to send message"
 msgstr "Mesaj gönderilemedi"
 
-#: src/pages/Shell.tsx:2018
-#: src/pages/Shell.tsx:2037
+#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2047
 msgid "Failed to stop"
 msgstr "Durdurulamadı"
 
@@ -1736,18 +1740,18 @@ msgstr "Başarısız oldu."
 msgid "Failure handling"
 msgstr "Hata yönetimi"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Find models"
 msgstr "Model bul"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Finding…"
 msgstr "Aranıyor…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
-#: src/pages/ModelSettingsOverlay.tsx:560
+#: src/pages/ModelSettingsOverlay.tsx:564
 #: src/pages/Onboarding.tsx:495
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "<0>{0}</0> adresinde oturum açmayı tamamla. Son sayfa yüklenmeyebilir; URL'sini veya kodu buraya yapıştır."
@@ -1773,7 +1777,7 @@ msgstr ""
 msgid "Forgot password?"
 msgstr "Parolanızı mı unuttunuz?"
 
-#: src/pages/ModelSettingsOverlay.tsx:1071
+#: src/pages/ModelSettingsOverlay.tsx:1075
 msgid "Free"
 msgstr ""
 
@@ -1786,7 +1790,7 @@ msgstr "Tam ekran"
 msgid "General"
 msgstr "Genel"
 
-#: src/components/integrations/IntegrationSetup.tsx:209
+#: src/components/integrations/IntegrationSetup.tsx:214
 msgid "Get credentials"
 msgstr ""
 
@@ -1801,8 +1805,8 @@ msgid "Git event"
 msgstr ""
 
 #: src/pages/MessagingSettingsOverlay.tsx:204
-#: src/pages/Shell.tsx:3019
-#: src/pages/Shell.tsx:3156
+#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3166
 msgid "Group"
 msgstr "Grup"
 
@@ -1844,15 +1848,15 @@ msgstr "Üstbilgi adı"
 msgid "Header value"
 msgstr "Üstbilgi değeri"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Hear a sample"
 msgstr "Örnek dinle"
 
-#: src/pages/VoiceSettingsOverlay.tsx:131
+#: src/pages/VoiceSettingsOverlay.tsx:135
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Merhaba, yanıtları sesli okuduğumda böyle duyulacağım."
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Hide bots"
 msgstr ""
 
@@ -1881,11 +1885,11 @@ msgstr "Ne sıklıkla"
 msgid "How to check"
 msgstr "Nasıl kontrol edilir"
 
-#: src/pages/Shell.tsx:5174
+#: src/pages/Shell.tsx:5188
 msgid "I’m done"
 msgstr "Bitirdim"
 
-#: src/pages/VoiceSettingsOverlay.tsx:136
+#: src/pages/VoiceSettingsOverlay.tsx:140
 msgid "If you heard that, voice is ready."
 msgstr "Bunu duyduysan ses hazır."
 
@@ -1917,12 +1921,12 @@ msgstr "Talimat"
 msgid "Integration domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:133
+#: src/components/integrations/IntegrationSetup.tsx:136
 msgid "Integration options"
 msgstr ""
 
 #: src/pages/PluginsOverlay.tsx:679
-#: src/pages/Shell.tsx:2874
+#: src/pages/Shell.tsx:2884
 msgid "Integrations"
 msgstr "Entegrasyonlar"
 
@@ -1952,11 +1956,11 @@ msgstr "Yalıtılmış"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Sohbeti, dosyaları ve rutinleri kalıcı olarak silinecek. Oluşturduğu botlar listende kalır."
 
-#: src/pages/Shell.tsx:4289
+#: src/pages/Shell.tsx:4303
 msgid "Jump to latest"
 msgstr "En son mesaja git"
 
-#: src/pages/Shell.tsx:5240
+#: src/pages/Shell.tsx:5254
 msgid "Jump to replied message"
 msgstr "Yanıtlanan mesaja git"
 
@@ -2014,7 +2018,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "Dinliyor…"
 
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Load earlier messages"
 msgstr "Önceki mesajları yükle"
 
@@ -2026,12 +2030,12 @@ msgstr "Etkinlik yükleniyor…"
 msgid "Loading integrations…"
 msgstr "Entegrasyonlar yükleniyor…"
 
-#: src/pages/MemorySettingsOverlay.tsx:182
+#: src/pages/MemorySettingsOverlay.tsx:186
 msgid "Loading memory settings…"
 msgstr "Hafıza ayarları yükleniyor…"
 
-#: src/pages/ModelSettingsOverlay.tsx:306
-#: src/pages/ModelSettingsOverlay.tsx:733
+#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:737
 msgid "Loading model catalog…"
 msgstr "Model kataloğu yükleniyor…"
 
@@ -2047,15 +2051,15 @@ msgstr "Kurallar yükleniyor…"
 msgid "Loading tools…"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:210
+#: src/pages/VoiceSettingsOverlay.tsx:214
 msgid "Loading voice providers…"
 msgstr "Ses sağlayıcıları yükleniyor…"
 
-#: src/App.tsx:58
+#: src/App.tsx:65
 #: src/pages/IntegrationSetup.tsx:72
 #: src/pages/Onboarding.tsx:282
 #: src/pages/PeerMessagesOverlay.tsx:98
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Loading…"
 msgstr "Yükleniyor…"
 
@@ -2067,7 +2071,11 @@ msgstr "Yerel"
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "Yerel erişim, botların sormadan komut çalıştırmasına izin verir. Paylaşılan veya herkese açık sunucularda bunu kullanma."
 
-#: src/pages/Shell.tsx:2932
+#: src/pages/LocalSettings.tsx:22
+msgid "Local Server Settings"
+msgstr ""
+
+#: src/pages/Shell.tsx:2942
 msgid "Log out"
 msgstr "Çıkış yap"
 
@@ -2083,8 +2091,8 @@ msgstr "MCP sunucularını yönet"
 msgid "Manage messaging settings"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:159
-#: src/pages/MemorySettingsOverlay.tsx:173
+#: src/pages/MemorySettingsOverlay.tsx:163
+#: src/pages/MemorySettingsOverlay.tsx:177
 msgid "Manage the Space semantic memory provider."
 msgstr "Çalışma alanının semantik hafıza sağlayıcısını yönet."
 
@@ -2125,7 +2133,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Üyeler ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} seç)"
 
 #: src/pages/KnowledgeSection.tsx:39
-#: src/pages/MemorySettingsOverlay.tsx:155
+#: src/pages/MemorySettingsOverlay.tsx:159
 #: src/pages/SettingsOverlay.tsx:94
 msgid "Memory"
 msgstr "Hafıza"
@@ -2134,7 +2142,7 @@ msgstr "Hafıza"
 msgid "Memory scope"
 msgstr "Hafıza kapsamı"
 
-#: src/pages/Shell.tsx:4697
+#: src/pages/Shell.tsx:4711
 msgid "Mentions"
 msgstr ""
 
@@ -2142,8 +2150,8 @@ msgstr ""
 msgid "Mentions only"
 msgstr ""
 
-#: src/pages/Shell.tsx:4898
-#: src/pages/Shell.tsx:5025
+#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:5039
 msgid "Message"
 msgstr "Mesaj"
 
@@ -2152,12 +2160,12 @@ msgstr "Mesaj"
 msgid "Message"
 msgstr "Mesaj"
 
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4898
+#: src/pages/Shell.tsx:4908
+#: src/pages/Shell.tsx:4912
 msgid "Message {activeName}"
 msgstr "{activeName} sohbetine yaz"
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4623
 msgid "Message composer"
 msgstr ""
 
@@ -2166,15 +2174,15 @@ msgstr ""
 msgid "Message event"
 msgstr ""
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Message from {peer}"
 msgstr "{peer} botundan mesaj"
 
-#: src/pages/Shell.tsx:4895
+#: src/pages/Shell.tsx:4909
 msgid "Message…"
 msgstr "Mesaj…"
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Messaged {peer}"
 msgstr "{peer} botuna mesaj gönderildi"
 
@@ -2195,8 +2203,8 @@ msgstr "Minimal"
 msgid "Minimize"
 msgstr "Küçült"
 
-#: src/pages/Shell.tsx:2461
-#: src/pages/Shell.tsx:2462
+#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2472
 msgid "Minimize bots"
 msgstr ""
 
@@ -2208,9 +2216,9 @@ msgstr "dakika"
 msgid "minutes"
 msgstr "dakika"
 
-#: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/ModelSettingsOverlay.tsx:509
-#: src/pages/ModelSettingsOverlay.tsx:959
+#: src/pages/ModelSettingsOverlay.tsx:448
+#: src/pages/ModelSettingsOverlay.tsx:513
+#: src/pages/ModelSettingsOverlay.tsx:963
 #: src/pages/Onboarding.tsx:420
 #: src/pages/Onboarding.tsx:468
 #: src/pages/Onboarding.tsx:476
@@ -2218,12 +2226,12 @@ msgstr "dakika"
 msgid "Model"
 msgstr "Model"
 
-#: src/pages/ModelSettingsOverlay.tsx:478
+#: src/pages/ModelSettingsOverlay.tsx:482
 #: src/pages/Onboarding.tsx:442
 msgid "Model id"
 msgstr "Model kimliği"
 
-#: src/pages/ModelSettingsOverlay.tsx:995
+#: src/pages/ModelSettingsOverlay.tsx:999
 msgid "Model options"
 msgstr "Model seçenekleri"
 
@@ -2235,16 +2243,21 @@ msgstr ""
 msgid "Model spend uses your provider keys."
 msgstr "Model harcaması senin sağlayıcı anahtarlarını kullanır."
 
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Model updated."
 msgstr "Model güncellendi."
 
-#: src/pages/ModelSettingsOverlay.tsx:317
+#: src/pages/LocalSettings.tsx:36
+#: src/pages/ModelSettingsOverlay.tsx:321
 #: src/pages/SettingsOverlay.tsx:93
 msgid "Models"
 msgstr "Modeller"
 
-#: src/pages/ModelSettingsOverlay.tsx:457
+#: src/pages/ModelSettingsOverlay.tsx:310
+msgid "Models for the server owner’s default space."
+msgstr ""
+
+#: src/pages/ModelSettingsOverlay.tsx:461
 #: src/pages/Onboarding.tsx:426
 msgid "Models from server"
 msgstr "Sunucudan gelen modeller"
@@ -2253,7 +2266,7 @@ msgstr "Sunucudan gelen modeller"
 msgid "Monthly"
 msgstr "Aylık"
 
-#: src/pages/Shell.tsx:5082
+#: src/pages/Shell.tsx:5096
 msgid "More"
 msgstr ""
 
@@ -2303,7 +2316,7 @@ msgstr "Girdi bekliyor"
 msgid "Needs takeover"
 msgstr "Devralma bekliyor"
 
-#: src/pages/Shell.tsx:3897
+#: src/pages/Shell.tsx:3911
 msgid "Needs you"
 msgstr ""
 
@@ -2381,7 +2394,7 @@ msgstr "Artık etkin değil"
 msgid "No managed app catalog is configured on this deployment."
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:1023
+#: src/pages/ModelSettingsOverlay.tsx:1027
 msgid "No matching models"
 msgstr ""
 
@@ -2397,7 +2410,7 @@ msgstr "Henüz MCP sunucusu yok."
 msgid "No messages with {peerBotName} yet."
 msgstr "{peerBotName} ile henüz mesaj yok."
 
-#: src/pages/ModelSettingsOverlay.tsx:737
+#: src/pages/ModelSettingsOverlay.tsx:741
 msgid "No model catalog is available."
 msgstr "Kullanılabilir model kataloğu yok."
 
@@ -2405,11 +2418,11 @@ msgstr "Kullanılabilir model kataloğu yok."
 msgid "No providers found"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:397
+#: src/pages/ModelSettingsOverlay.tsx:401
 msgid "No providers found."
 msgstr "Sağlayıcı bulunamadı."
 
-#: src/components/integrations/IntegrationSetup.tsx:264
+#: src/components/integrations/IntegrationSetup.tsx:273
 msgid "No remote MCP servers found"
 msgstr ""
 
@@ -2442,7 +2455,7 @@ msgstr ""
 msgid "None yet"
 msgstr "Henüz yok"
 
-#: src/pages/ModelSettingsOverlay.tsx:540
+#: src/pages/ModelSettingsOverlay.tsx:544
 msgid "Not connected"
 msgstr "Bağlı değil"
 
@@ -2463,7 +2476,7 @@ msgid "Now"
 msgstr "Şimdi"
 
 #. placeholder {0}: selected.label
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Now using {0}."
 msgstr "Artık {0} kullanılıyor."
 
@@ -2496,26 +2509,26 @@ msgstr "her ayın 1'inde saat {0}"
 msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
 msgstr ""
 
-#: src/pages/Shell.tsx:3671
+#: src/pages/Shell.tsx:3681
 msgid "Only empty spaces can be deleted. Delete its bots and groups first."
 msgstr ""
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3234
-#: src/pages/Shell.tsx:3239
+#: src/pages/Shell.tsx:3244
+#: src/pages/Shell.tsx:3249
 msgid "Open"
 msgstr "Aç"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2597
 msgid "Open {0}"
 msgstr ""
 
-#: src/pages/Shell.tsx:3202
+#: src/pages/Shell.tsx:3212
 msgid "Open in full window"
 msgstr "Tam pencerede aç"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3001
 msgid "Open navigation"
 msgstr "Gezinmeyi aç"
 
@@ -2523,20 +2536,20 @@ msgstr "Gezinmeyi aç"
 msgid "Open work"
 msgstr "Açık işler"
 
-#: src/pages/ModelSettingsOverlay.tsx:417
+#: src/pages/ModelSettingsOverlay.tsx:421
 #: src/pages/Onboarding.tsx:395
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI uyumlu sunucu URL'si"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5444
 msgid "Opened its thread."
 msgstr "Sohbeti açıldı."
 
-#: src/App.tsx:195
+#: src/App.tsx:202
 msgid "Opening your Space…"
 msgstr "Çalışma alanın açılıyor…"
 
-#: src/pages/ModelSettingsOverlay.tsx:650
+#: src/pages/ModelSettingsOverlay.tsx:654
 #: src/pages/Onboarding.tsx:569
 msgid "Optional"
 msgstr "İsteğe bağlı"
@@ -2549,7 +2562,7 @@ msgstr "Çoğu kişinin hiç ihtiyaç duymadığı isteğe bağlı ayarlar"
 msgid "Optional header value"
 msgstr "İsteğe bağlı üstbilgi değeri"
 
-#: src/pages/ModelSettingsOverlay.tsx:664
+#: src/pages/ModelSettingsOverlay.tsx:668
 msgid "Or connect an API key"
 msgstr "Veya bir API anahtarı bağla"
 
@@ -2565,7 +2578,7 @@ msgstr ""
 msgid "Organization API key"
 msgstr "Kuruluş API anahtarı"
 
-#: src/pages/ModelSettingsOverlay.tsx:465
+#: src/pages/ModelSettingsOverlay.tsx:469
 #: src/pages/Onboarding.tsx:435
 msgid "Other model…"
 msgstr "Başka model…"
@@ -2600,16 +2613,16 @@ msgstr "Parola güncellendi"
 msgid "Passwords do not match"
 msgstr "Parolalar eşleşmiyor"
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste a replacement key"
 msgstr "Yeni bir anahtar yapıştır"
 
-#: src/pages/ModelSettingsOverlay.tsx:428
+#: src/pages/ModelSettingsOverlay.tsx:432
 #: src/pages/Onboarding.tsx:406
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "Sunucundaki OpenAI uyumlu adresi yapıştır. Gerekirse Rakazo /v1 ekler."
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste your API key"
 msgstr "API anahtarını yapıştır"
 
@@ -2617,7 +2630,7 @@ msgstr "API anahtarını yapıştır"
 msgid "Paused"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:534
+#: src/pages/ModelSettingsOverlay.tsx:538
 msgid "Personal credential"
 msgstr "Kişisel kimlik bilgisi"
 
@@ -2625,7 +2638,7 @@ msgstr "Kişisel kimlik bilgisi"
 msgid "Pin"
 msgstr "Sabitle"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Playing…"
 msgstr "Çalınıyor…"
 
@@ -2642,17 +2655,17 @@ msgstr "{0} önizle"
 msgid "Private"
 msgstr "Özel"
 
-#: src/components/integrations/IntegrationSetup.tsx:177
+#: src/components/integrations/IntegrationSetup.tsx:182
 msgid "Project ID"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:215
+#: src/pages/MemorySettingsOverlay.tsx:219
 #: src/pages/Onboarding.tsx:292
 msgid "Provider"
 msgstr "Sağlayıcı"
 
-#: src/pages/ModelSettingsOverlay.tsx:352
-#: src/pages/VoiceSettingsOverlay.tsx:166
+#: src/pages/ModelSettingsOverlay.tsx:356
+#: src/pages/VoiceSettingsOverlay.tsx:170
 msgid "Providers"
 msgstr "Sağlayıcılar"
 
@@ -2684,7 +2697,7 @@ msgstr "Son"
 msgid "Reconnect OAuth"
 msgstr "OAuth'u yeniden bağla"
 
-#: src/App.tsx:150
+#: src/App.tsx:157
 #: src/components/ComputerUpdateProgress.tsx:54
 msgid "Reconnecting"
 msgstr "Yeniden bağlanıyor"
@@ -2747,7 +2760,7 @@ msgstr ""
 msgid "Refreshing…"
 msgstr ""
 
-#: src/pages/Shell.tsx:5164
+#: src/pages/Shell.tsx:5178
 msgid "Release"
 msgstr "Bırak"
 
@@ -2767,7 +2780,7 @@ msgid "Remove"
 msgstr "Kaldır"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4683
+#: src/pages/Shell.tsx:4697
 msgid "Remove {0}"
 msgstr "{0} kaldır"
 
@@ -2776,7 +2789,7 @@ msgid "Remove Git event"
 msgstr ""
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4845
 msgid "Remove mention {0}"
 msgstr "{0} bahsini kaldır"
 
@@ -2789,13 +2802,13 @@ msgid "Remove schedule"
 msgstr ""
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4824
 msgid "Remove skill {0}"
 msgstr "{0} becerisini kaldır"
 
-#: src/pages/Shell.tsx:4262
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:4276
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Remove thumbs-up"
 msgstr ""
 
@@ -2803,7 +2816,7 @@ msgstr ""
 msgid "Remove webhook"
 msgstr ""
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5443
 msgid "Removed with chat, computer, and memory."
 msgstr "Sohbeti, bilgisayarı ve hafızasıyla birlikte kaldırıldı."
 
@@ -2822,21 +2835,21 @@ msgstr "Kaldırılıyor…"
 msgid "Reopen"
 msgstr "Yeniden aç"
 
-#: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/ModelSettingsOverlay.tsx:695
+#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:699
 msgid "Replace API key"
 msgstr "API anahtarını değiştir"
 
-#: src/pages/VoiceSettingsOverlay.tsx:239
+#: src/pages/VoiceSettingsOverlay.tsx:243
 msgid "Replace key"
 msgstr "Anahtarı değiştir"
 
-#: src/pages/Shell.tsx:5074
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5088
+#: src/pages/Shell.tsx:5119
 msgid "Reply"
 msgstr "Yanıtla"
 
-#: src/pages/Shell.tsx:4646
+#: src/pages/Shell.tsx:4660
 msgid "Replying to {replyName}"
 msgstr "{replyName} yanıtlanıyor"
 
@@ -2870,8 +2883,8 @@ msgstr ""
 msgid "Restart to update"
 msgstr ""
 
-#: src/pages/Shell.tsx:2816
-#: src/pages/Shell.tsx:2847
+#: src/pages/Shell.tsx:2826
+#: src/pages/Shell.tsx:2857
 msgid "Restore"
 msgstr "Geri yükle"
 
@@ -2883,12 +2896,12 @@ msgstr ""
 msgid "Restoring your workspace"
 msgstr ""
 
-#: src/App.tsx:164
+#: src/App.tsx:171
 #: src/pages/PeerMessagesOverlay.tsx:109
 msgid "Retry now"
 msgstr "Şimdi tekrar dene"
 
-#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2398
 msgid "Retry screen"
 msgstr ""
 
@@ -2918,8 +2931,8 @@ msgid "Rotate key"
 msgstr ""
 
 #: src/pages/RoutineEditor.tsx:265
-#: src/pages/Shell.tsx:3419
-#: src/pages/Shell.tsx:3431
+#: src/pages/Shell.tsx:3429
+#: src/pages/Shell.tsx:3441
 msgid "Routine"
 msgstr "Rutin"
 
@@ -2936,7 +2949,7 @@ msgstr ""
 msgid "Run history"
 msgstr ""
 
-#: src/pages/Shell.tsx:3412
+#: src/pages/Shell.tsx:3422
 msgid "Run time must be in the future."
 msgstr ""
 
@@ -2966,7 +2979,7 @@ msgstr ""
 #: src/pages/GroupPanel.tsx:236
 #: src/pages/KnowledgeSection.tsx:203
 #: src/pages/KnowledgeSection.tsx:422
-#: src/pages/ModelSettingsOverlay.tsx:693
+#: src/pages/ModelSettingsOverlay.tsx:697
 #: src/pages/RoutineEditor.tsx:489
 #: src/pages/shell/bot-panel.tsx:539
 msgid "Save"
@@ -2983,7 +2996,7 @@ msgstr "Kaydedildi"
 msgid "Saved, but list refresh failed"
 msgstr "Kaydedildi ama liste yenilenemedi"
 
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Saved."
 msgstr "Kaydedildi."
 
@@ -3002,7 +3015,7 @@ msgstr ""
 #: src/components/AskCard.tsx:157
 #: src/components/teach/SkillDraftCard.tsx:142
 #: src/pages/GroupPanel.tsx:236
-#: src/pages/ModelSettingsOverlay.tsx:691
+#: src/pages/ModelSettingsOverlay.tsx:695
 #: src/pages/RoutineEditor.tsx:489
 msgid "Saving…"
 msgstr "Kaydediliyor…"
@@ -3016,15 +3029,15 @@ msgstr "Bir şey söyle. Sessiz kalınca gönderilir."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "Evet ya da hayır de veya bir cümleyle yanıtla."
 
-#: src/pages/ModelSettingsOverlay.tsx:984
+#: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
-#: src/pages/Shell.tsx:2530
+#: src/pages/Shell.tsx:2540
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "Ara"
 
-#: src/components/integrations/IntegrationSetup.tsx:241
-#: src/components/integrations/IntegrationSetup.tsx:242
+#: src/components/integrations/IntegrationSetup.tsx:250
+#: src/components/integrations/IntegrationSetup.tsx:251
 #: src/pages/PluginsOverlay.tsx:696
 #: src/pages/PluginsOverlay.tsx:697
 msgid "Search apps"
@@ -3038,11 +3051,11 @@ msgstr ""
 msgid "Search by domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:247
+#: src/components/integrations/IntegrationSetup.tsx:256
 msgid "Search integrations.sh"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:979
+#: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr ""
 
@@ -3051,8 +3064,8 @@ msgstr ""
 msgid "Search or create Bots"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:355
-#: src/pages/ModelSettingsOverlay.tsx:361
+#: src/pages/ModelSettingsOverlay.tsx:359
+#: src/pages/ModelSettingsOverlay.tsx:365
 msgid "Search providers"
 msgstr "Sağlayıcı ara"
 
@@ -3066,7 +3079,7 @@ msgstr "Sağlayıcı ve model ara"
 msgid "Searching…"
 msgstr "Aranıyor…"
 
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3030
 msgid "Select a bot"
 msgstr "Bir bot seç"
 
@@ -3074,8 +3087,8 @@ msgstr "Bir bot seç"
 msgid "Selected"
 msgstr ""
 
-#: src/pages/Shell.tsx:4929
-#: src/pages/Shell.tsx:4950
+#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4964
 msgid "Send"
 msgstr "Gönder"
 
@@ -3105,8 +3118,9 @@ msgstr "Gönderiliyor…"
 msgid "Sentry alert"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/AccountSettingsOverlay.tsx:158
+#: src/pages/LocalSettings.tsx:42
 msgid "Server integrations"
 msgstr ""
 
@@ -3114,33 +3128,33 @@ msgstr ""
 msgid "Server name"
 msgstr "Sunucu adı"
 
-#: src/components/integrations/IntegrationSetup.tsx:273
-#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:282
+#: src/components/integrations/IntegrationSetup.tsx:300
 #: src/pages/McpServersOverlay.tsx:329
-#: src/pages/ModelSettingsOverlay.tsx:412
+#: src/pages/ModelSettingsOverlay.tsx:416
 #: src/pages/Onboarding.tsx:390
 msgid "Server URL"
 msgstr "Sunucu URL'si"
 
 #: src/pages/MessagingSettingsOverlay.tsx:361
 #: src/pages/SettingsOverlay.tsx:103
-#: src/pages/SettingsOverlay.tsx:151
-#: src/pages/Shell.tsx:2896
-#: src/pages/Shell.tsx:2903
-#: src/pages/Shell.tsx:3152
+#: src/pages/SettingsOverlay.tsx:158
+#: src/pages/Shell.tsx:2906
+#: src/pages/Shell.tsx:2913
+#: src/pages/Shell.tsx:3162
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4982
 msgid "Settings: General"
 msgstr "Ayarlar: Genel"
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4984
 msgid "Settings: Usage"
 msgstr "Ayarlar: Kullanım"
 
-#: src/components/integrations/IntegrationSetup.tsx:319
-#: src/pages/ModelSettingsOverlay.tsx:425
+#: src/components/integrations/IntegrationSetup.tsx:328
+#: src/pages/ModelSettingsOverlay.tsx:429
 #: src/pages/Onboarding.tsx:403
 msgid "Setup help"
 msgstr "Kurulum yardımı"
@@ -3158,11 +3172,11 @@ msgstr "Paylaşılan belgeler"
 msgid "Show all providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Show bots"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show computer"
 msgstr "Bilgisayarı göster"
 
@@ -3178,14 +3192,14 @@ msgstr ""
 msgid "Show popular providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show settings"
 msgstr "Ayarları göster"
 
 #: src/lib/localized-provider-hint.ts:7
 #: src/pages/Auth.tsx:230
 #: src/pages/Auth.tsx:288
-#: src/pages/ModelSettingsOverlay.tsx:632
+#: src/pages/ModelSettingsOverlay.tsx:636
 #: src/pages/Onboarding.tsx:152
 msgid "Sign in"
 msgstr "Oturum aç"
@@ -3200,7 +3214,7 @@ msgid "Sign up"
 msgstr "Kaydol"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4758
 msgid "Skill {0}"
 msgstr "Beceri: {0}"
 
@@ -3208,8 +3222,8 @@ msgstr "Beceri: {0}"
 msgid "Skills"
 msgstr "Beceriler"
 
-#: src/components/integrations/IntegrationSetup.tsx:355
-#: src/pages/Shell.tsx:5171
+#: src/components/integrations/IntegrationSetup.tsx:364
+#: src/pages/Shell.tsx:5185
 msgid "Skip"
 msgstr "Atla"
 
@@ -3218,7 +3232,7 @@ msgid "Skip or deploy key"
 msgstr "Atla veya dağıtım anahtarı kullan"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1842
+#: src/pages/Shell.tsx:1852
 msgid "Skipped {0}"
 msgstr "{0} atlandı"
 
@@ -3250,21 +3264,21 @@ msgstr "Boşluk keser · Esc aramayı sonlandırır"
 msgid "Spaces"
 msgstr ""
 
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Speak"
 msgstr "Seslendir"
 
-#: src/pages/VoiceSettingsOverlay.tsx:190
+#: src/pages/VoiceSettingsOverlay.tsx:194
 msgid "Speak + transcribe"
 msgstr "Seslendir + yazıya dök"
 
-#: src/pages/VoiceSettingsOverlay.tsx:192
+#: src/pages/VoiceSettingsOverlay.tsx:196
 msgid "Speak only"
 msgstr "Yalnızca seslendir"
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Speak this reply"
 msgstr "Bu yanıtı seslendir"
 
@@ -3281,7 +3295,7 @@ msgid "Starting"
 msgstr "Başlıyor"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
-#: src/pages/ModelSettingsOverlay.tsx:630
+#: src/pages/ModelSettingsOverlay.tsx:634
 #: src/pages/Onboarding.tsx:554
 msgid "Starting…"
 msgstr "Başlatılıyor…"
@@ -3290,11 +3304,11 @@ msgstr "Başlatılıyor…"
 msgid "Steps"
 msgstr "Adımlar"
 
-#: src/pages/Shell.tsx:3912
-#: src/pages/Shell.tsx:3917
-#: src/pages/Shell.tsx:4939
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:3926
+#: src/pages/Shell.tsx:3931
+#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Stop"
 msgstr "Durdur"
 
@@ -3302,8 +3316,8 @@ msgstr "Durdur"
 msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
 msgstr ""
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Stop speaking"
 msgstr "Seslendirmeyi durdur"
 
@@ -3321,20 +3335,20 @@ msgstr "Durduruldu."
 msgid "Stored encrypted"
 msgstr "Şifreli saklanıyor"
 
-#: src/pages/ModelSettingsOverlay.tsx:545
+#: src/pages/ModelSettingsOverlay.tsx:549
 msgid "Stored securely. Never shown here."
 msgstr "Güvenle saklanır. Burada gösterilmez."
 
-#: src/pages/Shell.tsx:5383
+#: src/pages/Shell.tsx:5397
 msgid "subagent"
 msgstr "alt ajan"
 
-#: src/pages/ModelSettingsOverlay.tsx:590
+#: src/pages/ModelSettingsOverlay.tsx:594
 #: src/pages/Onboarding.tsx:521
 msgid "Submit"
 msgstr "Gönder"
 
-#: src/pages/ModelSettingsOverlay.tsx:503
+#: src/pages/ModelSettingsOverlay.tsx:507
 #: src/pages/Onboarding.tsx:462
 msgid "Supports thinking"
 msgstr "Düşünmeyi destekler"
@@ -3343,7 +3357,7 @@ msgstr "Düşünmeyi destekler"
 msgid "Switch bot"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:723
+#: src/pages/ModelSettingsOverlay.tsx:727
 msgid "Switching…"
 msgstr "Geçiliyor…"
 
@@ -3356,7 +3370,7 @@ msgstr "Sistem"
 msgid "Teach a task"
 msgstr "Görev öğret"
 
-#: src/pages/Shell.tsx:3076
+#: src/pages/Shell.tsx:3086
 msgid "Teaching in progress. Stop teaching before sending a new message."
 msgstr "Öğretme sürüyor. Yeni mesaj göndermeden önce öğretmeyi durdur."
 
@@ -3364,7 +3378,7 @@ msgstr "Öğretme sürüyor. Yeni mesaj göndermeden önce öğretmeyi durdur."
 msgid "Team"
 msgstr "Takım"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "Team Computer"
 msgstr "Takım Bilgisayarı"
 
@@ -3394,7 +3408,7 @@ msgstr ""
 msgid "The API did not come back. Refresh this page."
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:241
+#: src/pages/MemorySettingsOverlay.tsx:245
 msgid "The selected memory provider is not available in this build."
 msgstr "Seçilen hafıza sağlayıcısı bu sürümde kullanılamıyor."
 
@@ -3402,7 +3416,7 @@ msgstr "Seçilen hafıza sağlayıcısı bu sürümde kullanılamıyor."
 msgid "Thinking"
 msgstr "Düşünüyor"
 
-#: src/pages/Shell.tsx:5632
+#: src/pages/Shell.tsx:5646
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Bu bot bir Linux masaüstünde değil, bu bilgisayarda çalışır. Kabuk ve dosyalar senin kullanıcı klasörünü kullanır."
 
@@ -3455,7 +3469,7 @@ msgstr "Bu sunucu zaten bağlı. Yeniden yetkilendirmek için önce bağlantıs�
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools. A popup will open."
 msgstr "Bu sunucu tarayıcıyla oturum açar. Agent'larının araçlarını kullanabilmesi için yetkilendir. Bir açılır pencere açılacak."
 
-#: src/pages/ModelSettingsOverlay.tsx:705
+#: src/pages/ModelSettingsOverlay.tsx:709
 msgid "This subscription sign-in is not available in Rakazo yet. Use a deployment credential or choose another provider."
 msgstr "Bu abonelik girişi Rakazo'da henüz kullanılamıyor. Bir dağıtım kimlik bilgisi kullan veya başka bir sağlayıcı seç."
 
@@ -3514,7 +3528,7 @@ msgid "Unpin"
 msgstr "Sabitlemeyi kaldır"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1920
+#: src/pages/Shell.tsx:1930
 msgid "Unsupported file type: {0}"
 msgstr "Desteklenmeyen dosya türü: {0}"
 
@@ -3574,8 +3588,8 @@ msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:199
 #: src/pages/SettingsOverlay.tsx:96
-#: src/pages/Shell.tsx:2908
-#: src/pages/Shell.tsx:2919
+#: src/pages/Shell.tsx:2918
+#: src/pages/Shell.tsx:2929
 msgid "Usage"
 msgstr "Kullanım"
 
@@ -3583,7 +3597,7 @@ msgstr "Kullanım"
 msgid "Use {hostLabel}"
 msgstr "{hostLabel} kullan"
 
-#: src/pages/ModelSettingsOverlay.tsx:490
+#: src/pages/ModelSettingsOverlay.tsx:494
 #: src/pages/Onboarding.tsx:454
 msgid "Use a found model"
 msgstr "Bulunan bir modeli kullan"
@@ -3593,7 +3607,7 @@ msgstr "Bulunan bir modeli kullan"
 msgid "Use default guidance"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:725
+#: src/pages/ModelSettingsOverlay.tsx:729
 msgid "Use this model"
 msgstr "Bu modeli kullan"
 
@@ -3606,16 +3620,16 @@ msgid "Verifying…"
 msgstr "Doğrulanıyor…"
 
 #: src/pages/SettingsOverlay.tsx:95
-#: src/pages/Shell.tsx:4916
-#: src/pages/Shell.tsx:4917
+#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:4931
 #: src/pages/shell/bot-panel.tsx:482
-#: src/pages/VoiceSettingsOverlay.tsx:150
-#: src/pages/VoiceSettingsOverlay.tsx:249
+#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Voice"
 msgstr "Ses"
 
-#: src/pages/ModelSettingsOverlay.tsx:594
-#: src/pages/ModelSettingsOverlay.tsx:616
+#: src/pages/ModelSettingsOverlay.tsx:598
+#: src/pages/ModelSettingsOverlay.tsx:620
 #: src/pages/Onboarding.tsx:525
 #: src/pages/Onboarding.tsx:547
 msgid "Waiting for sign-in…"
@@ -3687,8 +3701,8 @@ msgstr ""
 msgid "Working…"
 msgstr "Çalışıyor…"
 
-#: src/pages/Shell.tsx:1616
-#: src/pages/Shell.tsx:2393
+#: src/pages/Shell.tsx:1626
+#: src/pages/Shell.tsx:2403
 msgid "You"
 msgstr "Sen"
 
@@ -3700,7 +3714,7 @@ msgstr "Otomatik yönlendirilmezsen bu sekmeyi kapatabilirsin."
 msgid "You can close this window."
 msgstr "Bu pencereyi kapatabilirsin."
 
-#: src/pages/Shell.tsx:3901
+#: src/pages/Shell.tsx:3915
 msgid "You have control"
 msgstr "Kontrol sende"
 

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -13,22 +13,22 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2720
+#: src/pages/Shell.tsx:2730
 msgid " (unread)"
 msgstr "（未读）"
 
 #. placeholder {0}: group.entries.length
-#: src/pages/ModelSettingsOverlay.tsx:382
+#: src/pages/ModelSettingsOverlay.tsx:386
 msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# 个模型} other {# 个模型}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1822
+#: src/pages/Shell.tsx:1832
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0}（最多 {ATTACHMENT_MAX_COUNT} 个附件）"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1826
+#: src/pages/Shell.tsx:1836
 msgid "{0} (over 10 MiB)"
 msgstr "{0}（超过 10 MiB）"
 
@@ -80,11 +80,11 @@ msgid "{0} will still respond to direct mentions."
 msgstr ""
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3245
+#: src/pages/Shell.tsx:3255
 msgid "{0}'s screen"
 msgstr ""
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "{botName}’s computer"
 msgstr "{botName} 的电脑"
 
@@ -132,12 +132,12 @@ msgstr "{title}，{label}"
 msgid "{toolCount, plural, one {# tool} other {# tools}}"
 msgstr ""
 
-#: src/pages/Shell.tsx:4072
+#: src/pages/Shell.tsx:4086
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} 正在工作"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4711
+#: src/pages/Shell.tsx:4725
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "About spaces"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:301
+#: src/components/integrations/IntegrationSetup.tsx:310
 msgid "Access token"
 msgstr ""
 
@@ -188,7 +188,7 @@ msgstr "操作确认"
 msgid "Actions for {0}"
 msgstr "{0} 的操作"
 
-#: src/pages/Shell.tsx:3619
+#: src/pages/Shell.tsx:3629
 msgid "Actions for space"
 msgstr ""
 
@@ -196,12 +196,12 @@ msgstr ""
 msgid "Active"
 msgstr "启用"
 
-#: src/pages/ModelSettingsOverlay.tsx:337
+#: src/pages/ModelSettingsOverlay.tsx:341
 msgid "Active model"
 msgstr "当前模型"
 
-#: src/pages/Shell.tsx:2440
-#: src/pages/Shell.tsx:2442
+#: src/pages/Shell.tsx:2450
+#: src/pages/Shell.tsx:2452
 msgid "Activity"
 msgstr "动态"
 
@@ -215,11 +215,11 @@ msgstr "添加"
 msgid "Add a model in Settings to use this."
 msgstr "请在设置中添加模型后再使用。"
 
-#: src/pages/Shell.tsx:3407
+#: src/pages/Shell.tsx:3417
 msgid "Add a run time for this one-shot."
 msgstr "为此一次性任务添加运行时间。"
 
-#: src/pages/Shell.tsx:3385
+#: src/pages/Shell.tsx:3395
 msgid "Add a schedule, webhook, GitHub, or message trigger"
 msgstr ""
 
@@ -259,7 +259,7 @@ msgstr "添加 GraphQL 端点"
 msgid "Add item"
 msgstr "添加项目"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/PluginsOverlay.tsx:951
 msgid "Add MCP server"
 msgstr "添加 MCP 服务器"
@@ -277,12 +277,12 @@ msgstr "添加远程 MCP 服务器"
 msgid "Add server"
 msgstr "添加服务器"
 
-#: src/components/integrations/IntegrationSetup.tsx:269
+#: src/components/integrations/IntegrationSetup.tsx:278
 msgid "Add server URL"
 msgstr ""
 
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Add thumbs-up"
 msgstr "点赞"
 
@@ -311,7 +311,7 @@ msgstr "正在添加…"
 
 #: src/pages/AccountSettingsOverlay.tsx:166
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/ModelSettingsOverlay.tsx:502
+#: src/pages/ModelSettingsOverlay.tsx:506
 #: src/pages/Onboarding.tsx:461
 #: src/pages/PluginsOverlay.tsx:836
 #: src/pages/RoutineSchedule.tsx:43
@@ -323,7 +323,7 @@ msgstr "高级"
 msgid "Advanced..."
 msgstr "高级..."
 
-#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3039
 msgid "Agent computer"
 msgstr "Agent 电脑"
 
@@ -405,15 +405,15 @@ msgid "API is back, but the update did not finish. Check the host logs."
 msgstr "API 已恢复，但更新未完成。请查看宿主日志。"
 
 #: src/components/AskCard.tsx:44
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 #: src/lib/localized-provider-hint.ts:9
-#: src/pages/ModelSettingsOverlay.tsx:644
-#: src/pages/ModelSettingsOverlay.tsx:647
-#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:648
+#: src/pages/ModelSettingsOverlay.tsx:651
+#: src/pages/ModelSettingsOverlay.tsx:670
 #: src/pages/Onboarding.tsx:563
 #: src/pages/Onboarding.tsx:566
 #: src/pages/Onboarding.tsx:580
-#: src/pages/VoiceSettingsOverlay.tsx:219
+#: src/pages/VoiceSettingsOverlay.tsx:223
 msgid "API key"
 msgstr "API 密钥"
 
@@ -444,15 +444,15 @@ msgstr "批准此服务器后，Agent 才能使用它的工具。"
 msgid "Archive"
 msgstr "归档"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5431
 msgid "archived"
 msgstr "已归档"
 
-#: src/pages/Shell.tsx:2789
+#: src/pages/Shell.tsx:2799
 msgid "Archived"
 msgstr "已归档"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5442
 msgid "Archived. Chat, memory, and files kept."
 msgstr "已归档。对话、记忆和文件保留。"
 
@@ -491,7 +491,7 @@ msgstr "购买前询问"
 msgid "Ask before sending external email"
 msgstr "发送外部邮件前询问"
 
-#: src/components/integrations/IntegrationSetup.tsx:219
+#: src/components/integrations/IntegrationSetup.tsx:228
 msgid "Ask the server owner to configure this provider."
 msgstr ""
 
@@ -506,15 +506,15 @@ msgstr "{0}"
 msgid "at {timeSelect}"
 msgstr "{timeSelect}"
 
-#: src/pages/Shell.tsx:4791
+#: src/pages/Shell.tsx:4805
 msgid "Attach file"
 msgstr "附加文件"
 
-#: src/pages/Shell.tsx:5023
+#: src/pages/Shell.tsx:5037
 msgid "Attachment"
 msgstr "附件"
 
-#: src/pages/ModelSettingsOverlay.tsx:577
+#: src/pages/ModelSettingsOverlay.tsx:581
 #: src/pages/Onboarding.tsx:512
 msgid "Authorization code or callback URL"
 msgstr "授权码或回调 URL"
@@ -567,23 +567,23 @@ msgstr "Base URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5644
+#: src/pages/Shell.tsx:5658
 msgid "Booting live desktop…"
 msgstr "正在启动实时桌面…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3877
 msgid "Booting up {0}’s computer"
 msgstr "正在启动 {0} 的电脑"
 
-#: src/pages/Shell.tsx:5292
-#: src/pages/Shell.tsx:5293
-#: src/pages/Shell.tsx:5421
+#: src/pages/Shell.tsx:5306
+#: src/pages/Shell.tsx:5307
+#: src/pages/Shell.tsx:5435
 msgid "bot"
 msgstr "Bot"
 
 #: src/pages/IntegrationSetup.tsx:51
-#: src/pages/Shell.tsx:1617
+#: src/pages/Shell.tsx:1627
 msgid "Bot"
 msgstr "Bot"
 
@@ -592,11 +592,11 @@ msgstr "Bot"
 msgid "Bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:3971
+#: src/pages/Shell.tsx:3985
 msgid "Bot screen"
 msgstr "Bot 屏幕"
 
-#: src/pages/Shell.tsx:3208
+#: src/pages/Shell.tsx:3218
 msgid "Bot screen preview"
 msgstr "Bot 屏幕预览"
 
@@ -608,7 +608,7 @@ msgstr "要关联的 Bot"
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first."
 msgstr "默认情况下 Bot 会直接执行。只有当你想先审核某类操作时，才添加例外。"
 
-#: src/pages/Shell.tsx:4073
+#: src/pages/Shell.tsx:4087
 msgid "Bots are working"
 msgstr "Bot 正在工作"
 
@@ -620,7 +620,7 @@ msgstr ""
 msgid "Call"
 msgstr "通话"
 
-#: src/App.tsx:152
+#: src/App.tsx:159
 msgid "Can't reach the server."
 msgstr "无法连接服务器。"
 
@@ -648,7 +648,7 @@ msgstr "取消新建 Bot"
 msgid "Cancel new group"
 msgstr "取消新建群组"
 
-#: src/pages/Shell.tsx:4649
+#: src/pages/Shell.tsx:4663
 msgid "Cancel reply"
 msgstr "取消回复"
 
@@ -685,7 +685,7 @@ msgstr "聊天应用"
 msgid "Chat apps, group channels, and agent connections."
 msgstr "聊天应用、群组频道和 Agent 连接。"
 
-#: src/pages/Shell.tsx:4966
+#: src/pages/Shell.tsx:4980
 msgid "Chat Settings"
 msgstr "聊天设置"
 
@@ -699,8 +699,8 @@ msgstr "检查失败"
 msgid "Check for updates"
 msgstr "检查更新"
 
-#: src/pages/Shell.tsx:3420
-#: src/pages/Shell.tsx:3432
+#: src/pages/Shell.tsx:3430
+#: src/pages/Shell.tsx:3442
 msgid "Check in."
 msgstr "报到。"
 
@@ -725,7 +725,7 @@ msgstr "选择 Bot…"
 msgid "Choose a new password"
 msgstr "设置新密码"
 
-#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:312
 msgid "Choose which connected model Rakazo uses."
 msgstr "选择 Rakazo 使用的已连接模型。"
 
@@ -747,11 +747,11 @@ msgstr "清空对话"
 msgid "Clearing…"
 msgstr "正在清空…"
 
-#: src/components/integrations/IntegrationSetup.tsx:167
+#: src/components/integrations/IntegrationSetup.tsx:172
 msgid "Client ID"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:189
+#: src/components/integrations/IntegrationSetup.tsx:194
 msgid "Client secret"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr "关闭"
 msgid "Close chart"
 msgstr "关闭图表"
 
-#: src/pages/Shell.tsx:3950
+#: src/pages/Shell.tsx:3964
 msgid "Close computer"
 msgstr "关闭电脑"
 
@@ -784,7 +784,7 @@ msgstr "关闭集成"
 msgid "Close MCP servers"
 msgstr "关闭 MCP 服务器"
 
-#: src/pages/MemorySettingsOverlay.tsx:164
+#: src/pages/MemorySettingsOverlay.tsx:168
 #: src/pages/SettingsOverlay.tsx:109
 msgid "Close memory settings"
 msgstr "关闭记忆设置"
@@ -793,16 +793,16 @@ msgstr "关闭记忆设置"
 msgid "Close messaging settings"
 msgstr "关闭消息设置"
 
-#: src/pages/ModelSettingsOverlay.tsx:324
+#: src/pages/ModelSettingsOverlay.tsx:328
 #: src/pages/SettingsOverlay.tsx:107
 msgid "Close model settings"
 msgstr "关闭模型设置"
 
-#: src/pages/Shell.tsx:2418
+#: src/pages/Shell.tsx:2428
 msgid "Close navigation"
 msgstr "关闭导航"
 
-#: src/pages/Shell.tsx:3186
+#: src/pages/Shell.tsx:3196
 msgid "Close panel"
 msgstr "关闭面板"
 
@@ -815,7 +815,7 @@ msgid "Close user settings"
 msgstr "关闭用户设置"
 
 #: src/pages/SettingsOverlay.tsx:111
-#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:158
 msgid "Close voice settings"
 msgstr "关闭语音设置"
 
@@ -828,7 +828,7 @@ msgid "Code"
 msgstr "代码"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2590
+#: src/pages/Shell.tsx:2600
 msgid "Collapse {0}"
 msgstr "折叠 {0}"
 
@@ -855,24 +855,24 @@ msgid "Complete"
 msgstr "完成"
 
 #: src/pages/SettingsOverlay.tsx:97
-#: src/pages/Shell.tsx:5578
+#: src/pages/Shell.tsx:5592
 #: src/pages/shell/bot-panel.tsx:57
 msgid "Computer"
 msgstr "电脑"
 
-#: src/pages/Shell.tsx:5647
+#: src/pages/Shell.tsx:5661
 msgid "Computer failed to boot"
 msgstr "电脑启动失败"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4008
 msgid "Computer is asleep"
 msgstr "电脑已休眠"
 
-#: src/pages/Shell.tsx:5646
+#: src/pages/Shell.tsx:5660
 msgid "Computer is asleep. Open it to wake."
 msgstr ""
 
-#: src/pages/Shell.tsx:5648
+#: src/pages/Shell.tsx:5662
 msgid "Computer is stopped"
 msgstr "电脑已停止"
 
@@ -884,7 +884,7 @@ msgstr "电脑"
 msgid "Computers are off. Set SANDBOX_PROVIDER=docker with SANDBOX_SUPERVISOR_TOKEN, or set SANDBOX_PROVIDER to e2b, daytona, or box with its API key. Recreate the stack after changing .env."
 msgstr "电脑未开启。请设置 SANDBOX_PROVIDER=docker 并提供 SANDBOX_SUPERVISOR_TOKEN，或将 SANDBOX_PROVIDER 设为 e2b、daytona 或 box 并提供对应 API 密钥。更改 .env 后请重建环境。"
 
-#: src/pages/ModelSettingsOverlay.tsx:344
+#: src/pages/ModelSettingsOverlay.tsx:348
 msgid "Configured by deployment"
 msgstr "由部署配置"
 
@@ -902,12 +902,12 @@ msgstr "确认删除"
 msgid "Confirm password"
 msgstr "确认密码"
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:258
-#: src/components/integrations/IntegrationSetup.tsx:282
-#: src/components/integrations/IntegrationSetup.tsx:315
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:267
+#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:324
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
-#: src/pages/VoiceSettingsOverlay.tsx:241
+#: src/pages/VoiceSettingsOverlay.tsx:245
 msgid "Connect"
 msgstr "连接"
 
@@ -915,7 +915,7 @@ msgstr "连接"
 msgid "Connect a model"
 msgstr "连接模型"
 
-#: src/pages/ModelSettingsOverlay.tsx:697
+#: src/pages/ModelSettingsOverlay.tsx:701
 msgid "Connect API key"
 msgstr "连接 API 密钥"
 
@@ -931,7 +931,7 @@ msgstr "连接 MCP 服务器“{name}”"
 msgid "Connect OAuth"
 msgstr "连接 OAuth"
 
-#: src/pages/ModelSettingsOverlay.tsx:547
+#: src/pages/ModelSettingsOverlay.tsx:551
 msgid "Connect this provider to use it as your personal model."
 msgstr "连接此提供方，作为你的个人模型。"
 
@@ -939,30 +939,30 @@ msgstr "连接此提供方，作为你的个人模型。"
 msgid "Connect Treg"
 msgstr "连接 Treg"
 
-#: src/components/integrations/IntegrationSetup.tsx:159
-#: src/components/integrations/IntegrationSetup.tsx:258
+#: src/components/integrations/IntegrationSetup.tsx:164
+#: src/components/integrations/IntegrationSetup.tsx:267
 #: src/pages/McpOAuthCallback.tsx:54
-#: src/pages/MemorySettingsOverlay.tsx:187
-#: src/pages/ModelSettingsOverlay.tsx:389
+#: src/pages/MemorySettingsOverlay.tsx:191
+#: src/pages/ModelSettingsOverlay.tsx:393
 #: src/pages/shell/message-cards.tsx:187
-#: src/pages/VoiceSettingsOverlay.tsx:198
+#: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "已连接"
 
 #. placeholder {0}: credential.label
-#: src/pages/ModelSettingsOverlay.tsx:538
+#: src/pages/ModelSettingsOverlay.tsx:542
 msgid "Connected · {0}"
 msgstr "已连接 · {0}"
 
 #. placeholder {0}: selected.name
-#: src/pages/VoiceSettingsOverlay.tsx:102
+#: src/pages/VoiceSettingsOverlay.tsx:106
 msgid "Connected {0}."
 msgstr "已连接 {0}。"
 
 #. placeholder {0}: selected.label
 #. placeholder {0}: selectedLabelRef.current ?? "this model"
-#: src/pages/ModelSettingsOverlay.tsx:82
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:84
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Connected and using {0}."
 msgstr "已连接并使用 {0}。"
 
@@ -970,12 +970,12 @@ msgstr "已连接并使用 {0}。"
 msgid "Connected. Its tools are available from your next message."
 msgstr "已连接，下一条消息起即可使用其工具。"
 
-#: src/components/integrations/IntegrationSetup.tsx:213
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:222
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/McpServersOverlay.tsx:38
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:82
 #: src/pages/shell/message-cards.tsx:360
-#: src/pages/VoiceSettingsOverlay.tsx:237
+#: src/pages/VoiceSettingsOverlay.tsx:241
 msgid "Connecting…"
 msgstr "正在连接…"
 
@@ -984,7 +984,7 @@ msgstr "正在连接…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "与 {0} 的连接仍在等待。可以关闭此窗口稍后再看。"
 
-#: src/components/integrations/IntegrationSetup.tsx:352
+#: src/components/integrations/IntegrationSetup.tsx:361
 #: src/pages/Onboarding.tsx:604
 #: src/pages/Onboarding.tsx:667
 msgid "Continue"
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Continue with email"
 msgstr "使用邮箱继续"
 
-#: src/pages/Shell.tsx:5109
+#: src/pages/Shell.tsx:5123
 msgid "Copy"
 msgstr "复制"
 
@@ -1022,7 +1022,7 @@ msgstr "无法授权此应用"
 msgid "Could not change password"
 msgstr "无法修改密码"
 
-#: src/pages/ModelSettingsOverlay.tsx:245
+#: src/pages/ModelSettingsOverlay.tsx:247
 msgid "Could not change the default model"
 msgstr "无法更改默认模型"
 
@@ -1046,30 +1046,30 @@ msgstr "无法完成 OAuth"
 msgid "Could not complete the update. Try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:76
+#: src/components/integrations/IntegrationSetup.tsx:79
 #: src/pages/PluginsOverlay.tsx:264
 msgid "Could not connect"
 msgstr "无法连接"
 
 #. placeholder {0}: registration.name
-#: src/pages/MemorySettingsOverlay.tsx:115
+#: src/pages/MemorySettingsOverlay.tsx:119
 msgid "Could not connect {0}"
 msgstr "无法连接 {0}"
 
-#: src/pages/ModelSettingsOverlay.tsx:284
+#: src/pages/ModelSettingsOverlay.tsx:286
 msgid "Could not connect this provider"
 msgstr "无法连接此提供方"
 
-#: src/pages/VoiceSettingsOverlay.tsx:104
+#: src/pages/VoiceSettingsOverlay.tsx:108
 msgid "Could not connect this voice provider"
 msgstr "无法连接此语音提供方"
 
-#: src/pages/Shell.tsx:875
+#: src/pages/Shell.tsx:885
 msgid "Could not connect to the computer screen"
 msgstr ""
 
 #: src/pages/Auth.tsx:99
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2368
 msgid "Could not continue"
 msgstr "无法继续"
 
@@ -1117,7 +1117,7 @@ msgstr "无法删除技能"
 msgid "Could not delete space"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:129
+#: src/pages/MemorySettingsOverlay.tsx:133
 msgid "Could not disconnect memory provider"
 msgstr "无法断开记忆提供方"
 
@@ -1158,7 +1158,7 @@ msgstr "无法加载审批规则"
 msgid "Could not load bots. Reload to try again."
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:67
+#: src/components/integrations/IntegrationSetup.tsx:70
 #: src/pages/PluginsOverlay.tsx:143
 #: src/pages/PluginsOverlay.tsx:719
 msgid "Could not load integrations"
@@ -1168,7 +1168,7 @@ msgstr "无法加载集成"
 msgid "Could not load MCP servers"
 msgstr "无法加载 MCP 服务器"
 
-#: src/pages/ModelSettingsOverlay.tsx:129
+#: src/pages/ModelSettingsOverlay.tsx:131
 msgid "Could not load model settings"
 msgstr "无法加载模型设置"
 
@@ -1188,11 +1188,15 @@ msgstr "无法加载此文件。"
 msgid "Could not load update status"
 msgstr "无法加载更新状态"
 
-#: src/pages/VoiceSettingsOverlay.tsx:77
+#: src/pages/VoiceSettingsOverlay.tsx:81
 msgid "Could not load voice settings"
 msgstr "无法加载语音设置"
 
-#: src/pages/VoiceSettingsOverlay.tsx:138
+#: src/pages/LocalSettings.tsx:26
+msgid "Could not open local settings. Start the local server and create its owner account, then try again."
+msgstr ""
+
+#: src/pages/VoiceSettingsOverlay.tsx:142
 msgid "Could not play a test clip"
 msgstr "无法播放测试片段"
 
@@ -1202,7 +1206,7 @@ msgstr "无法播放测试片段"
 msgid "Could not reach the server"
 msgstr "无法连接服务器"
 
-#: src/pages/ModelSettingsOverlay.tsx:229
+#: src/pages/ModelSettingsOverlay.tsx:231
 #: src/pages/Onboarding.tsx:191
 msgid "Could not reach this model server"
 msgstr "无法访问此模型服务器"
@@ -1240,7 +1244,7 @@ msgstr "无法重置密码"
 msgid "Could not revoke connection"
 msgstr "无法撤销连接"
 
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3496
 msgid "Could not run routine"
 msgstr "无法运行例行任务"
 
@@ -1262,7 +1266,7 @@ msgstr "无法保存群组"
 msgid "Could not save model"
 msgstr "无法保存模型"
 
-#: src/pages/Shell.tsx:3457
+#: src/pages/Shell.tsx:3467
 msgid "Could not save routine"
 msgstr "无法保存例行任务"
 
@@ -1278,7 +1282,7 @@ msgstr "无法保存技能"
 msgid "Could not save that choice"
 msgstr "无法保存该选择"
 
-#: src/pages/VoiceSettingsOverlay.tsx:119
+#: src/pages/VoiceSettingsOverlay.tsx:123
 msgid "Could not save that voice"
 msgstr "无法保存该语音"
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Could not submit this answer"
 msgstr "无法提交此回答"
 
-#: src/pages/Shell.tsx:2212
+#: src/pages/Shell.tsx:2222
 msgid "Could not take control"
 msgstr "无法接管"
 
@@ -1326,11 +1330,11 @@ msgstr "无法更新 Agent 权限"
 msgid "Could not update computer"
 msgstr "无法更新电脑"
 
-#: src/pages/Shell.tsx:1808
+#: src/pages/Shell.tsx:1818
 msgid "Could not update reaction"
 msgstr "无法更新反应"
 
-#: src/pages/MemorySettingsOverlay.tsx:143
+#: src/pages/MemorySettingsOverlay.tsx:147
 msgid "Could not update the default memory scope"
 msgstr "无法更新默认记忆范围"
 
@@ -1346,7 +1350,7 @@ msgstr "无法更新头像"
 msgid "Couldn't update messaging settings"
 msgstr "无法更新消息设置"
 
-#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2481
 #: src/pages/shell/bot-panel.tsx:184
 #: src/pages/shell/dialogs.tsx:208
 msgid "Create"
@@ -1460,8 +1464,8 @@ msgstr "默认范围"
 #: src/pages/KnowledgeSection.tsx:449
 #: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:301
-#: src/pages/Shell.tsx:2825
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2835
+#: src/pages/Shell.tsx:2866
 #: src/pages/shell/dialogs.tsx:351
 #: src/pages/shell/dialogs.tsx:412
 msgid "Delete"
@@ -1469,8 +1473,8 @@ msgstr "删除"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2822
-#: src/pages/Shell.tsx:2853
+#: src/pages/Shell.tsx:2832
+#: src/pages/Shell.tsx:2863
 msgid "Delete {0}"
 msgstr "删除 {0}"
 
@@ -1489,11 +1493,11 @@ msgstr "删除群组"
 msgid "Delete memories too"
 msgstr "同时删除记忆"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3643
 msgid "Delete space"
 msgstr ""
 
-#: src/pages/Shell.tsx:5419
+#: src/pages/Shell.tsx:5433
 msgid "deleted"
 msgstr "已删除"
 
@@ -1511,7 +1515,7 @@ msgstr "已拒绝"
 msgid "Deny"
 msgstr "拒绝"
 
-#: src/pages/ModelSettingsOverlay.tsx:340
+#: src/pages/ModelSettingsOverlay.tsx:344
 msgid "Deployment default"
 msgstr "部署默认"
 
@@ -1534,16 +1538,16 @@ msgstr ""
 msgid "Desktop update"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:40
+#: src/components/integrations/IntegrationSetup.tsx:43
 msgid "Direct MCP"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:493
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnect"
 msgstr "断开"
 
-#: src/pages/MemorySettingsOverlay.tsx:207
+#: src/pages/MemorySettingsOverlay.tsx:211
 msgid "Disconnecting…"
 msgstr "正在断开…"
 
@@ -1553,7 +1557,7 @@ msgstr "正在断开…"
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/Shell.tsx:4629
+#: src/pages/Shell.tsx:4643
 msgid "Dismiss error"
 msgstr "关闭错误"
 
@@ -1601,7 +1605,7 @@ msgstr "下载 {name}"
 msgid "Download as markdown"
 msgstr "下载为 Markdown"
 
-#: src/components/integrations/IntegrationSetup.tsx:327
+#: src/components/integrations/IntegrationSetup.tsx:336
 msgid "Download Executor"
 msgstr ""
 
@@ -1617,7 +1621,7 @@ msgstr "技能草稿"
 msgid "Duplicate"
 msgstr "复制"
 
-#: src/pages/Shell.tsx:5245
+#: src/pages/Shell.tsx:5259
 msgid "Earlier message"
 msgstr "更早的消息"
 
@@ -1638,7 +1642,7 @@ msgid "Engage when... Ignore..."
 msgstr ""
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
-#: src/pages/ModelSettingsOverlay.tsx:600
+#: src/pages/ModelSettingsOverlay.tsx:604
 #: src/pages/Onboarding.tsx:531
 msgid "Enter this code at <0>{0}</0>"
 msgstr "在 <0>{0}</0> 输入此代码"
@@ -1687,7 +1691,7 @@ msgid "Expand"
 msgstr "展开"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2589
+#: src/pages/Shell.tsx:2599
 msgid "Expand {0}"
 msgstr "展开 {0}"
 
@@ -1716,14 +1720,14 @@ msgstr "失败"
 msgid "Failed"
 msgstr "失败"
 
-#: src/pages/Shell.tsx:1981
-#: src/pages/Shell.tsx:1983
-#: src/pages/Shell.tsx:1985
+#: src/pages/Shell.tsx:1991
+#: src/pages/Shell.tsx:1993
+#: src/pages/Shell.tsx:1995
 msgid "Failed to send message"
 msgstr "发送消息失败"
 
-#: src/pages/Shell.tsx:2018
-#: src/pages/Shell.tsx:2037
+#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2047
 msgid "Failed to stop"
 msgstr "停止失败"
 
@@ -1736,18 +1740,18 @@ msgstr "失败。"
 msgid "Failure handling"
 msgstr "失败处理"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Find models"
 msgstr "查找模型"
 
-#: src/pages/ModelSettingsOverlay.tsx:439
+#: src/pages/ModelSettingsOverlay.tsx:443
 #: src/pages/Onboarding.tsx:415
 msgid "Finding…"
 msgstr "正在查找…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
-#: src/pages/ModelSettingsOverlay.tsx:560
+#: src/pages/ModelSettingsOverlay.tsx:564
 #: src/pages/Onboarding.tsx:495
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "在 <0>{0}</0> 完成登录。最后一页可能无法加载；把 URL 或代码粘贴到这里。"
@@ -1773,7 +1777,7 @@ msgstr "标记异常操作"
 msgid "Forgot password?"
 msgstr "忘记密码？"
 
-#: src/pages/ModelSettingsOverlay.tsx:1071
+#: src/pages/ModelSettingsOverlay.tsx:1075
 msgid "Free"
 msgstr "免费"
 
@@ -1786,7 +1790,7 @@ msgstr "全屏"
 msgid "General"
 msgstr "通用"
 
-#: src/components/integrations/IntegrationSetup.tsx:209
+#: src/components/integrations/IntegrationSetup.tsx:214
 msgid "Get credentials"
 msgstr ""
 
@@ -1801,8 +1805,8 @@ msgid "Git event"
 msgstr "Git 事件"
 
 #: src/pages/MessagingSettingsOverlay.tsx:204
-#: src/pages/Shell.tsx:3019
-#: src/pages/Shell.tsx:3156
+#: src/pages/Shell.tsx:3029
+#: src/pages/Shell.tsx:3166
 msgid "Group"
 msgstr "群组"
 
@@ -1844,15 +1848,15 @@ msgstr "请求头名称"
 msgid "Header value"
 msgstr "请求头值"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Hear a sample"
 msgstr "试听"
 
-#: src/pages/VoiceSettingsOverlay.tsx:131
+#: src/pages/VoiceSettingsOverlay.tsx:135
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "你好，这是我朗读回复时的声音。"
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Hide bots"
 msgstr ""
 
@@ -1881,11 +1885,11 @@ msgstr "频率"
 msgid "How to check"
 msgstr "如何检查"
 
-#: src/pages/Shell.tsx:5174
+#: src/pages/Shell.tsx:5188
 msgid "I’m done"
 msgstr "我做完了"
 
-#: src/pages/VoiceSettingsOverlay.tsx:136
+#: src/pages/VoiceSettingsOverlay.tsx:140
 msgid "If you heard that, voice is ready."
 msgstr "如果听到了，说明语音已就绪。"
 
@@ -1917,12 +1921,12 @@ msgstr "指令"
 msgid "Integration domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:133
+#: src/components/integrations/IntegrationSetup.tsx:136
 msgid "Integration options"
 msgstr ""
 
 #: src/pages/PluginsOverlay.tsx:679
-#: src/pages/Shell.tsx:2874
+#: src/pages/Shell.tsx:2884
 msgid "Integrations"
 msgstr "集成"
 
@@ -1952,11 +1956,11 @@ msgstr "隔离"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "它的对话、文件和例行任务将被永久删除。它创建的 Bot 仍留在列表中。"
 
-#: src/pages/Shell.tsx:4289
+#: src/pages/Shell.tsx:4303
 msgid "Jump to latest"
 msgstr "跳到最新"
 
-#: src/pages/Shell.tsx:5240
+#: src/pages/Shell.tsx:5254
 msgid "Jump to replied message"
 msgstr "跳到被回复的消息"
 
@@ -2014,7 +2018,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "正在听…"
 
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Load earlier messages"
 msgstr "加载更早的消息"
 
@@ -2026,12 +2030,12 @@ msgstr "正在加载动态…"
 msgid "Loading integrations…"
 msgstr "正在加载集成…"
 
-#: src/pages/MemorySettingsOverlay.tsx:182
+#: src/pages/MemorySettingsOverlay.tsx:186
 msgid "Loading memory settings…"
 msgstr "正在加载记忆设置…"
 
-#: src/pages/ModelSettingsOverlay.tsx:306
-#: src/pages/ModelSettingsOverlay.tsx:733
+#: src/pages/ModelSettingsOverlay.tsx:308
+#: src/pages/ModelSettingsOverlay.tsx:737
 msgid "Loading model catalog…"
 msgstr "正在加载模型目录…"
 
@@ -2047,15 +2051,15 @@ msgstr "正在加载规则…"
 msgid "Loading tools…"
 msgstr ""
 
-#: src/pages/VoiceSettingsOverlay.tsx:210
+#: src/pages/VoiceSettingsOverlay.tsx:214
 msgid "Loading voice providers…"
 msgstr "正在加载语音提供方…"
 
-#: src/App.tsx:58
+#: src/App.tsx:65
 #: src/pages/IntegrationSetup.tsx:72
 #: src/pages/Onboarding.tsx:282
 #: src/pages/PeerMessagesOverlay.tsx:98
-#: src/pages/Shell.tsx:4188
+#: src/pages/Shell.tsx:4202
 msgid "Loading…"
 msgstr "加载中…"
 
@@ -2067,7 +2071,11 @@ msgstr "本地"
 msgid "Local access lets bots run commands without asking. Avoid it on shared or public servers."
 msgstr "本地访问权限允许 Bot 无需询问就执行命令。请勿在共享或公开服务器上启用。"
 
-#: src/pages/Shell.tsx:2932
+#: src/pages/LocalSettings.tsx:22
+msgid "Local Server Settings"
+msgstr ""
+
+#: src/pages/Shell.tsx:2942
 msgid "Log out"
 msgstr "退出登录"
 
@@ -2083,8 +2091,8 @@ msgstr "管理 MCP 服务器"
 msgid "Manage messaging settings"
 msgstr "管理消息设置"
 
-#: src/pages/MemorySettingsOverlay.tsx:159
-#: src/pages/MemorySettingsOverlay.tsx:173
+#: src/pages/MemorySettingsOverlay.tsx:163
+#: src/pages/MemorySettingsOverlay.tsx:177
 msgid "Manage the Space semantic memory provider."
 msgstr "管理工作区语义记忆提供方。"
 
@@ -2125,7 +2133,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "成员（选择 {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} 个）"
 
 #: src/pages/KnowledgeSection.tsx:39
-#: src/pages/MemorySettingsOverlay.tsx:155
+#: src/pages/MemorySettingsOverlay.tsx:159
 #: src/pages/SettingsOverlay.tsx:94
 msgid "Memory"
 msgstr "记忆"
@@ -2134,7 +2142,7 @@ msgstr "记忆"
 msgid "Memory scope"
 msgstr "记忆范围"
 
-#: src/pages/Shell.tsx:4697
+#: src/pages/Shell.tsx:4711
 msgid "Mentions"
 msgstr "提及"
 
@@ -2142,8 +2150,8 @@ msgstr "提及"
 msgid "Mentions only"
 msgstr ""
 
-#: src/pages/Shell.tsx:4898
-#: src/pages/Shell.tsx:5025
+#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:5039
 msgid "Message"
 msgstr "消息"
 
@@ -2152,12 +2160,12 @@ msgstr "消息"
 msgid "Message"
 msgstr "消息"
 
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4898
+#: src/pages/Shell.tsx:4908
+#: src/pages/Shell.tsx:4912
 msgid "Message {activeName}"
 msgstr "给 {activeName} 发消息"
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4623
 msgid "Message composer"
 msgstr "消息输入框"
 
@@ -2166,15 +2174,15 @@ msgstr "消息输入框"
 msgid "Message event"
 msgstr ""
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Message from {peer}"
 msgstr "来自 {peer} 的消息"
 
-#: src/pages/Shell.tsx:4895
+#: src/pages/Shell.tsx:4909
 msgid "Message…"
 msgstr "消息…"
 
-#: src/pages/Shell.tsx:5310
+#: src/pages/Shell.tsx:5324
 msgid "Messaged {peer}"
 msgstr "已发给 {peer}"
 
@@ -2195,8 +2203,8 @@ msgstr "最低"
 msgid "Minimize"
 msgstr "最小化"
 
-#: src/pages/Shell.tsx:2461
-#: src/pages/Shell.tsx:2462
+#: src/pages/Shell.tsx:2471
+#: src/pages/Shell.tsx:2472
 msgid "Minimize bots"
 msgstr ""
 
@@ -2208,9 +2216,9 @@ msgstr "分钟"
 msgid "minutes"
 msgstr "分钟"
 
-#: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/ModelSettingsOverlay.tsx:509
-#: src/pages/ModelSettingsOverlay.tsx:959
+#: src/pages/ModelSettingsOverlay.tsx:448
+#: src/pages/ModelSettingsOverlay.tsx:513
+#: src/pages/ModelSettingsOverlay.tsx:963
 #: src/pages/Onboarding.tsx:420
 #: src/pages/Onboarding.tsx:468
 #: src/pages/Onboarding.tsx:476
@@ -2218,12 +2226,12 @@ msgstr "分钟"
 msgid "Model"
 msgstr "模型"
 
-#: src/pages/ModelSettingsOverlay.tsx:478
+#: src/pages/ModelSettingsOverlay.tsx:482
 #: src/pages/Onboarding.tsx:442
 msgid "Model id"
 msgstr "模型 ID"
 
-#: src/pages/ModelSettingsOverlay.tsx:995
+#: src/pages/ModelSettingsOverlay.tsx:999
 msgid "Model options"
 msgstr "模型选项"
 
@@ -2235,16 +2243,21 @@ msgstr ""
 msgid "Model spend uses your provider keys."
 msgstr "模型费用使用你的提供方密钥。"
 
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Model updated."
 msgstr "模型已更新。"
 
-#: src/pages/ModelSettingsOverlay.tsx:317
+#: src/pages/LocalSettings.tsx:36
+#: src/pages/ModelSettingsOverlay.tsx:321
 #: src/pages/SettingsOverlay.tsx:93
 msgid "Models"
 msgstr "模型"
 
-#: src/pages/ModelSettingsOverlay.tsx:457
+#: src/pages/ModelSettingsOverlay.tsx:310
+msgid "Models for the server owner’s default space."
+msgstr ""
+
+#: src/pages/ModelSettingsOverlay.tsx:461
 #: src/pages/Onboarding.tsx:426
 msgid "Models from server"
 msgstr "来自服务器的模型"
@@ -2253,7 +2266,7 @@ msgstr "来自服务器的模型"
 msgid "Monthly"
 msgstr "每月"
 
-#: src/pages/Shell.tsx:5082
+#: src/pages/Shell.tsx:5096
 msgid "More"
 msgstr ""
 
@@ -2303,7 +2316,7 @@ msgstr "需要输入"
 msgid "Needs takeover"
 msgstr "需要接管"
 
-#: src/pages/Shell.tsx:3897
+#: src/pages/Shell.tsx:3911
 msgid "Needs you"
 msgstr ""
 
@@ -2381,7 +2394,7 @@ msgstr "已停用"
 msgid "No managed app catalog is configured on this deployment."
 msgstr "此部署未配置托管应用目录。"
 
-#: src/pages/ModelSettingsOverlay.tsx:1023
+#: src/pages/ModelSettingsOverlay.tsx:1027
 msgid "No matching models"
 msgstr "没有匹配的模型"
 
@@ -2397,7 +2410,7 @@ msgstr "还没有 MCP 服务器。"
 msgid "No messages with {peerBotName} yet."
 msgstr "还没有与 {peerBotName} 的消息。"
 
-#: src/pages/ModelSettingsOverlay.tsx:737
+#: src/pages/ModelSettingsOverlay.tsx:741
 msgid "No model catalog is available."
 msgstr "没有可用的模型目录。"
 
@@ -2405,11 +2418,11 @@ msgstr "没有可用的模型目录。"
 msgid "No providers found"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:397
+#: src/pages/ModelSettingsOverlay.tsx:401
 msgid "No providers found."
 msgstr "未找到提供方。"
 
-#: src/components/integrations/IntegrationSetup.tsx:264
+#: src/components/integrations/IntegrationSetup.tsx:273
 msgid "No remote MCP servers found"
 msgstr ""
 
@@ -2442,7 +2455,7 @@ msgstr "无触发器"
 msgid "None yet"
 msgstr "暂无"
 
-#: src/pages/ModelSettingsOverlay.tsx:540
+#: src/pages/ModelSettingsOverlay.tsx:544
 msgid "Not connected"
 msgstr "未连接"
 
@@ -2463,7 +2476,7 @@ msgid "Now"
 msgstr "现在"
 
 #. placeholder {0}: selected.label
-#: src/pages/ModelSettingsOverlay.tsx:243
+#: src/pages/ModelSettingsOverlay.tsx:245
 msgid "Now using {0}."
 msgstr "正在使用 {0}。"
 
@@ -2496,26 +2509,26 @@ msgstr "每月 1 日 {0}"
 msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
 msgstr ""
 
-#: src/pages/Shell.tsx:3671
+#: src/pages/Shell.tsx:3681
 msgid "Only empty spaces can be deleted. Delete its bots and groups first."
 msgstr ""
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3234
-#: src/pages/Shell.tsx:3239
+#: src/pages/Shell.tsx:3244
+#: src/pages/Shell.tsx:3249
 msgid "Open"
 msgstr "打开"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2597
 msgid "Open {0}"
 msgstr "打开 {0}"
 
-#: src/pages/Shell.tsx:3202
+#: src/pages/Shell.tsx:3212
 msgid "Open in full window"
 msgstr "在完整窗口中打开"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3001
 msgid "Open navigation"
 msgstr "打开导航"
 
@@ -2523,20 +2536,20 @@ msgstr "打开导航"
 msgid "Open work"
 msgstr "待办"
 
-#: src/pages/ModelSettingsOverlay.tsx:417
+#: src/pages/ModelSettingsOverlay.tsx:421
 #: src/pages/Onboarding.tsx:395
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI 兼容服务器 URL"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5444
 msgid "Opened its thread."
 msgstr "已打开其对话。"
 
-#: src/App.tsx:195
+#: src/App.tsx:202
 msgid "Opening your Space…"
 msgstr "正在打开工作区…"
 
-#: src/pages/ModelSettingsOverlay.tsx:650
+#: src/pages/ModelSettingsOverlay.tsx:654
 #: src/pages/Onboarding.tsx:569
 msgid "Optional"
 msgstr "可选"
@@ -2549,7 +2562,7 @@ msgstr "多数人用不到的可选项"
 msgid "Optional header value"
 msgstr "可选请求头值"
 
-#: src/pages/ModelSettingsOverlay.tsx:664
+#: src/pages/ModelSettingsOverlay.tsx:668
 msgid "Or connect an API key"
 msgstr "或连接 API 密钥"
 
@@ -2565,7 +2578,7 @@ msgstr "自然"
 msgid "Organization API key"
 msgstr "组织 API 密钥"
 
-#: src/pages/ModelSettingsOverlay.tsx:465
+#: src/pages/ModelSettingsOverlay.tsx:469
 #: src/pages/Onboarding.tsx:435
 msgid "Other model…"
 msgstr "其他模型…"
@@ -2600,16 +2613,16 @@ msgstr "密码已更新"
 msgid "Passwords do not match"
 msgstr "两次密码不一致"
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste a replacement key"
 msgstr "粘贴替换密钥"
 
-#: src/pages/ModelSettingsOverlay.tsx:428
+#: src/pages/ModelSettingsOverlay.tsx:432
 #: src/pages/Onboarding.tsx:406
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "粘贴服务器的 OpenAI 兼容地址。需要时 Rakazo 会补上 /v1。"
 
-#: src/pages/VoiceSettingsOverlay.tsx:227
+#: src/pages/VoiceSettingsOverlay.tsx:231
 msgid "Paste your API key"
 msgstr "粘贴你的 API 密钥"
 
@@ -2617,7 +2630,7 @@ msgstr "粘贴你的 API 密钥"
 msgid "Paused"
 msgstr "已暂停"
 
-#: src/pages/ModelSettingsOverlay.tsx:534
+#: src/pages/ModelSettingsOverlay.tsx:538
 msgid "Personal credential"
 msgstr "个人凭据"
 
@@ -2625,7 +2638,7 @@ msgstr "个人凭据"
 msgid "Pin"
 msgstr "置顶"
 
-#: src/pages/VoiceSettingsOverlay.tsx:272
+#: src/pages/VoiceSettingsOverlay.tsx:276
 msgid "Playing…"
 msgstr "播放中…"
 
@@ -2642,17 +2655,17 @@ msgstr "预览 {0}"
 msgid "Private"
 msgstr "私有"
 
-#: src/components/integrations/IntegrationSetup.tsx:177
+#: src/components/integrations/IntegrationSetup.tsx:182
 msgid "Project ID"
 msgstr ""
 
-#: src/pages/MemorySettingsOverlay.tsx:215
+#: src/pages/MemorySettingsOverlay.tsx:219
 #: src/pages/Onboarding.tsx:292
 msgid "Provider"
 msgstr "提供方"
 
-#: src/pages/ModelSettingsOverlay.tsx:352
-#: src/pages/VoiceSettingsOverlay.tsx:166
+#: src/pages/ModelSettingsOverlay.tsx:356
+#: src/pages/VoiceSettingsOverlay.tsx:170
 msgid "Providers"
 msgstr "提供方"
 
@@ -2684,7 +2697,7 @@ msgstr "最近"
 msgid "Reconnect OAuth"
 msgstr "重新连接 OAuth"
 
-#: src/App.tsx:150
+#: src/App.tsx:157
 #: src/components/ComputerUpdateProgress.tsx:54
 msgid "Reconnecting"
 msgstr "正在重新连接"
@@ -2747,7 +2760,7 @@ msgstr ""
 msgid "Refreshing…"
 msgstr ""
 
-#: src/pages/Shell.tsx:5164
+#: src/pages/Shell.tsx:5178
 msgid "Release"
 msgstr "释放"
 
@@ -2767,7 +2780,7 @@ msgid "Remove"
 msgstr "移除"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4683
+#: src/pages/Shell.tsx:4697
 msgid "Remove {0}"
 msgstr "移除 {0}"
 
@@ -2776,7 +2789,7 @@ msgid "Remove Git event"
 msgstr ""
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4845
 msgid "Remove mention {0}"
 msgstr "移除提及 {0}"
 
@@ -2789,13 +2802,13 @@ msgid "Remove schedule"
 msgstr "移除计划"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4824
 msgid "Remove skill {0}"
 msgstr "移除技能 {0}"
 
-#: src/pages/Shell.tsx:4262
-#: src/pages/Shell.tsx:5060
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:4276
+#: src/pages/Shell.tsx:5074
+#: src/pages/Shell.tsx:5111
 msgid "Remove thumbs-up"
 msgstr "取消点赞"
 
@@ -2803,7 +2816,7 @@ msgstr "取消点赞"
 msgid "Remove webhook"
 msgstr "移除 Webhook"
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5443
 msgid "Removed with chat, computer, and memory."
 msgstr "已连同对话、电脑和记忆一起移除。"
 
@@ -2822,21 +2835,21 @@ msgstr "正在移除…"
 msgid "Reopen"
 msgstr "重新打开"
 
-#: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/ModelSettingsOverlay.tsx:695
+#: src/pages/ModelSettingsOverlay.tsx:666
+#: src/pages/ModelSettingsOverlay.tsx:699
 msgid "Replace API key"
 msgstr "替换 API 密钥"
 
-#: src/pages/VoiceSettingsOverlay.tsx:239
+#: src/pages/VoiceSettingsOverlay.tsx:243
 msgid "Replace key"
 msgstr "替换密钥"
 
-#: src/pages/Shell.tsx:5074
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5088
+#: src/pages/Shell.tsx:5119
 msgid "Reply"
 msgstr "回复"
 
-#: src/pages/Shell.tsx:4646
+#: src/pages/Shell.tsx:4660
 msgid "Replying to {replyName}"
 msgstr "正在回复 {replyName}"
 
@@ -2870,8 +2883,8 @@ msgstr "正在重置…"
 msgid "Restart to update"
 msgstr ""
 
-#: src/pages/Shell.tsx:2816
-#: src/pages/Shell.tsx:2847
+#: src/pages/Shell.tsx:2826
+#: src/pages/Shell.tsx:2857
 msgid "Restore"
 msgstr "恢复"
 
@@ -2883,12 +2896,12 @@ msgstr "还原上次保存的工作区。电脑上未保存的工作会丢失。
 msgid "Restoring your workspace"
 msgstr ""
 
-#: src/App.tsx:164
+#: src/App.tsx:171
 #: src/pages/PeerMessagesOverlay.tsx:109
 msgid "Retry now"
 msgstr "立即重试"
 
-#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2398
 msgid "Retry screen"
 msgstr ""
 
@@ -2918,8 +2931,8 @@ msgid "Rotate key"
 msgstr "轮换密钥"
 
 #: src/pages/RoutineEditor.tsx:265
-#: src/pages/Shell.tsx:3419
-#: src/pages/Shell.tsx:3431
+#: src/pages/Shell.tsx:3429
+#: src/pages/Shell.tsx:3441
 msgid "Routine"
 msgstr "例行任务"
 
@@ -2936,7 +2949,7 @@ msgstr "运行时间"
 msgid "Run history"
 msgstr "运行记录"
 
-#: src/pages/Shell.tsx:3412
+#: src/pages/Shell.tsx:3422
 msgid "Run time must be in the future."
 msgstr "运行时间必须是将来的时间。"
 
@@ -2966,7 +2979,7 @@ msgstr ""
 #: src/pages/GroupPanel.tsx:236
 #: src/pages/KnowledgeSection.tsx:203
 #: src/pages/KnowledgeSection.tsx:422
-#: src/pages/ModelSettingsOverlay.tsx:693
+#: src/pages/ModelSettingsOverlay.tsx:697
 #: src/pages/RoutineEditor.tsx:489
 #: src/pages/shell/bot-panel.tsx:539
 msgid "Save"
@@ -2983,7 +2996,7 @@ msgstr "已保存"
 msgid "Saved, but list refresh failed"
 msgstr "已保存，但列表刷新失败"
 
-#: src/pages/ModelSettingsOverlay.tsx:282
+#: src/pages/ModelSettingsOverlay.tsx:284
 msgid "Saved."
 msgstr "已保存。"
 
@@ -3002,7 +3015,7 @@ msgstr ""
 #: src/components/AskCard.tsx:157
 #: src/components/teach/SkillDraftCard.tsx:142
 #: src/pages/GroupPanel.tsx:236
-#: src/pages/ModelSettingsOverlay.tsx:691
+#: src/pages/ModelSettingsOverlay.tsx:695
 #: src/pages/RoutineEditor.tsx:489
 msgid "Saving…"
 msgstr "正在保存…"
@@ -3016,15 +3029,15 @@ msgstr "说点什么。静音即发送。"
 msgid "Say yes or no, or answer in a sentence."
 msgstr "回答是或否，或一句话说明。"
 
-#: src/pages/ModelSettingsOverlay.tsx:984
+#: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
-#: src/pages/Shell.tsx:2530
+#: src/pages/Shell.tsx:2540
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "搜索"
 
-#: src/components/integrations/IntegrationSetup.tsx:241
-#: src/components/integrations/IntegrationSetup.tsx:242
+#: src/components/integrations/IntegrationSetup.tsx:250
+#: src/components/integrations/IntegrationSetup.tsx:251
 #: src/pages/PluginsOverlay.tsx:696
 #: src/pages/PluginsOverlay.tsx:697
 msgid "Search apps"
@@ -3038,11 +3051,11 @@ msgstr ""
 msgid "Search by domain"
 msgstr ""
 
-#: src/components/integrations/IntegrationSetup.tsx:247
+#: src/components/integrations/IntegrationSetup.tsx:256
 msgid "Search integrations.sh"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:979
+#: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr "搜索模型"
 
@@ -3051,8 +3064,8 @@ msgstr "搜索模型"
 msgid "Search or create Bots"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:355
-#: src/pages/ModelSettingsOverlay.tsx:361
+#: src/pages/ModelSettingsOverlay.tsx:359
+#: src/pages/ModelSettingsOverlay.tsx:365
 msgid "Search providers"
 msgstr "搜索提供方"
 
@@ -3066,7 +3079,7 @@ msgstr "搜索提供方和模型"
 msgid "Searching…"
 msgstr "正在搜索…"
 
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3030
 msgid "Select a bot"
 msgstr "选择 Bot"
 
@@ -3074,8 +3087,8 @@ msgstr "选择 Bot"
 msgid "Selected"
 msgstr ""
 
-#: src/pages/Shell.tsx:4929
-#: src/pages/Shell.tsx:4950
+#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4964
 msgid "Send"
 msgstr "发送"
 
@@ -3105,8 +3118,9 @@ msgstr "正在发送…"
 msgid "Sentry alert"
 msgstr "Sentry 告警"
 
-#: src/components/integrations/IntegrationSetup.tsx:129
+#: src/components/integrations/IntegrationSetup.tsx:132
 #: src/pages/AccountSettingsOverlay.tsx:158
+#: src/pages/LocalSettings.tsx:42
 msgid "Server integrations"
 msgstr ""
 
@@ -3114,33 +3128,33 @@ msgstr ""
 msgid "Server name"
 msgstr "服务器名称"
 
-#: src/components/integrations/IntegrationSetup.tsx:273
-#: src/components/integrations/IntegrationSetup.tsx:291
+#: src/components/integrations/IntegrationSetup.tsx:282
+#: src/components/integrations/IntegrationSetup.tsx:300
 #: src/pages/McpServersOverlay.tsx:329
-#: src/pages/ModelSettingsOverlay.tsx:412
+#: src/pages/ModelSettingsOverlay.tsx:416
 #: src/pages/Onboarding.tsx:390
 msgid "Server URL"
 msgstr "服务器 URL"
 
 #: src/pages/MessagingSettingsOverlay.tsx:361
 #: src/pages/SettingsOverlay.tsx:103
-#: src/pages/SettingsOverlay.tsx:151
-#: src/pages/Shell.tsx:2896
-#: src/pages/Shell.tsx:2903
-#: src/pages/Shell.tsx:3152
+#: src/pages/SettingsOverlay.tsx:158
+#: src/pages/Shell.tsx:2906
+#: src/pages/Shell.tsx:2913
+#: src/pages/Shell.tsx:3162
 msgid "Settings"
 msgstr "设置"
 
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4982
 msgid "Settings: General"
 msgstr "设置：通用"
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4984
 msgid "Settings: Usage"
 msgstr "设置：用量"
 
-#: src/components/integrations/IntegrationSetup.tsx:319
-#: src/pages/ModelSettingsOverlay.tsx:425
+#: src/components/integrations/IntegrationSetup.tsx:328
+#: src/pages/ModelSettingsOverlay.tsx:429
 #: src/pages/Onboarding.tsx:403
 msgid "Setup help"
 msgstr "设置帮助"
@@ -3158,11 +3172,11 @@ msgstr "共享文档"
 msgid "Show all providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2952
 msgid "Show bots"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show computer"
 msgstr "显示电脑"
 
@@ -3178,14 +3192,14 @@ msgstr "显示密码"
 msgid "Show popular providers"
 msgstr ""
 
-#: src/pages/Shell.tsx:3176
+#: src/pages/Shell.tsx:3186
 msgid "Show settings"
 msgstr "显示设置"
 
 #: src/lib/localized-provider-hint.ts:7
 #: src/pages/Auth.tsx:230
 #: src/pages/Auth.tsx:288
-#: src/pages/ModelSettingsOverlay.tsx:632
+#: src/pages/ModelSettingsOverlay.tsx:636
 #: src/pages/Onboarding.tsx:152
 msgid "Sign in"
 msgstr "登录"
@@ -3200,7 +3214,7 @@ msgid "Sign up"
 msgstr "注册"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4758
 msgid "Skill {0}"
 msgstr "技能 {0}"
 
@@ -3208,8 +3222,8 @@ msgstr "技能 {0}"
 msgid "Skills"
 msgstr "技能"
 
-#: src/components/integrations/IntegrationSetup.tsx:355
-#: src/pages/Shell.tsx:5171
+#: src/components/integrations/IntegrationSetup.tsx:364
+#: src/pages/Shell.tsx:5185
 msgid "Skip"
 msgstr "跳过"
 
@@ -3218,7 +3232,7 @@ msgid "Skip or deploy key"
 msgstr "跳过或使用部署密钥"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1842
+#: src/pages/Shell.tsx:1852
 msgid "Skipped {0}"
 msgstr "已跳过 {0}"
 
@@ -3250,21 +3264,21 @@ msgstr "空格键打断 · Esc 挂断"
 msgid "Spaces"
 msgstr ""
 
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Speak"
 msgstr "朗读"
 
-#: src/pages/VoiceSettingsOverlay.tsx:190
+#: src/pages/VoiceSettingsOverlay.tsx:194
 msgid "Speak + transcribe"
 msgstr "朗读 + 转写"
 
-#: src/pages/VoiceSettingsOverlay.tsx:192
+#: src/pages/VoiceSettingsOverlay.tsx:196
 msgid "Speak only"
 msgstr "仅朗读"
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Speak this reply"
 msgstr "朗读这条回复"
 
@@ -3281,7 +3295,7 @@ msgid "Starting"
 msgstr "正在开始"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
-#: src/pages/ModelSettingsOverlay.tsx:630
+#: src/pages/ModelSettingsOverlay.tsx:634
 #: src/pages/Onboarding.tsx:554
 msgid "Starting…"
 msgstr "正在开始…"
@@ -3290,11 +3304,11 @@ msgstr "正在开始…"
 msgid "Steps"
 msgstr "步骤"
 
-#: src/pages/Shell.tsx:3912
-#: src/pages/Shell.tsx:3917
-#: src/pages/Shell.tsx:4939
-#: src/pages/Shell.tsx:5278
-#: src/pages/Shell.tsx:5529
+#: src/pages/Shell.tsx:3926
+#: src/pages/Shell.tsx:3931
+#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:5292
+#: src/pages/Shell.tsx:5543
 msgid "Stop"
 msgstr "停止"
 
@@ -3302,8 +3316,8 @@ msgstr "停止"
 msgid "Stop all workers and confirm that provider operations have stopped before releasing this computer."
 msgstr ""
 
-#: src/pages/Shell.tsx:5274
-#: src/pages/Shell.tsx:5525
+#: src/pages/Shell.tsx:5288
+#: src/pages/Shell.tsx:5539
 msgid "Stop speaking"
 msgstr "停止朗读"
 
@@ -3321,20 +3335,20 @@ msgstr "已停止。"
 msgid "Stored encrypted"
 msgstr "已加密存储"
 
-#: src/pages/ModelSettingsOverlay.tsx:545
+#: src/pages/ModelSettingsOverlay.tsx:549
 msgid "Stored securely. Never shown here."
 msgstr "已安全存储。不会显示在这里。"
 
-#: src/pages/Shell.tsx:5383
+#: src/pages/Shell.tsx:5397
 msgid "subagent"
 msgstr "子 Agent"
 
-#: src/pages/ModelSettingsOverlay.tsx:590
+#: src/pages/ModelSettingsOverlay.tsx:594
 #: src/pages/Onboarding.tsx:521
 msgid "Submit"
 msgstr "提交"
 
-#: src/pages/ModelSettingsOverlay.tsx:503
+#: src/pages/ModelSettingsOverlay.tsx:507
 #: src/pages/Onboarding.tsx:462
 msgid "Supports thinking"
 msgstr "支持思考"
@@ -3343,7 +3357,7 @@ msgstr "支持思考"
 msgid "Switch bot"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:723
+#: src/pages/ModelSettingsOverlay.tsx:727
 msgid "Switching…"
 msgstr "正在切换…"
 
@@ -3356,7 +3370,7 @@ msgstr "系统"
 msgid "Teach a task"
 msgstr "示范任务"
 
-#: src/pages/Shell.tsx:3076
+#: src/pages/Shell.tsx:3086
 msgid "Teaching in progress. Stop teaching before sending a new message."
 msgstr "正在示范，发送新消息前请先停止示范。"
 
@@ -3364,7 +3378,7 @@ msgstr "正在示范，发送新消息前请先停止示范。"
 msgid "Team"
 msgstr "团队"
 
-#: src/pages/Shell.tsx:5652
+#: src/pages/Shell.tsx:5666
 msgid "Team Computer"
 msgstr "团队电脑"
 
@@ -3394,7 +3408,7 @@ msgstr "测试运行"
 msgid "The API did not come back. Refresh this page."
 msgstr "API 未恢复。请刷新此页面。"
 
-#: src/pages/MemorySettingsOverlay.tsx:241
+#: src/pages/MemorySettingsOverlay.tsx:245
 msgid "The selected memory provider is not available in this build."
 msgstr "所选记忆提供方在此构建中不可用。"
 
@@ -3402,7 +3416,7 @@ msgstr "所选记忆提供方在此构建中不可用。"
 msgid "Thinking"
 msgstr "思考"
 
-#: src/pages/Shell.tsx:5632
+#: src/pages/Shell.tsx:5646
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "此 Bot 运行在这台电脑上，而不是 Linux 桌面。Shell 和文件使用你的主目录。"
 
@@ -3455,7 +3469,7 @@ msgstr "此服务器已连接。请先断开再重新授权。"
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools. A popup will open."
 msgstr "此服务器使用浏览器登录。授权后 Agent 才能使用其工具，将打开弹窗。"
 
-#: src/pages/ModelSettingsOverlay.tsx:705
+#: src/pages/ModelSettingsOverlay.tsx:709
 msgid "This subscription sign-in is not available in Rakazo yet. Use a deployment credential or choose another provider."
 msgstr "此订阅登录在 Rakazo 中尚不可用。请使用部署凭据或选择其他提供方。"
 
@@ -3514,7 +3528,7 @@ msgid "Unpin"
 msgstr "取消置顶"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1920
+#: src/pages/Shell.tsx:1930
 msgid "Unsupported file type: {0}"
 msgstr "不支持的文件类型：{0}"
 
@@ -3574,8 +3588,8 @@ msgstr "正在更新…"
 
 #: src/pages/AccountSettingsOverlay.tsx:199
 #: src/pages/SettingsOverlay.tsx:96
-#: src/pages/Shell.tsx:2908
-#: src/pages/Shell.tsx:2919
+#: src/pages/Shell.tsx:2918
+#: src/pages/Shell.tsx:2929
 msgid "Usage"
 msgstr "用量"
 
@@ -3583,7 +3597,7 @@ msgstr "用量"
 msgid "Use {hostLabel}"
 msgstr "使用 {hostLabel}"
 
-#: src/pages/ModelSettingsOverlay.tsx:490
+#: src/pages/ModelSettingsOverlay.tsx:494
 #: src/pages/Onboarding.tsx:454
 msgid "Use a found model"
 msgstr "使用找到的模型"
@@ -3593,7 +3607,7 @@ msgstr "使用找到的模型"
 msgid "Use default guidance"
 msgstr ""
 
-#: src/pages/ModelSettingsOverlay.tsx:725
+#: src/pages/ModelSettingsOverlay.tsx:729
 msgid "Use this model"
 msgstr "使用此模型"
 
@@ -3606,16 +3620,16 @@ msgid "Verifying…"
 msgstr "正在校验…"
 
 #: src/pages/SettingsOverlay.tsx:95
-#: src/pages/Shell.tsx:4916
-#: src/pages/Shell.tsx:4917
+#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:4931
 #: src/pages/shell/bot-panel.tsx:482
-#: src/pages/VoiceSettingsOverlay.tsx:150
-#: src/pages/VoiceSettingsOverlay.tsx:249
+#: src/pages/VoiceSettingsOverlay.tsx:154
+#: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Voice"
 msgstr "语音"
 
-#: src/pages/ModelSettingsOverlay.tsx:594
-#: src/pages/ModelSettingsOverlay.tsx:616
+#: src/pages/ModelSettingsOverlay.tsx:598
+#: src/pages/ModelSettingsOverlay.tsx:620
 #: src/pages/Onboarding.tsx:525
 #: src/pages/Onboarding.tsx:547
 msgid "Waiting for sign-in…"
@@ -3687,8 +3701,8 @@ msgstr ""
 msgid "Working…"
 msgstr "处理中…"
 
-#: src/pages/Shell.tsx:1616
-#: src/pages/Shell.tsx:2393
+#: src/pages/Shell.tsx:1626
+#: src/pages/Shell.tsx:2403
 msgid "You"
 msgstr "你"
 
@@ -3700,7 +3714,7 @@ msgstr "如果没有自动跳转，可以关闭此标签页。"
 msgid "You can close this window."
 msgstr "可以关闭此窗口。"
 
-#: src/pages/Shell.tsx:3901
+#: src/pages/Shell.tsx:3915
 msgid "You have control"
 msgstr "你已接管"
 

--- a/apps/web/src/pages/LocalSettings.tsx
+++ b/apps/web/src/pages/LocalSettings.tsx
@@ -1,0 +1,54 @@
+import { Trans } from "@lingui/react/macro";
+import { Button } from "@rakazo/ui-web";
+import { useEffect, useState } from "react";
+import { IntegrationSetup } from "../components/integrations/IntegrationSetup";
+import { rpc } from "../lib/rpc";
+import { ModelSettingsOverlay } from "./ModelSettingsOverlay";
+
+export function LocalSettingsPage() {
+  const [section, setSection] = useState<"models" | "integrations" | null>(null);
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState(false);
+  useEffect(() => {
+    void rpc.integrationSetup
+      .get()
+      .then(() => setReady(true))
+      .catch(() => setError(true));
+  }, []);
+  return (
+    <main className="h-full overflow-auto bg-background px-6 py-12">
+      <div className="mx-auto max-w-xl space-y-6">
+        <h1 className="text-2xl font-medium">
+          <Trans>Local Server Settings</Trans>
+        </h1>
+        {error ? (
+          <p role="alert">
+            <Trans>
+              Could not open local settings. Start the local server and create its owner account,
+              then try again.
+            </Trans>
+          </p>
+        ) : null}
+        {ready ? (
+          <>
+            <nav className="flex gap-2">
+              <Button variant="outline" onClick={() => setSection("models")}>
+                <Trans>Models</Trans>
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => setSection(section === "integrations" ? null : "integrations")}
+              >
+                <Trans>Server integrations</Trans>
+              </Button>
+            </nav>
+            {section === "models" ? (
+              <ModelSettingsOverlay onClose={() => setSection(null)} localOwner />
+            ) : null}
+            {section === "integrations" ? <IntegrationSetup serverSetup managedOnly /> : null}
+          </>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -34,7 +34,13 @@ import type { ModelCatalogEntry, ModelCredential } from "../lib/model-auth";
 import { rpc } from "../lib/rpc";
 import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
 
-export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
+export function ModelSettingsOverlay({
+  onClose,
+  localOwner = false,
+}: {
+  onClose: () => void;
+  localOwner?: boolean;
+}) {
   const { t } = useLingui();
   const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
   const [credentials, setCredentials] = useState<ModelCredential[]>([]);
@@ -314,6 +320,8 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
             <DialogDescription className="mt-1 text-[13.5px] text-muted-foreground/70">
               {loading ? (
                 <Trans>Loading model catalog…</Trans>
+              ) : localOwner ? (
+                <Trans>Models for the server owner’s default space.</Trans>
               ) : (
                 <Trans>Choose which connected model Rakazo uses.</Trans>
               )}

--- a/infra/compose/docker-compose.images.yml
+++ b/infra/compose/docker-compose.images.yml
@@ -118,6 +118,7 @@ services:
     environment:
       NODE_ENV: production
       API_HOST: "0.0.0.0"
+      RAKAZO_DESKTOP_STACK_TOKEN: ${RAKAZO_DESKTOP_STACK_TOKEN:-}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://127.0.0.1:5173}
       WEB_ORIGIN: ${WEB_ORIGIN:-http://127.0.0.1:5173}
       API_URL: ${API_URL:-http://127.0.0.1:5173}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,7 +8,8 @@
       "types": "./src/index.ts",
       "development": "./src/index.ts",
       "default": "./src/index.ts"
-    }
+    },
+    "./local-settings": "./src/local-settings.js"
   },
   "scripts": {
     "check": "tsc --noEmit -p tsconfig.json",

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -37,6 +37,10 @@ export interface RakazoDesktopOAuthCallback {
 }
 
 export interface RakazoDesktop {
+  /** Only the isolated local settings window is authorized to call this bridge. */
+  localSettings?: {
+    request: (pathname: string, body: string) => Promise<{ status: number; body: string }>;
+  };
   platform: string;
   window: {
     close: () => Promise<void>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,6 +5,7 @@ export * from "./domain.js";
 export * from "./events.js";
 export * from "./ids.js";
 export * from "./integration-settings.js";
+export * from "./local-settings.js";
 export * from "./mcp.js";
 export * from "./openai-compatible-ui.js";
 export * from "./rpc.js";

--- a/packages/contracts/src/local-settings.d.ts
+++ b/packages/contracts/src/local-settings.d.ts
@@ -1,0 +1,4 @@
+export const LOCAL_SETTINGS_PAGE: `/${string}`;
+export const LOCAL_SETTINGS_RPC: `/${string}`;
+export const LOCAL_SETTINGS_TOKEN_HEADER: string;
+export function isLocalSettingsProcedure(pathname: string): boolean;

--- a/packages/contracts/src/local-settings.js
+++ b/packages/contracts/src/local-settings.js
@@ -19,7 +19,8 @@ const procedures = new Set([
   "integrationSetup/save",
 ]);
 
-export function isLocalSettingsProcedure(pathname: string): boolean {
+/** @param {string} pathname */
+export function isLocalSettingsProcedure(pathname) {
   return (
     pathname.startsWith(`${LOCAL_SETTINGS_RPC}/`) &&
     procedures.has(pathname.slice(LOCAL_SETTINGS_RPC.length + 1))

--- a/packages/contracts/src/local-settings.ts
+++ b/packages/contracts/src/local-settings.ts
@@ -1,0 +1,27 @@
+/** Local host capability: limited to server configuration and its owner's model settings. */
+export const LOCAL_SETTINGS_PAGE = "/desktop-settings";
+export const LOCAL_SETTINGS_RPC = "/api/desktop-settings/rpc";
+export const LOCAL_SETTINGS_TOKEN_HEADER = "x-rakazo-local-settings-token";
+
+const procedures = new Set([
+  "me",
+  "models/list",
+  "models/credentials",
+  "models/connect",
+  "models/probeOpenAiCompatible",
+  "models/beginOAuth",
+  "models/submitOAuthCode",
+  "models/completeOAuth",
+  "models/finishOAuth",
+  "models/cancelOAuth",
+  "models/setDefault",
+  "integrationSetup/get",
+  "integrationSetup/save",
+]);
+
+export function isLocalSettingsProcedure(pathname: string): boolean {
+  return (
+    pathname.startsWith(`${LOCAL_SETTINGS_RPC}/`) &&
+    procedures.has(pathname.slice(LOCAL_SETTINGS_RPC.length + 1))
+  );
+}


### PR DESCRIPTION
## Why

Desktop users running Rakazo on their own computer need to change models and server integrations after setup, including while signed out. The existing server-switching menu does not expose these settings.

## What changed

Add a native Local Server Settings menu item with the standard settings shortcut. Its isolated window reuses the model and integration forms. Model settings apply to the server owner's default space; managed integration credentials apply server-wide. This host-only workflow is desktop-specific; web and mobile retain their authenticated settings.

The main process keeps the local capability out of the renderer and forwards only allowlisted settings operations to the verified loopback stack. The API checks the capability and resolves the owner itself, ignoring client account/space selection. Ordinary browser sessions do not gain settings access. An existing owner account and running local stack are required.

## UI copy

- “Local Server Settings…” and “Local Server Settings” identify the menu entry and destination. The entry must remain discoverable while signed out; the heading identifies the separate window.
- “Models” and “Server integrations” reuse existing labels and reveal their forms only when selected.
- “Models for the server owner’s default space.” appears only inside model settings to make the affected scope clear without a signed-in account context.
- “Start the local server before opening its settings.”, “Could not open local server settings. Try again.”, and “Could not open local settings. Start the local server and create its owner account, then try again.” appear only after the relevant failure. Removing them would leave the action without a recovery explanation.

## Validation

Full-project type checks passed. Desktop unit tests and the API unit suite passed. Two browser tests passed, covering the signed-out forms, integration saving, and ordinary-browser rejection. Lint passed with existing repository warnings. Electron E2E coverage was added for the native menu and scoped IPC; it is reserved for CI's virtual display.

CI screenshots: [server integrations while signed out](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34171592886-1/screenshots/images/153-local-server-integrations-logged-out.png) · [models while signed out](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34171592886-1/screenshots/images/154-local-server-models-logged-out.png).

The shared settings contract also has a native JavaScript export for packaged Electron, verified by importing it with TypeScript loading disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Local Server Settings page accessible from the desktop app menu.
  - Settings open in an isolated window with protected communication to the local server.
  - Added configuration for server integrations and models, including API key setup and model management.
  - Managed settings support focuses integration choices on supported providers.
  - Settings identify unavailable servers or missing owner accounts and display an error.
  - Added local settings requests through the desktop bridge.
- **Documentation**
  - Added and updated translations for local server settings and related messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
