### PR TITLE
Fix plus-picker search placeholder showing Lingui hash IDs

### DIFF
--- a/apps/web/e2e/new-bot-ux.spec.ts
+++ b/apps/web/e2e/new-bot-ux.spec.ts
@@ -20,6 +20,7 @@ test("create opens form, then empty chat; picker lists bots; sidebar collapses",
   await page.getByTestId("create-menu-trigger").click();
   const picker = page.getByTestId("bot-create-picker");
   await expect(picker).toBeVisible();
+  await expect(picker.getByPlaceholder("Search")).toBeVisible();
   await expect(picker.getByTestId("create-new-bot")).toBeVisible();
   await expect(picker.getByText("Chief", { exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "plus-picker-bots");

--- a/apps/web/scripts/translations-de.json
+++ b/apps/web/scripts/translations-de.json
@@ -581,5 +581,6 @@
   "No messages with {peerBotName} yet.": "Noch keine Nachrichten mit {peerBotName}.",
   "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker begrenzt für mehr Sicherheit den Zugriff auf deinen Computer. Wenn {hostLabel} verwendet wird, können Bots mit deinen lokalen Dateien und Werkzeugen arbeiten.",
   "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "Mit lokalem Zugriff können Bots ohne Rückfrage Befehle ausführen. Vermeide dies auf gemeinsam genutzten oder öffentlichen Servern.",
-  "Docker": "Docker"
+  "Docker": "Docker",
+  "To:": "An:"
 }

--- a/apps/web/scripts/translations-es.json
+++ b/apps/web/scripts/translations-es.json
@@ -724,5 +724,6 @@
   "Authorization expired — reconnect required": "Autorización expirada: se requiere reconectar",
   "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker limita el acceso a tu computadora para mayor seguridad. Usar {hostLabel} permite que los bots trabajen con tus archivos y herramientas locales.",
   "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "El acceso local permite que los bots ejecuten comandos sin preguntar. Evítalo en servidores compartidos o públicos.",
-  "Docker": "Docker"
+  "Docker": "Docker",
+  "To:": "Para:"
 }

--- a/apps/web/scripts/translations-hi.json
+++ b/apps/web/scripts/translations-hi.json
@@ -584,5 +584,6 @@
   "No messages with {peerBotName} yet.": "{peerBotName} के साथ अभी कोई संदेश नहीं.",
   "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker अतिरिक्त सुरक्षा के लिए आपके कंप्यूटर तक पहुँच सीमित करता है। {hostLabel} चुनने पर बॉट्स आपकी स्थानीय फ़ाइलों और टूल्स के साथ काम कर सकते हैं।",
   "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "स्थानीय पहुँच मिलने पर बॉट्स बिना पूछे कमांड चला सकते हैं। साझा या सार्वजनिक सर्वर पर इससे बचें।",
-  "Docker": "Docker"
+  "Docker": "Docker",
+  "To:": "प्रति:"
 }

--- a/apps/web/scripts/translations-ko.json
+++ b/apps/web/scripts/translations-ko.json
@@ -581,5 +581,6 @@
   "No messages with {peerBotName} yet.": "{peerBotName}와의 메시지가 아직 없습니다.",
   "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker는 보안을 위해 컴퓨터 접근을 제한합니다. {hostLabel}에서는 Bot이 로컬 파일과 도구로 작업할 수 있습니다.",
   "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "로컬 접근을 허용하면 Bot이 묻지 않고 명령을 실행할 수 있습니다. 공유 서버나 공개 서버에서는 허용하지 마세요.",
-  "Docker": "Docker"
+  "Docker": "Docker",
+  "To:": "받는 사람:"
 }

--- a/apps/web/scripts/translations-pt-BR.json
+++ b/apps/web/scripts/translations-pt-BR.json
@@ -583,5 +583,6 @@
   "No messages with {peerBotName} yet.": "Ainda sem mensagens com {peerBotName}.",
   "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "O Docker limita o acesso ao seu computador para maior segurança. Usar {hostLabel} permite que os bots trabalhem com seus arquivos e ferramentas locais.",
   "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "O acesso local permite que os bots executem comandos sem perguntar. Evite usá-lo em servidores compartilhados ou públicos.",
