### PR TITLE
fix: attach OpenCode session ids for Go and Zen chats

### DIFF
--- a/packages/adapters/src/pi-runtime-transport.test.ts
+++ b/packages/adapters/src/pi-runtime-transport.test.ts
@@ -1,6 +1,10 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
-import { reliableStreamOptions } from "./pi-runtime.js";
+import {
+  conversationSessionId,
+  isOpenCodeProvider,
+  reliableStreamOptions,
+} from "./pi-runtime.js";
 
 describe("Pi runtime transport", () => {
   it.each([
@@ -20,5 +24,43 @@ describe("Pi runtime transport", () => {
     const options = { transport: "auto" as const, maxRetries: 2 };
 
     expect(reliableStreamOptions(model, options)).toBe(options);
+  });
+  it.each(["opencode", "opencode-go"] as const)(
+    "attaches a sticky OpenCode session header for %s",
+    (provider) => {
+      const model = { provider, api: "openai-completions" } as Model<Api>;
+      const options = {
+        sessionId: "thread-1:bot-1",
+        transport: "auto" as const,
+        headers: { "X-Custom": "1" },
+      };
+
+      expect(isOpenCodeProvider(provider)).toBe(true);
+      expect(reliableStreamOptions(model, options)).toEqual({
+        sessionId: "thread-1:bot-1",
+        transport: "auto",
+        headers: {
+          "x-opencode-session": "thread-1:bot-1",
+          "x-opencode-client": "rakazo",
+          "X-Custom": "1",
+        },
+      });
+    },
+  );
+
+  it("generates an OpenCode session id when the agent did not provide one", () => {
+    const model = { provider: "opencode-go", api: "openai-completions" } as Model<Api>;
+    const result = reliableStreamOptions(model, { transport: "auto" });
+
+    expect(result?.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(result?.headers?.["x-opencode-session"]).toBe(result?.sessionId);
+    expect(result?.headers?.["x-opencode-client"]).toBe("rakazo");
+  });
+
+  it("keeps a stable conversation session id per bot thread", () => {
+    expect(conversationSessionId("thread-1", "bot-1")).toBe("thread-1:bot-1");
+    expect(conversationSessionId("thread-1", "bot-1", "sub-1")).toBe("thread-1:bot-1:sub-1");
   });
 });

--- a/packages/adapters/src/pi-runtime-transport.test.ts
+++ b/packages/adapters/src/pi-runtime-transport.test.ts
@@ -1,10 +1,6 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
-import {
-  conversationSessionId,
-  isOpenCodeProvider,
-  reliableStreamOptions,
-} from "./pi-runtime.js";
+import { conversationSessionId, isOpenCodeProvider, reliableStreamOptions } from "./pi-runtime.js";
 
 describe("Pi runtime transport", () => {
   it.each([

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   Agent,
   type AgentMessage,
@@ -25,7 +26,6 @@ import type {
   ConnectorTool,
 } from "@rakazo/adapter-kit";
 import { getLogger } from "@rakazo/logging";
-import { randomUUID } from "node:crypto";
 import { isToolPauseResult } from "./approval-effect.js";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
 import { DEFAULT_OPENROUTER_MODEL_ID } from "./deployment-model.js";
@@ -1357,8 +1357,7 @@ export function isOpenCodeProvider(provider: string): boolean {
   return provider === "opencode" || provider === "opencode-go";
 }
 
-const OPENCODE_SESSION_ERROR =
-  "OpenCode rejected this chat session. Send the message again.";
+const OPENCODE_SESSION_ERROR = "OpenCode rejected this chat session. Send the message again.";
 
 function looksLikeOpenCodeSessionError(message: string): boolean {
   return (

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -25,6 +25,7 @@ import type {
   ConnectorTool,
 } from "@rakazo/adapter-kit";
 import { getLogger } from "@rakazo/logging";
+import { randomUUID } from "node:crypto";
 import { isToolPauseResult } from "./approval-effect.js";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
 import { DEFAULT_OPENROUTER_MODEL_ID } from "./deployment-model.js";
@@ -227,7 +228,7 @@ export class PiAgentRuntime implements AgentRuntime {
 
         let agent: Agent;
         agent = new Agent({
-          sessionId: `${request.threadId}:${request.botId}`,
+          sessionId: conversationSessionId(request.threadId, request.botId),
           steeringMode: "all",
           streamFn: (m, ctx, options) =>
             models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
@@ -374,7 +375,7 @@ export class PiAgentRuntime implements AgentRuntime {
         const budgetExceeded = host.toolCallBudget.exceeded;
         const error = agent.state.errorMessage;
         if (error && !budgetExceeded) {
-          throw new Error(sanitizeError(error));
+          throw new Error(sanitizeProviderError(model.provider, error));
         }
         if (budgetExceeded) {
           const budgetMessage = toolCallBudgetExceededMessage(host.toolCallBudget.limit);
@@ -964,6 +965,7 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
     depth: 1,
   };
   const nested = new Agent({
+    sessionId: conversationSessionId(host.request.threadId, host.request.botId, agentId),
     streamFn: (m, ctx, options) =>
       selectedModel.models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
     getApiKey: async () => selectedModel.apiKey,
@@ -1061,7 +1063,7 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
     const budgetExceeded = host.toolCallBudget.exceeded;
     const error = nested.state.errorMessage;
     if (error && !budgetExceeded) {
-      const message = sanitizeError(error);
+      const message = sanitizeProviderError(subagentModel.provider, error);
       host.queue.push({ type: "subagent", agentId, name, task, status: "failed", result: message });
       return `Subagent failed: ${message}`;
     }
@@ -1346,6 +1348,34 @@ function sanitizeError(message: string) {
   return sanitizeSensitiveText(message);
 }
 
+/** Stable OpenCode affinity id for a bot conversation (and optional nested agent). */
+export function conversationSessionId(threadId: string, botId: string, agentId?: string): string {
+  return agentId ? `${threadId}:${botId}:${agentId}` : `${threadId}:${botId}`;
+}
+
+export function isOpenCodeProvider(provider: string): boolean {
+  return provider === "opencode" || provider === "opencode-go";
+}
+
+const OPENCODE_SESSION_ERROR =
+  "OpenCode rejected this chat session. Send the message again.";
+
+function looksLikeOpenCodeSessionError(message: string): boolean {
+  return (
+    /x-opencode-session/i.test(message) ||
+    /session\s*(id|header|required|missing|invalid|expired|stale)/i.test(message) ||
+    /model is unavailable/i.test(message)
+  );
+}
+
+function sanitizeProviderError(provider: string, message: string): string {
+  const sanitized = sanitizeError(message);
+  if (isOpenCodeProvider(provider) && looksLikeOpenCodeSessionError(sanitized)) {
+    return OPENCODE_SESSION_ERROR;
+  }
+  return sanitized;
+}
+
 interface EventQueue {
   push(event: AgentRuntimeEvent): void;
   fail(error: Error): void;
@@ -1448,11 +1478,29 @@ export function reliableStreamOptions(
   model: Pick<Model<Api>, "api" | "provider">,
   options?: SimpleStreamOptions,
 ): SimpleStreamOptions | undefined {
-  if (model.provider !== "openai-codex" && model.api !== "openai-codex-responses") {
-    return options;
+  let next = options;
+
+  if (model.provider === "openai-codex" || model.api === "openai-codex-responses") {
+    // Pi cannot fall back after a WebSocket has emitted its start event. Long tool
+    // runs then surface abnormal close 1006 as a terminal model error. SSE has
+    // bounded network retries and no long-lived connection between tool turns.
+    next = { ...next, transport: "sse" };
   }
-  // Pi cannot fall back after a WebSocket has emitted its start event. Long tool
-  // runs then surface abnormal close 1006 as a terminal model error. SSE has
-  // bounded network retries and no long-lived connection between tool turns.
-  return { ...options, transport: "sse" };
+
+  // OpenCode Go/Zen require a sticky x-opencode-session header (affinity + some
+  // models 400 without it). Pi 0.85.1 does not attach that header on its own.
+  if (isOpenCodeProvider(model.provider)) {
+    const sessionId = next?.sessionId?.trim() || randomUUID();
+    next = {
+      ...next,
+      sessionId,
+      headers: {
+        "x-opencode-session": sessionId,
+        "x-opencode-client": "rakazo",
+        ...next?.headers,
+      },
+    };
+  }
+
+  return next;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

OpenCode Go now requires an `x-opencode-session` header on model requests. Rakazo already kept a stable Pi agent session per thread/bot, but never forwarded it as that header, so every OpenCode Go chat failed with a raw provider error.

## What changed

- For `opencode` and `opencode-go`, `reliableStreamOptions` now sends sticky `x-opencode-session` / `x-opencode-client` headers, reusing the conversation session id (`threadId:botId`, plus nested agent id when relevant).
- Nested agents also get a session id so subagent calls hit the same requirement.
- Session-shaped OpenCode failures map to a short retry prompt instead of dumping the provider error:
  - `OpenCode rejected this chat session. Send the message again.`
- Extended the existing Pi transport unit tests for OpenCode header attachment and stable session ids.

## Testing

- `pnpm exec vitest run packages/adapters/src/pi-runtime-transport.test.ts packages/adapters/src/pi-runtime-thinking-level.test.ts packages/adapters/src/pi-runtime-error.test.ts packages/adapters/src/pi-models.test.ts`

Fixes #795

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-201c4487-3a2b-41db-9055-2127e8596ed8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-201c4487-3a2b-41db-9055-2127e8596ed8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenCode providers.
  * Improved session handling for conversations and nested agents.
  * Added reliable streaming behavior for supported providers.
  * Added client and session headers for OpenCode connections.

* **Bug Fixes**
  * Improved error messages for OpenCode session-related failures.
  * Preserved existing provider error redaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->