-  "Docker": "Docker"
+  "Docker": "Docker",
+  "To:": "Para:"
 }

--- a/apps/web/scripts/translations-tr.json
+++ b/apps/web/scripts/translations-tr.json
@@ -578,5 +578,6 @@
   "No messages with {peerBotName} yet.": "{peerBotName} ile henüz mesaj yok.",
   "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker, ek güvenlik için bilgisayarına erişimi sınırlar. {hostLabel} kullanıldığında botlar yerel dosyaların ve araçlarınla çalışabilir.",
   "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "Yerel erişim, botların sormadan komut çalıştırmasına izin verir. Paylaşılan veya herkese açık sunucularda bunu kullanma.",
-  "Docker": "Docker"
+  "Docker": "Docker",
+  "To:": "Kime:"
 }

--- a/apps/web/scripts/translations-zh-CN.json
+++ b/apps/web/scripts/translations-zh-CN.json
@@ -730,5 +730,6 @@
   "When a webhook fires": "当 Webhook 触发时",
   "Docker limits access to your computer for added security. Using {hostLabel} lets bots work with your local files and tools.": "Docker 限制对你电脑的访问，以提高安全性。使用{hostLabel}时，Bot 可以处理你的本地文件并使用本地工具。",
   "Local access lets bots run commands without asking. Avoid it on shared or public servers.": "本地访问权限允许 Bot 无需询问就执行命令。请勿在共享或公开服务器上启用。",
-  "Docker": "Docker"
+  "Docker": "Docker",
+  "To:": "至:"
 }

--- a/apps/web/src/lib/i18n-catalog.test.ts
+++ b/apps/web/src/lib/i18n-catalog.test.ts
@@ -176,6 +176,8 @@ describe("lingui catalogs", () => {
     i18n.activate("de");
     expect(i18n._({ id: "Settings", message: "Settings" })).toBe("Einstellungen");
     expect(i18n._({ id: "Cancel", message: "Cancel" })).toBe("Abbrechen");
+    expect(i18n._({ id: "Search", message: "Search" })).toBe("Suchen");
+    expect(i18n._({ id: "To:", message: "To:" })).toBe("An:");
 
     i18n.load("ko", ko as Record<string, string>);
     i18n.activate("ko");

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3032,6 +3032,8 @@ msgstr "Antworte mit Ja oder Nein oder in einem Satz."
 #: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
 #: src/pages/Shell.tsx:2540
+#: src/pages/shell/bot-picker.tsx:55
+#: src/pages/shell/bot-picker.tsx:56
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "Suchen"
@@ -3058,11 +3060,6 @@ msgstr ""
 #: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr "Modelle suchen"
-
-#: src/pages/shell/bot-picker.tsx:55
-#: src/pages/shell/bot-picker.tsx:56
-msgid "Search or create Bots"
-msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:359
 #: src/pages/ModelSettingsOverlay.tsx:365
@@ -3485,7 +3482,7 @@ msgstr "Titel"
 
 #: src/pages/shell/bot-picker.tsx:50
 msgid "To:"
-msgstr ""
+msgstr "An:"
 
 #: src/pages/PluginsOverlay.tsx:1114
 msgid "Tool sources"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -3032,6 +3032,8 @@ msgstr "Say yes or no, or answer in a sentence."
 #: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
 #: src/pages/Shell.tsx:2540
+#: src/pages/shell/bot-picker.tsx:55
+#: src/pages/shell/bot-picker.tsx:56
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "Search"
@@ -3058,11 +3060,6 @@ msgstr "Search integrations.sh"
 #: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr "Search models"
-
-#: src/pages/shell/bot-picker.tsx:55
-#: src/pages/shell/bot-picker.tsx:56
-msgid "Search or create Bots"
-msgstr "Search or create Bots"
 
 #: src/pages/ModelSettingsOverlay.tsx:359
 #: src/pages/ModelSettingsOverlay.tsx:365

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -3032,6 +3032,8 @@ msgstr "Di sí o no, o responde en una frase."
 #: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
 #: src/pages/Shell.tsx:2540
+#: src/pages/shell/bot-picker.tsx:55
+#: src/pages/shell/bot-picker.tsx:56
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "Buscar"
@@ -3058,11 +3060,6 @@ msgstr ""
 #: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr "Buscar modelos"
-
-#: src/pages/shell/bot-picker.tsx:55
-#: src/pages/shell/bot-picker.tsx:56
-msgid "Search or create Bots"
-msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:359
 #: src/pages/ModelSettingsOverlay.tsx:365
@@ -3485,7 +3482,7 @@ msgstr "Título"
 
 #: src/pages/shell/bot-picker.tsx:50
 msgid "To:"
-msgstr ""
+msgstr "Para:"
 
 #: src/pages/PluginsOverlay.tsx:1114
 msgid "Tool sources"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3032,6 +3032,8 @@ msgstr "हां या ना कहें, या एक वाक्य म�
 #: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
 #: src/pages/Shell.tsx:2540
+#: src/pages/shell/bot-picker.tsx:55
+#: src/pages/shell/bot-picker.tsx:56
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "खोजें"
@@ -3057,11 +3059,6 @@ msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
-msgstr ""
-
-#: src/pages/shell/bot-picker.tsx:55
-#: src/pages/shell/bot-picker.tsx:56
-msgid "Search or create Bots"
 msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:359
@@ -3485,7 +3482,7 @@ msgstr "शीर्षक"
 
 #: src/pages/shell/bot-picker.tsx:50
 msgid "To:"
-msgstr ""
+msgstr "प्रति:"
 
 #: src/pages/PluginsOverlay.tsx:1114
 msgid "Tool sources"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3032,6 +3032,8 @@ msgstr "예 또는 아니요로 답하거나 문장으로 답해 주세요."
 #: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
 #: src/pages/Shell.tsx:2540
+#: src/pages/shell/bot-picker.tsx:55
+#: src/pages/shell/bot-picker.tsx:56
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "검색"
@@ -3058,11 +3060,6 @@ msgstr ""
 #: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr "모델 검색"
-
-#: src/pages/shell/bot-picker.tsx:55
-#: src/pages/shell/bot-picker.tsx:56
-msgid "Search or create Bots"
-msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:359
 #: src/pages/ModelSettingsOverlay.tsx:365
@@ -3485,7 +3482,7 @@ msgstr "역할"
 
 #: src/pages/shell/bot-picker.tsx:50
 msgid "To:"
-msgstr ""
+msgstr "받는 사람:"
 
 #: src/pages/PluginsOverlay.tsx:1114
 msgid "Tool sources"

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3032,6 +3032,8 @@ msgstr "Diga sim ou não, ou responda em uma frase."
 #: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
 #: src/pages/Shell.tsx:2540
+#: src/pages/shell/bot-picker.tsx:55
+#: src/pages/shell/bot-picker.tsx:56
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "Pesquisar"
@@ -3057,11 +3059,6 @@ msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
-msgstr ""
-
-#: src/pages/shell/bot-picker.tsx:55
-#: src/pages/shell/bot-picker.tsx:56
-msgid "Search or create Bots"
 msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:359
@@ -3485,7 +3482,7 @@ msgstr "Título"
 
 #: src/pages/shell/bot-picker.tsx:50
 msgid "To:"
-msgstr ""
+msgstr "Para:"
 
 #: src/pages/PluginsOverlay.tsx:1114
 msgid "Tool sources"

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3032,6 +3032,8 @@ msgstr "Evet ya da hayır de veya bir cümleyle yanıtla."
 #: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
 #: src/pages/Shell.tsx:2540
+#: src/pages/shell/bot-picker.tsx:55
+#: src/pages/shell/bot-picker.tsx:56
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "Ara"
@@ -3057,11 +3059,6 @@ msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
-msgstr ""
-
-#: src/pages/shell/bot-picker.tsx:55
-#: src/pages/shell/bot-picker.tsx:56
-msgid "Search or create Bots"
 msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:359
@@ -3485,7 +3482,7 @@ msgstr "Başlık"
 
 #: src/pages/shell/bot-picker.tsx:50
 msgid "To:"
-msgstr ""
+msgstr "Kime:"
 
 #: src/pages/PluginsOverlay.tsx:1114
 msgid "Tool sources"

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -3032,6 +3032,8 @@ msgstr "回答是或否，或一句话说明。"
 #: src/pages/ModelSettingsOverlay.tsx:988
 #: src/pages/PluginsOverlay.tsx:878
 #: src/pages/Shell.tsx:2540
+#: src/pages/shell/bot-picker.tsx:55
+#: src/pages/shell/bot-picker.tsx:56
 #: src/pages/shell/command-palette.tsx:102
 msgid "Search"
 msgstr "搜索"
@@ -3058,11 +3060,6 @@ msgstr ""
 #: src/pages/ModelSettingsOverlay.tsx:983
 msgid "Search models"
 msgstr "搜索模型"
-
-#: src/pages/shell/bot-picker.tsx:55
-#: src/pages/shell/bot-picker.tsx:56
-msgid "Search or create Bots"
-msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:359
 #: src/pages/ModelSettingsOverlay.tsx:365
@@ -3485,7 +3482,7 @@ msgstr "标题"
 
 #: src/pages/shell/bot-picker.tsx:50
 msgid "To:"
-msgstr ""
+msgstr "至:"
 
 #: src/pages/PluginsOverlay.tsx:1114
 msgid "Tool sources"

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -52,8 +52,8 @@ export function BotCreatePicker({
         <input
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          placeholder={t`Search or create Bots`}
-          aria-label={t`Search or create Bots`}
+          placeholder={t`Search`}
+          aria-label={t`Search`}
           className="min-w-0 flex-1 bg-transparent text-[14px] text-foreground outline-none placeholder:text-muted-foreground"
         />
       </label>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

In non-English locales, the plus-picker bot search field showed raw Lingui message hashes (for example `ZxkdRe PHfiXN`) instead of readable copy. Those strings were missing from locale catalogs, so production builds fell back to the hashed ids. (#796)

## What changed

- Plus-picker search `placeholder` / `aria-label` now use the existing `Search` message (already translated, e.g. German `Suchen`).
- Copy change: `"Search or create Bots"` → `"Search"`. The longer string had no translations and was the broken catalog key; reusing `Search` matches the expected placeholder and other search fields. A longer untranslated phrase would still hash-leak in production.
- Filled `To:` translations in seeded locale catalogs so the recipient label no longer leaks its message hash beside the field.
- Web E2E asserts the picker search placeholder is `Search` and keeps the existing `plus-picker-bots` feature frame.
- Catalog unit test checks German `Search` / `To:` resolution.

## Testing

- Catalog assertion for German `Search` → `Suchen` and `To:` → `An:`.
- Web E2E: open plus picker, assert `getByPlaceholder("Search")`, screenshot `plus-picker-bots` (CI frame; no local screenshots).
- On an earlier CI head, app Playwright reported 105 passed and produced the feature frame below. Later heads hit unrelated flakes (`apps/www` marketing dialog once; `golden.spec.ts` failedRequests once). This PR does not touch those files.

CI E2E screenshot for this UI: [plus picker bots](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34186082126-1/screenshots/images/196-plus-picker-bots.png).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ec60876-95eb-4171-9c34-4c5b24c67c17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ec60876-95eb-4171-9c34-4c5b24c67c17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Interface**
  - Updated the bot picker search field label and placeholder to “Search” for clearer, more consistent navigation.
  - The picker continues to support searching and creating bots.

- **Localization**
  - Added translations for “To:” in German, Spanish, Hindi, Korean, Brazilian Portuguese, Turkish, and Simplified Chinese.
  - Updated localized bot picker search text to use the shorter “Search” label.

- **Tests**
  - Added coverage confirming the bot picker’s search field is visible during the creation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->