### PR TITLE
Mobile chat polish: padding, empty start, working avatar, live profile

### DIFF
--- a/apps/api/src/bot-update.test.ts
+++ b/apps/api/src/bot-update.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@rakazo/db", () => ({
+  appendEventInTransaction: vi.fn(),
+}));
+
+import { botProfileLabelsChanged, commitBotUpdate } from "./bot-update.js";
+
+describe("botProfileLabelsChanged", () => {
+  it("is true only when name, title, or description is present", () => {
+    expect(botProfileLabelsChanged({})).toBe(false);
+    expect(botProfileLabelsChanged({ name: "SEO" })).toBe(true);
+    expect(botProfileLabelsChanged({ title: "Strategist" })).toBe(true);
+    expect(botProfileLabelsChanged({ description: "Helps with SEO" })).toBe(true);
+  });
+});
+
+describe("commitBotUpdate", () => {
+  it("writes the bot row and bot.updated in one transaction when labels change", async () => {
+    const updated = {
+      id: "bot-1",
+      name: "SEO Strategist",
+      title: "SEO Strategist",
+      description: "Helps with keyword research",
+    };
+    const botUpdate = vi.fn().mockResolvedValue(updated);
+    const tx = { bot: { update: botUpdate } };
+    const transaction = vi.fn(async (run: (client: typeof tx) => Promise<unknown>) => run(tx));
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const appendEvent = vi.fn().mockResolvedValue({ seq: 9 });
+    const prisma = {
+      $transaction: transaction,
+      bot: { update: vi.fn() },
+    };
+
+    await expect(
+      commitBotUpdate(
+        {
+          prisma: prisma as never,
+          notify,
+          spaceId: "space-1",
+          threadId: "thread-1",
+          botId: "bot-1",
+          data: { name: "SEO Strategist", title: "SEO Strategist" },
+          emitBotUpdated: true,
+        },
+        appendEvent,
+      ),
+    ).resolves.toEqual(updated);
+
+    expect(transaction).toHaveBeenCalledOnce();
+    expect(botUpdate).toHaveBeenCalledOnce();
+    expect(appendEvent).toHaveBeenCalledWith(tx, {
+      spaceId: "space-1",
+      threadId: "thread-1",
+      botId: "bot-1",
+      type: "bot.updated",
+      payload: {
+        botId: "bot-1",
+        name: "SEO Strategist",
+        title: "SEO Strategist",
+        description: "Helps with keyword research",
+      },
+    });
+    expect(notify).toHaveBeenCalledWith("thread-1", 9);
+    expect(prisma.bot.update).not.toHaveBeenCalled();
+  });
+
+  it("fails the whole update when the durable event write fails", async () => {
+    const appendEvent = vi.fn().mockRejectedValue(new Error("event store unavailable"));
+    const transaction = vi.fn(async (run: (client: unknown) => Promise<unknown>) =>
+      run({
+        bot: {
+          update: vi.fn().mockResolvedValue({
+            id: "bot-1",
+            name: "SEO",
+            title: "SEO",
+            description: "",
+          }),
+        },
+      }),
+    );
+    const notify = vi.fn();
+    const prisma = {
+      $transaction: transaction,
+      bot: { update: vi.fn() },
+    };
+
+    await expect(
+      commitBotUpdate(
+        {
+          prisma: prisma as never,
+          notify,
+          spaceId: "space-1",
+          threadId: "thread-1",
+          botId: "bot-1",
+          data: { name: "SEO" },
+          emitBotUpdated: true,
+        },
+        appendEvent,
+      ),
+    ).rejects.toThrow("event store unavailable");
+    expect(notify).not.toHaveBeenCalled();
+    expect(prisma.bot.update).not.toHaveBeenCalled();
+  });
+
+  it("updates without an event when profile labels are unchanged", async () => {
+    const update = vi.fn().mockResolvedValue({
+      id: "bot-1",
+      name: "Chief",
+      title: "Chief",
+      description: "",
+    });
+    const prisma = {
+      $transaction: vi.fn(),
+      bot: { update },
+    };
+    const notify = vi.fn();
+    const appendEvent = vi.fn();
+
+    await expect(
+      commitBotUpdate(
+        {
+          prisma: prisma as never,
+          notify,
+          spaceId: "space-1",
+          threadId: "thread-1",
+          botId: "bot-1",
+          data: { pinned: true },
+          emitBotUpdated: false,
+        },
+        appendEvent,
+      ),
+    ).resolves.toMatchObject({ id: "bot-1" });
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+    expect(appendEvent).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/bot-update.ts
+++ b/apps/api/src/bot-update.ts
@@ -15,7 +15,7 @@ export async function commitBotUpdate(
     spaceId: string;
     threadId: string;
     botId: string;
-    data: Prisma.BotUpdateInput;
+    data: Prisma.BotUncheckedUpdateInput;
     emitBotUpdated: boolean;
   },
   appendEvent: AppendEvent = appendEventInTransaction,

--- a/apps/api/src/bot-update.ts
+++ b/apps/api/src/bot-update.ts
@@ -1,0 +1,64 @@
+import { appendEventInTransaction, type Prisma, type PrismaClient } from "@rakazo/db";
+import { getLogger } from "@rakazo/logging";
+
+type AppendEvent = typeof appendEventInTransaction;
+
+/**
+ * Persist a bot row. When profile labels change, write `bot.updated` in the same
+ * transaction so clients never observe a successful rename without a durable event.
+ * Realtime notify stays best-effort after commit.
+ */
+export async function commitBotUpdate(
+  options: {
+    prisma: PrismaClient;
+    notify: (threadId: string, seq: number) => Promise<void>;
+    spaceId: string;
+    threadId: string;
+    botId: string;
+    data: Prisma.BotUpdateInput;
+    emitBotUpdated: boolean;
+  },
+  appendEvent: AppendEvent = appendEventInTransaction,
+): Promise<{ id: string; name: string; title: string; description: string }> {
+  if (!options.emitBotUpdated) {
+    return options.prisma.bot.update({
+      where: { id: options.botId },
+      data: options.data,
+      select: { id: true, name: true, title: true, description: true },
+    });
+  }
+
+  const committed = await options.prisma.$transaction(async (tx) => {
+    const updated = await tx.bot.update({
+      where: { id: options.botId },
+      data: options.data,
+      select: { id: true, name: true, title: true, description: true },
+    });
+    const event = await appendEvent(tx, {
+      spaceId: options.spaceId,
+      threadId: options.threadId,
+      botId: options.botId,
+      type: "bot.updated",
+      payload: {
+        botId: updated.id,
+        name: updated.name,
+        title: updated.title,
+        description: updated.description,
+      },
+    });
+    return { updated, seq: event.seq };
+  });
+
+  await options.notify(options.threadId, committed.seq).catch((error) => {
+    getLogger().error("bot.updated realtime notification", error);
+  });
+  return committed.updated;
+}
+
+export function botProfileLabelsChanged(input: {
+  name?: unknown;
+  title?: unknown;
+  description?: unknown;
+}): boolean {
+  return input.name !== undefined || input.title !== undefined || input.description !== undefined;
+}

--- a/apps/api/src/onboarding.ts
+++ b/apps/api/src/onboarding.ts
@@ -130,20 +130,12 @@ export async function startOnboarding(
   actor: Actor,
   botId: string,
 ): Promise<void> {
-  const { bot, thread } = await requireBotThread(deps, actor, botId);
+  const { thread } = await requireBotThread(deps, actor, botId);
   const existing = await deps.prisma.message.count({ where: { threadId: thread.id } });
   if (existing > 0) return;
-  const user = await deps.prisma.user.findUnique({
-    where: { id: actor.userId },
-    select: { name: true },
-  });
-  const firstName = (user?.name ?? "there").split(/\s+/)[0];
-  const target = { spaceId: actor.spaceId, botId: bot.id, threadId: thread.id };
-  // Greeting only. The focus card is posted later via promptFocus so non-first
-  // bots can wait ~10s for free typing, or skip if the user already engaged.
-  await post(deps, target, [
-    { kind: "text", text: `Hey ${firstName}. Fresh start on my side, so I’ll keep this short.` },
-  ]);
+  // Fresh chats start empty (same as web). The focus card is posted later via
+  // promptFocus so non-first bots can wait ~10s for free typing, or skip if the
+  // user already engaged.
 }
 
 function messageHasChoice(blocks: MessageBlock[]): boolean {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -947,6 +947,28 @@ export function createRouter(deps: RouterDeps) {
         const bots = await repos.listBots(context.actor);
         const bot = bots.find((b) => b.id === input.botId);
         if (!bot) throw new IsolationError();
+        if (
+          input.name !== undefined ||
+          input.title !== undefined ||
+          input.description !== undefined
+        ) {
+          await deps.events
+            .append({
+              spaceId: context.actor.spaceId,
+              threadId: bot.threadId,
+              botId: bot.id,
+              type: "bot.updated",
+              payload: {
+                botId: bot.id,
+                name: bot.name,
+                title: bot.title,
+                description: bot.description,
+              },
+            })
+            .catch((error) => {
+              getLogger().error("bot.updated after bots.update", error);
+            });
+        }
         return bot;
       }),
       setComputer: authed.bots.setComputer.handler(async ({ context, input }) => {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -133,6 +133,7 @@ import { getLogger } from "@rakazo/logging";
 import { deleteAgentSecret, listAgentSecrets, putAgentSecret } from "./agent-secrets.js";
 import { createAgentSkillsService } from "./agent-skills.js";
 import { createOwnedArtifact, getOwnedArtifact, getSpaceArtifact } from "./artifacts.js";
+import { botProfileLabelsChanged, commitBotUpdate } from "./bot-update.js";
 import {
   executionBlocksUserTakeover,
   resolveBusyBotName,
@@ -920,8 +921,14 @@ export function createRouter(deps: RouterDeps) {
             }
           }
         }
-        await deps.prisma.bot.update({
-          where: { id: input.botId },
+        if (!existing.thread) throw new IsolationError();
+        await commitBotUpdate({
+          prisma: deps.prisma,
+          notify: (threadId, seq) => deps.events.notify(threadId, seq),
+          spaceId: context.actor.spaceId,
+          threadId: existing.thread.id,
+          botId: input.botId,
+          emitBotUpdated: botProfileLabelsChanged(input),
           data: {
             name: input.name,
             title: input.title,
@@ -947,28 +954,6 @@ export function createRouter(deps: RouterDeps) {
         const bots = await repos.listBots(context.actor);
         const bot = bots.find((b) => b.id === input.botId);
         if (!bot) throw new IsolationError();
-        if (
-          input.name !== undefined ||
-          input.title !== undefined ||
-          input.description !== undefined
-        ) {
-          await deps.events
-            .append({
-              spaceId: context.actor.spaceId,
-              threadId: bot.threadId,
-              botId: bot.id,
-              type: "bot.updated",
-              payload: {
-                botId: bot.id,
-                name: bot.name,
-                title: bot.title,
-                description: bot.description,
-              },
-            })
-            .catch((error) => {
-              getLogger().error("bot.updated after bots.update", error);
-            });
-        }
         return bot;
       }),
       setComputer: authed.bots.setComputer.handler(async ({ context, input }) => {

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -500,9 +500,7 @@ function Thread() {
       headerTitle: () => (
         <Pressable
           accessibilityRole="button"
-          accessibilityLabel={
-            !inGroup && botId ? t("Bot settings") : displayName || t("Thread")
-          }
+          accessibilityLabel={!inGroup && botId ? t("Bot settings") : displayName || t("Thread")}
           disabled={inGroup || !botId}
           onPress={() => {
             if (!botId || inGroup) return;
@@ -1942,7 +1940,9 @@ function Thread() {
             <TextInput
               value={draft}
               onChangeText={updateDraft}
-              accessibilityLabel={displayName ? t("Message {name}", { name: displayName }) : t("Message")}
+              accessibilityLabel={
+                displayName ? t("Message {name}", { name: displayName }) : t("Message")
+              }
               onKeyPress={(event) => {
                 if (
                   event.nativeEvent.key === "Backspace" &&

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -259,6 +259,8 @@ function Thread() {
   activeBotId.current = botId;
   const activeGroupId = useRef(groupId);
   activeGroupId.current = groupId;
+  const routeName = useRef(name);
+  routeName.current = name;
   const readVisibleTarget = useRef<string | null>(null);
   const threadKey = groupId ?? botId;
   const [threadScrollState, setThreadScrollState] = useState<ThreadScrollState>(() =>
@@ -409,14 +411,16 @@ function Thread() {
       setMentionBots(bots);
       if (botId) {
         const next = bots.find((bot) => bot.id === botId);
-        if (next?.name && next.name !== name) {
+        // Read the route name from a ref so renaming does not recreate this
+        // callback (and restart the SSE subscription that depends on it).
+        if (next?.name && next.name !== routeName.current) {
           router.setParams({ name: next.name });
         }
       }
     } catch {
       // Keep the last known roster if refresh fails.
     }
-  }, [botId, groupId, name, router]);
+  }, [botId, groupId, router]);
 
   useEffect(() => {
     void refreshMentionBots();
@@ -500,7 +504,7 @@ function Thread() {
       headerTitle: () => (
         <Pressable
           accessibilityRole="button"
-          accessibilityLabel={!inGroup && botId ? t("Bot settings") : displayName || t("Thread")}
+          accessibilityLabel={!inGroup && botId ? t("Chat settings") : displayName || t("Thread")}
           disabled={inGroup || !botId}
           onPress={() => {
             if (!botId || inGroup) return;

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -49,7 +49,7 @@ import {
   type TextProps,
   View,
 } from "react-native";
-import { KeyboardAvoidingView } from "react-native-keyboard-controller";
+import { KeyboardAvoidingView, useKeyboardState } from "react-native-keyboard-controller";
 import { useReducedMotion } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AppConnectCard } from "../components/AppConnectCard";
@@ -230,6 +230,7 @@ function Thread() {
   const router = useRouter();
   const headerHeight = useHeaderHeight();
   const insets = useSafeAreaInsets();
+  const keyboardVisible = useKeyboardState((state) => state.isVisible);
   const { botId, groupId, name, messageId } = useLocalSearchParams<{
     botId?: string;
     groupId?: string;
@@ -372,6 +373,7 @@ function Thread() {
         })
       : [];
   const currentBot = botId ? mentionBots.find((bot) => bot.id === botId) : undefined;
+  const displayName = currentBot?.name ?? name;
   const notificationThreadId = snap?.threadId ?? currentBot?.threadId;
   activeThreadId.current = notificationThreadId;
   const currentBotStatus = snap ? snap.run?.status : currentBot?.status;
@@ -400,14 +402,28 @@ function Thread() {
     setThreadScrollState(scrollBehavior.current.state());
   }, [threadKey]);
 
+  const refreshMentionBots = useCallback(async () => {
+    if (!botId && !groupId) return;
+    try {
+      const bots = await rpc<MobileBot[]>("bots/list");
+      setMentionBots(bots);
+      if (botId) {
+        const next = bots.find((bot) => bot.id === botId);
+        if (next?.name && next.name !== name) {
+          router.setParams({ name: next.name });
+        }
+      }
+    } catch {
+      // Keep the last known roster if refresh fails.
+    }
+  }, [botId, groupId, name, router]);
+
   useEffect(() => {
-    void rpc<MobileBot[]>("bots/list")
-      .then(setMentionBots)
-      .catch(() => setMentionBots([]));
+    void refreshMentionBots();
     void rpc<MobileGroup[]>("groups/list")
       .then(setMentionGroups)
       .catch(() => setMentionGroups([]));
-  }, []);
+  }, [refreshMentionBots]);
 
   useEffect(() => {
     if (mentionBots.length === 0) {
@@ -480,9 +496,18 @@ function Thread() {
 
   useLayoutEffect(() => {
     navigation.setOptions({
-      title: name || t("Thread"),
+      title: displayName || t("Thread"),
       headerTitle: () => (
-        <View
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={
+            !inGroup && botId ? t("Bot settings") : displayName || t("Thread")
+          }
+          disabled={inGroup || !botId}
+          onPress={() => {
+            if (!botId || inGroup) return;
+            router.push({ pathname: "/bot-settings", params: { botId } });
+          }}
           style={{
             flexDirection: "row",
             alignItems: "center",
@@ -503,9 +528,9 @@ function Thread() {
             numberOfLines={1}
             style={{ color: tokens.foreground, fontSize: 18, fontWeight: "600" }}
           >
-            {name || t("Thread")}
+            {displayName || t("Thread")}
           </Text>
-        </View>
+        </Pressable>
       ),
       headerRight: () =>
         inGroup ? (
@@ -541,9 +566,9 @@ function Thread() {
     botId,
     currentBot,
     currentBotStatus,
+    displayName,
     groupId,
     inGroup,
-    name,
     navigation,
     router,
     t,
@@ -575,11 +600,19 @@ function Thread() {
 
   const botActions = [
     {
+      text: t("Chat settings"),
+      onPress: () =>
+        router.push({
+          pathname: "/bot-settings",
+          params: { botId: botId ?? "" },
+        }),
+    },
+    {
       text: t("Open computer"),
       onPress: () =>
         router.push({
           pathname: "/computer",
-          params: { botId: botId ?? "", name: name ?? t("Bot") },
+          params: { botId: botId ?? "", name: displayName ?? t("Bot") },
         }),
     },
     {
@@ -612,7 +645,7 @@ function Thread() {
     {
       text: t("Delete…"),
       destructive: true,
-      onPress: () => confirmDeleteBot({ id: botId ?? "", name: name || t("Bot") }, leaveBot),
+      onPress: () => confirmDeleteBot({ id: botId ?? "", name: displayName || t("Bot") }, leaveBot),
     },
   ];
 
@@ -776,11 +809,12 @@ function Thread() {
           threadId: notificationThreadId,
         }).catch(() => undefined);
       }
+      void refreshMentionBots();
       markReadIfVisible();
       return () => {
         void setOpenNotificationThread(null).catch(() => undefined);
       };
-    }, [botId, markReadIfVisible, notificationThreadId]),
+    }, [botId, markReadIfVisible, notificationThreadId, refreshMentionBots]),
   );
 
   useEffect(() => {
@@ -853,11 +887,15 @@ function Thread() {
                 }
                 setSnap((prev) => applyMobileThreadEvent(prev, event));
               }
+              if (event.type === "bot.updated") {
+                void refreshMentionBots();
+              }
               if (event.type === "thread.message.created" && event.payload?.role === "bot") {
                 readVisibleTarget.current = null;
                 markReadIfVisible();
               }
               if (isRunTerminalEvent(event)) {
+                void refreshMentionBots();
                 if (!jumpScrollTarget.current && !expandedHistoryThread.current) {
                   void refresh().catch(() => undefined);
                 }
@@ -879,7 +917,7 @@ function Thread() {
     return () => {
       abort.abort();
     };
-  }, [botId, groupId, markReadIfVisible]);
+  }, [botId, groupId, markReadIfVisible, refreshMentionBots]);
 
   useEffect(() => {
     if (!botId && !groupId) return;
@@ -1370,7 +1408,7 @@ function Thread() {
               botId={botId ?? snap?.members?.[0]?.botId ?? ""}
               groupId={groupId}
               message={message}
-              botName={name}
+              botName={displayName}
               bots={mentionBots}
               members={snap?.members}
               replyPreview={
@@ -1406,10 +1444,11 @@ function Thread() {
   const workingFooter =
     !inGroup && currentBot && isWorkingStatus(currentBotStatus) && !hasLiveProgress ? (
       <View
+        accessibilityLabel={t("{name} is working", { name: currentBot.name })}
+        accessibilityRole="text"
         style={{
           flexDirection: "row",
           alignItems: "center",
-          gap: 10,
           minHeight: 40,
           marginTop: 12,
         }}
@@ -1420,16 +1459,18 @@ function Thread() {
           size={28}
           status={currentBotStatus}
         />
-        <Text style={{ color: tokens.mutedForeground, fontSize: 13.5 }}>
-          {t("{name} is working", { name: currentBot.name })}
-        </Text>
       </View>
     ) : inGroup && workingGroupBots.length > 0 ? (
       <View
+        accessibilityLabel={
+          workingGroupBots.length === 1
+            ? t("{name} is working", { name: workingGroupBots[0]?.name ?? t("Agent") })
+            : t("{count} agents working", { count: workingGroupBots.length })
+        }
+        accessibilityRole="text"
         style={{
           flexDirection: "row",
           alignItems: "center",
-          gap: 10,
           minHeight: 40,
           marginTop: 12,
         }}
@@ -1447,11 +1488,6 @@ function Thread() {
             </View>
           ))}
         </View>
-        <Text style={{ color: tokens.mutedForeground, fontSize: 13.5, flexShrink: 1 }}>
-          {workingGroupBots.length === 1
-            ? t("{name} is working", { name: workingGroupBots[0]?.name ?? t("Agent") })
-            : t("{count} agents working", { count: workingGroupBots.length })}
-        </Text>
       </View>
     ) : null;
 
@@ -1585,7 +1621,7 @@ function Thread() {
           </Pressable>
         ) : null}
       </View>
-      <View style={{ paddingBottom: Math.max(insets.bottom + 12, 24) }}>
+      <View style={{ paddingBottom: keyboardVisible ? 12 : Math.max(insets.bottom + 12, 24) }}>
         {replyTarget ? (
           <View
             style={{
@@ -1906,7 +1942,7 @@ function Thread() {
             <TextInput
               value={draft}
               onChangeText={updateDraft}
-              accessibilityLabel={name ? t("Message {name}", { name }) : t("Message")}
+              accessibilityLabel={displayName ? t("Message {name}", { name: displayName }) : t("Message")}
               onKeyPress={(event) => {
                 if (
                   event.nativeEvent.key === "Backspace" &&
@@ -1919,8 +1955,8 @@ function Thread() {
               placeholder={
                 selectedSkill || selectedMentions.length
                   ? undefined
-                  : name
-                    ? t("Message {name}", { name })
+                  : displayName
+                    ? t("Message {name}", { name: displayName })
                     : t("Message…")
               }
               placeholderTextColor={tokens.mutedForeground}

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -262,6 +262,7 @@ function Thread() {
   const routeName = useRef(name);
   routeName.current = name;
   const mentionBotsRefreshGeneration = useRef(0);
+  const mentionBotsAppliedGeneration = useRef(0);
   const readVisibleTarget = useRef<string | null>(null);
   const threadKey = groupId ?? botId;
   const [threadScrollState, setThreadScrollState] = useState<ThreadScrollState>(() =>
@@ -411,8 +412,11 @@ function Thread() {
     const targetBotId = botId;
     try {
       const bots = await rpc<MobileBot[]>("bots/list");
-      if (generation !== mentionBotsRefreshGeneration.current) return;
+      // Apply any successful response that is still the newest applied so far.
+      // A later failed refresh must not discard an earlier success.
+      if (generation < mentionBotsAppliedGeneration.current) return;
       if (targetBotId !== activeBotId.current) return;
+      mentionBotsAppliedGeneration.current = generation;
       setMentionBots(bots);
       if (targetBotId) {
         const next = bots.find((bot) => bot.id === targetBotId);

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -261,6 +261,7 @@ function Thread() {
   activeGroupId.current = groupId;
   const routeName = useRef(name);
   routeName.current = name;
+  const mentionBotsRefreshGeneration = useRef(0);
   const readVisibleTarget = useRef<string | null>(null);
   const threadKey = groupId ?? botId;
   const [threadScrollState, setThreadScrollState] = useState<ThreadScrollState>(() =>
@@ -406,11 +407,15 @@ function Thread() {
 
   const refreshMentionBots = useCallback(async () => {
     if (!botId && !groupId) return;
+    const generation = ++mentionBotsRefreshGeneration.current;
+    const targetBotId = botId;
     try {
       const bots = await rpc<MobileBot[]>("bots/list");
+      if (generation !== mentionBotsRefreshGeneration.current) return;
+      if (targetBotId !== activeBotId.current) return;
       setMentionBots(bots);
-      if (botId) {
-        const next = bots.find((bot) => bot.id === botId);
+      if (targetBotId) {
+        const next = bots.find((bot) => bot.id === targetBotId);
         // Read the route name from a ref so renaming does not recreate this
         // callback (and restart the SSE subscription that depends on it).
         if (next?.name && next.name !== routeName.current) {

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -30,7 +30,8 @@ describe("Android mobile platform contract", () => {
     expect(thread).not.toContain("automaticOffset");
     expect(thread).not.toContain("KeyboardStickyView");
     expect(thread).toContain("useSafeAreaInsets");
-    expect(thread).toContain("Math.max(insets.bottom + 12, 24)");
+    expect(thread).toContain("useKeyboardState");
+    expect(thread).toContain("keyboardVisible ? 12 : Math.max(insets.bottom + 12, 24)");
   });
 
   it("requests live-update promotion and exposes its Android settings", () => {
@@ -166,6 +167,13 @@ describe("Android mobile platform contract", () => {
     expect(thread).toContain("inGroup && workingGroupBots.length > 0 ?");
     expect(thread).toContain("workingGroupBots.length - index");
     expect(thread).toContain("agents working");
+    // Visible chrome is avatar-only; copy stays on accessibilityLabel.
+    expect(thread).toMatch(
+      /accessibilityLabel=\{\s*workingGroupBots\.length === 1[\s\S]*agents working/,
+    );
+    expect(thread).not.toMatch(
+      /workingGroupBots\.length === 1\s*\?[\s\S]*<Text[^>]*>\s*\{t\("\{name\} is working"/,
+    );
   });
 
   it("keeps send and stop separate while steering active work", () => {

--- a/apps/mobile/lib/avatar-motion.test.ts
+++ b/apps/mobile/lib/avatar-motion.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import { workingAvatarDuration, workingAvatarFrame } from "@rakazo/core";
+import { describe, expect, it } from "vitest";
 
 describe("working avatar motion", () => {
   it("reuses shared core choreography", () => {

--- a/apps/mobile/lib/avatar-motion.ts
+++ b/apps/mobile/lib/avatar-motion.ts
@@ -1,84 +1,10 @@
-export interface WorkingAvatarFrame {
-  translationX: number;
-  translationY: number;
-  scaleX: number;
-  scaleY: number;
-  rotation: number;
-  eyeOffsetX: number;
-  eyeOffsetY: number;
-}
-
-const WORKING_DURATIONS_MS = [1800, 1350, 1600, 2400, 1350, 1350, 1100, 1350, 1600, 1350];
-
-export function workingAvatarDuration(seed: number): number {
-  "worklet";
-  return WORKING_DURATIONS_MS[seed % 10] ?? 1800;
-}
-
-export function workingAvatarFrame(seed: number, progress: number): WorkingAvatarFrame {
-  "worklet";
-  const middle = (1 - Math.cos(progress * Math.PI * 2)) / 2;
-  const frame: WorkingAvatarFrame = {
-    translationX: 0,
-    translationY: 0,
-    scaleX: 1,
-    scaleY: 1,
-    rotation: 0,
-    eyeOffsetX: 0,
-    eyeOffsetY: 0,
-  };
-
-  switch (seed % 10) {
-    case 0:
-      frame.translationY = 2 - 5 * middle;
-      frame.scaleX = 1.02 - 0.04 * middle;
-      break;
-    case 1:
-      frame.translationY = 2 - 5 * middle;
-      frame.scaleX = 1.04 - 0.08 * middle;
-      frame.scaleY = 0.96 + 0.09 * middle;
-      break;
-    case 2:
-    case 8:
-      frame.translationX = -1 + 2 * middle;
-      frame.rotation = -3 + 6 * middle;
-      break;
-    case 3:
-    case 4:
-      frame.scaleX = 0.98 + 0.06 * middle;
-      frame.scaleY = 0.98 + 0.06 * middle;
-      frame.rotation = -4 + 8 * middle;
-      break;
-    case 5:
-    case 9:
-      frame.scaleX = 1.04 - 0.08 * middle;
-      frame.scaleY = 0.96 + 0.08 * middle;
-      break;
-    case 6:
-      frame.scaleX = 0.96 + 0.1 * middle;
-      frame.scaleY = 0.96 + 0.1 * middle;
-      break;
-    default:
-      frame.rotation = -4 + 9 * middle;
-  }
-
-  const angle = progress * Math.PI * 2;
-  switch (seed % 4) {
-    case 0:
-      frame.eyeOffsetX = Math.sin(angle) * 9;
-      frame.eyeOffsetY = Math.cos(angle) * 2;
-      break;
-    case 1:
-      frame.eyeOffsetX = Math.cos(angle) * 7;
-      frame.eyeOffsetY = Math.sin(angle) * 4;
-      break;
-    case 2:
-      frame.eyeOffsetX = Math.cos(angle) * 8;
-      frame.eyeOffsetY = Math.sin(angle) * 3;
-      break;
-    default:
-      frame.eyeOffsetX = Math.sin(angle * 2) * 6;
-      frame.eyeOffsetY = Math.cos(angle * 2) * 3;
-  }
-  return frame;
-}
+/**
+ * Re-export shared choreography for Reanimated worklets.
+ * Source of truth: `@rakazo/core` (`avatar-motion.ts`), mirrored by web CSS.
+ */
+export {
+  WORKING_AVATAR_DURATIONS_MS,
+  type WorkingAvatarFrame,
+  workingAvatarDuration,
+  workingAvatarFrame,
+} from "@rakazo/core";

--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -48,8 +48,15 @@ test("message hover shows beside-bubble actions; reply links to parent", async (
 
   const transcript = page.getByTestId("transcript");
 
-  // Bot welcome (left bubble): rail hidden at rest, then beside on hover.
-  const botRow = transcript.locator(`[data-message-id]`).first();
+  // Empty start: no Fresh-start greeting. Answer the focus card so a plain
+  // bot text bubble exists for hover layout checks.
+  await expect(page.getByText("What do you want me on first?", { exact: true })).toBeVisible({
+    timeout: 20_000,
+  });
+  await page.getByRole("button", { name: /Day-to-day work/ }).click();
+  const botText = page.getByText(/Got it\./);
+  await expect(botText).toBeVisible({ timeout: 20_000 });
+  const botRow = transcript.locator(`[data-message-id]`).filter({ has: botText }).first();
   await expect(botRow).toBeVisible();
   await expectRailAtRest(page, botRow);
   await captureScreenshot(page, testInfo, "message-actions-rest-desktop");
@@ -328,7 +335,17 @@ test.describe("touch message actions", () => {
     expect(
       await page.evaluate(() => matchMedia("(hover: hover) and (pointer: fine)").matches),
     ).toBe(false);
-    const row = page.getByTestId("transcript").locator("[data-message-id]").first();
+    await expect(page.getByText("What do you want me on first?", { exact: true })).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.getByRole("button", { name: /Day-to-day work/ }).click();
+    const botText = page.getByText(/Got it\./);
+    await expect(botText).toBeVisible({ timeout: 20_000 });
+    const row = page
+      .getByTestId("transcript")
+      .locator("[data-message-id]")
+      .filter({ has: botText })
+      .first();
     const rail = row.getByTestId("message-hover-rail");
     await expect(rail).toHaveCSS("opacity", "1");
     await expect(rail.getByRole("button", { name: "Reply", exact: true })).toBeHidden();

--- a/apps/web/e2e/onboarding-conversation.spec.ts
+++ b/apps/web/e2e/onboarding-conversation.spec.ts
@@ -14,7 +14,7 @@ test("focus choice suggests apps and preserves a completed connection", async ({
 
   await expect(
     page.getByText("Hey Robin. Fresh start on my side, so I’ll keep this short."),
-  ).toBeVisible();
+  ).toHaveCount(0);
   await expect(page.getByText("What do you want me on first?", { exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: /Day-to-day work/ })).toBeVisible();
   await expect(page.getByRole("button", { name: /Research & writing/ })).toBeVisible();

--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -744,6 +744,28 @@ export const builtinAgentTools: ConnectorTool[] = [
     },
   },
   {
+    name: "update_bot",
+    description:
+      "Update this bot's own profile fields that the user sees in chat: name (header and list label), title (short role line), and description. Call this when the user asks you to rename yourself or change your title/description. Do not claim you updated the profile without calling this tool.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description: "Display name shown in the chat header and bot list.",
+        },
+        title: {
+          type: "string",
+          description: "Short role or headline shown in bot settings.",
+        },
+        description: {
+          type: "string",
+          description: "Longer blurb describing what this bot does.",
+        },
+      },
+    },
+  },
+  {
     name: "archive_bot",
     description:
       "Archive a bot this bot created. Archiving stops its work and routines, hides it from the active list, and preserves its conversation, memory, and files for the user to restore or delete later. confirm_name must exactly match its name. This cannot archive you, bots the user created, or bots another bot created.",

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -29,6 +29,9 @@ import {
 import type { MessageBlock, RunStatus } from "@rakazo/contracts";
 import {
   ATTACHMENT_MAX_BYTES,
+  BOT_DESCRIPTION_MAX_LENGTH,
+  BOT_NAME_MAX_LENGTH,
+  BOT_TITLE_MAX_LENGTH,
   BotSecretName,
   BotSecretSubmission,
   isAttachmentImageMimeType,
@@ -3033,6 +3036,81 @@ export function createRunExecutor(deps: ExecutorDeps) {
             }
             return spawned;
           }
+          if (name === "update_bot") {
+            const patch: { name?: string; title?: string; description?: string } = {};
+            if (args.name !== undefined) patch.name = String(args.name);
+            if (args.title !== undefined) patch.title = String(args.title);
+            if (args.description !== undefined) patch.description = String(args.description);
+            if (Object.keys(patch).length === 0) {
+              return finish({
+                error: "Provide at least one of name, title, or description.",
+              });
+            }
+            if (patch.name !== undefined) {
+              const nextName = patch.name.trim();
+              if (!nextName) return finish({ error: "name cannot be empty." });
+              if (nextName.length > BOT_NAME_MAX_LENGTH) {
+                return finish({ error: `name must be at most ${BOT_NAME_MAX_LENGTH} characters.` });
+              }
+              patch.name = nextName;
+            }
+            if (patch.title !== undefined) {
+              const nextTitle = patch.title.trim();
+              if (nextTitle.length > BOT_TITLE_MAX_LENGTH) {
+                return finish({
+                  error: `title must be at most ${BOT_TITLE_MAX_LENGTH} characters.`,
+                });
+              }
+              patch.title = nextTitle;
+            }
+            if (patch.description !== undefined) {
+              const nextDescription = patch.description.trim();
+              if (nextDescription.length > BOT_DESCRIPTION_MAX_LENGTH) {
+                return finish({
+                  error: `description must be at most ${BOT_DESCRIPTION_MAX_LENGTH} characters.`,
+                });
+              }
+              patch.description = nextDescription;
+            }
+            // Placeholder names stay invisible in the header if only title changes;
+            // promote the title into name so chat chrome matches the profile update.
+            if (
+              patch.name === undefined &&
+              patch.title &&
+              /^(New Bot|Bot|Untitled)$/i.test(bot.name)
+            ) {
+              patch.name = patch.title.slice(0, BOT_NAME_MAX_LENGTH);
+            }
+            const updated = await deps.prisma.bot.update({
+              where: { id: bot.id },
+              data: patch,
+              select: { id: true, name: true, title: true, description: true },
+            });
+            try {
+              await deps.events.append({
+                spaceId: run.spaceId,
+                threadId: thread.id,
+                botId: bot.id,
+                runId: run.id,
+                type: "bot.updated",
+                payload: {
+                  botId: updated.id,
+                  name: updated.name,
+                  title: updated.title,
+                  description: updated.description,
+                },
+              });
+            } catch (error) {
+              getLogger().error("bot.updated notification", error);
+            }
+            return finish({
+              ok: true,
+              botId: updated.id,
+              name: updated.name,
+              title: updated.title,
+              description: updated.description,
+            });
+          }
           if (name === "message_user") {
             const rawMessage = redactSecrets(String(args.message ?? ""), runSecrets);
             const text = clampUserProgressMessage(rawMessage);
@@ -3301,6 +3379,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 "A bot and a subagent are different. Never use both for the same request.",
                 "create_space proposes a new privacy boundary inside the current organization. Use it when the user asks to create a space or separate data between teams or projects. It always pauses for explicit user approval; never claim the space exists before the tool succeeds.",
                 "spawn_bot creates a lasting regular bot (own chat, computer, memory) that appears in the user's bot list. If the user asked to create a bot, call spawn_bot once and stop. Do not run_subagent to demo it.",
+                "update_bot updates this bot's own name (chat header / list label), title, and description. When the user asks you to rename yourself or change your title or description, call update_bot — do not claim you changed them without the tool.",
                 "run_subagent is a short helper inside this turn only. It is not a bot, has no thread, and does not show in the list. Use it for parallel work you will summarize here.",
                 botDirectory,
                 "archive_bot safely archives a bot this bot created, and only that bot. Use it when the user asks to remove that bot or when it is finished and unused. The user can restore it or permanently delete it later. confirm_name must exactly match its name.",

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -40,6 +40,7 @@ export const ProductEventType = z.enum([
   "effect.reconciled",
   "usage.recorded",
   "bot.spawned",
+  "bot.updated",
   "bot.archived",
   "bot.deleted",
   "group.created",

--- a/packages/core/src/avatar-motion.test.ts
+++ b/packages/core/src/avatar-motion.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { workingAvatarDuration, workingAvatarFrame } from "@rakazo/core";
+import { workingAvatarDuration, workingAvatarFrame } from "./avatar-motion.js";
 
 describe("working avatar motion", () => {
-  it("reuses shared core choreography", () => {
+  it("loops cleanly while keeping identity-specific choreography", () => {
     const start = workingAvatarFrame(0, 0);
     const end = workingAvatarFrame(0, 1);
     expect(end.translationY).toBeCloseTo(start.translationY);

--- a/packages/core/src/avatar-motion.ts
+++ b/packages/core/src/avatar-motion.ts
@@ -17,7 +17,7 @@ export interface WorkingAvatarFrame {
 
 /** Per shape-family loop length in ms — keep in sync with web CSS animation durations. */
 export const WORKING_AVATAR_DURATIONS_MS = [
-  1800, 1350, 1600, 2400, 1350, 1350, 1100, 1350, 1600, 1350,
+  1800, 1350, 1600, 2400, 2400, 1350, 1100, 1350, 1600, 1350,
 ] as const;
 
 export function workingAvatarDuration(seed: number): number {

--- a/packages/core/src/avatar-motion.ts
+++ b/packages/core/src/avatar-motion.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared working-avatar choreography used by mobile (Reanimated) and mirrored
+ * by web CSS in `@rakazo/ui-web` (`styles.css` organic working keyframes).
+ *
+ * Duration families and transform midpoints must stay aligned across surfaces.
+ */
+
+export interface WorkingAvatarFrame {
+  translationX: number;
+  translationY: number;
+  scaleX: number;
+  scaleY: number;
+  rotation: number;
+  eyeOffsetX: number;
+  eyeOffsetY: number;
+}
+
+/** Per shape-family loop length in ms — keep in sync with web CSS animation durations. */
+export const WORKING_AVATAR_DURATIONS_MS = [
+  1800, 1350, 1600, 2400, 1350, 1350, 1100, 1350, 1600, 1350,
+] as const;
+
+export function workingAvatarDuration(seed: number): number {
+  "worklet";
+  return WORKING_AVATAR_DURATIONS_MS[seed % 10] ?? 1800;
+}
+
+export function workingAvatarFrame(seed: number, progress: number): WorkingAvatarFrame {
+  "worklet";
+  const middle = (1 - Math.cos(progress * Math.PI * 2)) / 2;
+  const frame: WorkingAvatarFrame = {
+    translationX: 0,
+    translationY: 0,
+    scaleX: 1,
+    scaleY: 1,
+    rotation: 0,
+    eyeOffsetX: 0,
+    eyeOffsetY: 0,
+  };
+
+  switch (seed % 10) {
+    case 0:
+      frame.translationY = 2 - 5 * middle;
+      frame.scaleX = 1.02 - 0.04 * middle;
+      break;
+    case 1:
+      frame.translationY = 2 - 5 * middle;
+      frame.scaleX = 1.04 - 0.08 * middle;
+      frame.scaleY = 0.96 + 0.09 * middle;
+      break;
+    case 2:
+    case 8:
+      frame.translationX = -1 + 2 * middle;
+      frame.rotation = -3 + 6 * middle;
+      break;
+    case 3:
+    case 4:
+      frame.scaleX = 0.98 + 0.06 * middle;
+      frame.scaleY = 0.98 + 0.06 * middle;
+      frame.rotation = -4 + 8 * middle;
+      break;
+    case 5:
+    case 9:
+      frame.scaleX = 1.04 - 0.08 * middle;
+      frame.scaleY = 0.96 + 0.08 * middle;
+      break;
+    case 6:
+      frame.scaleX = 0.96 + 0.1 * middle;
+      frame.scaleY = 0.96 + 0.1 * middle;
+      break;
+    default:
+      frame.rotation = -4 + 9 * middle;
+  }
+
+  const angle = progress * Math.PI * 2;
+  switch (seed % 4) {
+    case 0:
+      frame.eyeOffsetX = Math.sin(angle) * 9;
+      frame.eyeOffsetY = Math.cos(angle) * 2;
+      break;
+    case 1:
+      frame.eyeOffsetX = Math.cos(angle) * 7;
+      frame.eyeOffsetY = Math.sin(angle) * 4;
+      break;
+    case 2:
+      frame.eyeOffsetX = Math.cos(angle) * 8;
+      frame.eyeOffsetY = Math.sin(angle) * 3;
+      break;
+    default:
+      frame.eyeOffsetX = Math.sin(angle * 2) * 6;
+      frame.eyeOffsetY = Math.cos(angle * 2) * 3;
+  }
+  return frame;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./agent-skill.js";
 export * from "./answerable-ask.js";
 export * from "./async.js";
 export * from "./attachments.js";
+export * from "./avatar-motion.js";
 export * from "./avatar-shape.js";
 export * from "./bot-messages.js";
 export * from "./bot-sections.js";

--- a/packages/ui-web/src/avatar-motion-sync.test.ts
+++ b/packages/ui-web/src/avatar-motion-sync.test.ts
@@ -5,18 +5,18 @@ import { WORKING_AVATAR_DURATIONS_MS } from "@rakazo/core";
 import { describe, expect, it } from "vitest";
 
 /** CSS `data-shape-family` → expected duration seconds (mirrors styles.css). */
-const FAMILY_DURATION_SECONDS: Record<number, number> = {
-  0: 1.8,
-  1: 1.35,
-  2: 1.6,
-  3: 2.4,
-  4: 2.4,
-  5: 1.35,
-  6: 1.1,
-  7: 1.35,
-  8: 1.6,
-  9: 1.35,
-};
+const FAMILY_DURATION_SECONDS = [1.8, 1.35, 1.6, 2.4, 2.4, 1.35, 1.1, 1.35, 1.6, 1.35] as const;
+
+function workingDurationSecondsForFamily(css: string, family: number): number | null {
+  // Split on rule closers so a wrong duration cannot match a later family's token.
+  for (const chunk of css.split("}")) {
+    if (!chunk.includes(`data-shape-family="${family}"]`)) continue;
+    if (!chunk.includes(".rakazo-organic-avatar-body-working")) continue;
+    const match = chunk.match(/animation:\s*[^;]*?\s([\d.]+)s\b/);
+    if (match?.[1]) return Number(match[1]);
+  }
+  return null;
+}
 
 describe("organic working avatar CSS", () => {
   it("keeps each shape-family duration aligned with shared core choreography", () => {
@@ -24,16 +24,13 @@ describe("organic working avatar CSS", () => {
       resolve(dirname(fileURLToPath(import.meta.url)), "styles.css"),
       "utf8",
     );
-    for (const [family, seconds] of Object.entries(FAMILY_DURATION_SECONDS)) {
-      const index = Number(family);
-      expect(WORKING_AVATAR_DURATIONS_MS[index] / 1000).toBe(seconds);
-      const token = `${seconds}s`;
-      expect(css).toContain(`data-shape-family="${family}"] .rakazo-organic-avatar-body-working`);
-      // Duration appears on the rule for this family (shared rules cover 2/8, 3/4, 5/9).
-      const familyBlock = css.match(
-        new RegExp(`data-shape-family="${family}"[\\s\\S]*?animation:[^;]*\\s(${seconds}s)\\s`),
-      );
-      expect(familyBlock?.[1]).toBe(token);
+    expect(WORKING_AVATAR_DURATIONS_MS).toHaveLength(FAMILY_DURATION_SECONDS.length);
+    for (let family = 0; family < FAMILY_DURATION_SECONDS.length; family += 1) {
+      const seconds = FAMILY_DURATION_SECONDS[family]!;
+      const sharedMs = WORKING_AVATAR_DURATIONS_MS[family];
+      expect(sharedMs).toBeTypeOf("number");
+      expect(sharedMs! / 1000).toBe(seconds);
+      expect(workingDurationSecondsForFamily(css, family)).toBe(seconds);
     }
   });
 });

--- a/packages/ui-web/src/avatar-motion-sync.test.ts
+++ b/packages/ui-web/src/avatar-motion-sync.test.ts
@@ -4,16 +4,36 @@ import { fileURLToPath } from "node:url";
 import { WORKING_AVATAR_DURATIONS_MS } from "@rakazo/core";
 import { describe, expect, it } from "vitest";
 
+/** CSS `data-shape-family` → expected duration seconds (mirrors styles.css). */
+const FAMILY_DURATION_SECONDS: Record<number, number> = {
+  0: 1.8,
+  1: 1.35,
+  2: 1.6,
+  3: 2.4,
+  4: 2.4,
+  5: 1.35,
+  6: 1.1,
+  7: 1.35,
+  8: 1.6,
+  9: 1.35,
+};
+
 describe("organic working avatar CSS", () => {
-  it("keeps working durations aligned with shared core choreography", () => {
+  it("keeps each shape-family duration aligned with shared core choreography", () => {
     const css = readFileSync(
       resolve(dirname(fileURLToPath(import.meta.url)), "styles.css"),
       "utf8",
     );
-    const uniqueSeconds = [...new Set(WORKING_AVATAR_DURATIONS_MS.map((ms) => ms / 1000))];
-    for (const seconds of uniqueSeconds) {
-      const token = Number.isInteger(seconds) ? `${seconds}s` : `${seconds}s`;
-      expect(css).toContain(token);
+    for (const [family, seconds] of Object.entries(FAMILY_DURATION_SECONDS)) {
+      const index = Number(family);
+      expect(WORKING_AVATAR_DURATIONS_MS[index] / 1000).toBe(seconds);
+      const token = `${seconds}s`;
+      expect(css).toContain(`data-shape-family="${family}"] .rakazo-organic-avatar-body-working`);
+      // Duration appears on the rule for this family (shared rules cover 2/8, 3/4, 5/9).
+      const familyBlock = css.match(
+        new RegExp(`data-shape-family="${family}"[\\s\\S]*?animation:[^;]*\\s(${seconds}s)\\s`),
+      );
+      expect(familyBlock?.[1]).toBe(token);
     }
   });
 });

--- a/packages/ui-web/src/avatar-motion-sync.test.ts
+++ b/packages/ui-web/src/avatar-motion-sync.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { WORKING_AVATAR_DURATIONS_MS } from "@rakazo/core";
+import { describe, expect, it } from "vitest";
+
+describe("organic working avatar CSS", () => {
+  it("keeps working durations aligned with shared core choreography", () => {
+    const css = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "styles.css"),
+      "utf8",
+    );
+    const uniqueSeconds = [...new Set(WORKING_AVATAR_DURATIONS_MS.map((ms) => ms / 1000))];
+    for (const seconds of uniqueSeconds) {
+      const token = Number.isInteger(seconds) ? `${seconds}s` : `${seconds}s`;
+      expect(css).toContain(token);
+    }
+  });
+});

--- a/packages/ui-web/src/styles.css
+++ b/packages/ui-web/src/styles.css
@@ -165,6 +165,7 @@
   animation: rakazo-organic-eyes-loop-3 7.8s ease-in-out -2.1s infinite;
 }
 
+/* Durations mirror @rakazo/core WORKING_AVATAR_DURATIONS_MS (avatar-motion). */
 .rakazo-organic-avatar[data-shape-family="0"] .rakazo-organic-avatar-body-working {
   animation: rakazo-organic-float 1.8s ease-in-out infinite;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Mobile chat still felt off vs web/Grok: a tall empty band above the keyboard, an automatic Fresh-start welcome, a verbose "{name} is working" line, and a stale header/placeholder after the bot (or settings) changed name/title/description. Header also lacked a clear tap target into bot settings.

## What

1. **Composer padding** — when the keyboard is open, use 12px bottom padding instead of safe-area + 12, so the input row sits snug to the keyboard.
2. **Empty start** — `onboarding.start` no longer posts the Fresh-start greeting; new chats open empty (focus card still arrives later via `promptFocus`).
3. **Working indicator** — avatar only (copy kept on `accessibilityLabel`); idle shows nothing.
4. **Shared motion** — working-avatar choreography lives in `@rakazo/core` (`avatar-motion.ts`); mobile re-exports it; web CSS documents/tests duration sync via `avatar-motion-sync.test.ts`. Bot colors remain `@rakazo/ui-tokens` `botColors`.
5. **Header → settings** — tapping the bot name/avatar opens `/bot-settings` (also "Chat settings" in the menu).
6. **Live profile** — thread uses `displayName` from `bots/list`; refreshes on focus, run end, and `bot.updated`. New `update_bot` tool persists name/title/description and emits `bot.updated` (settings `bots.update` does too). Placeholder names like "New Bot" promote from title when only title is set.

## Screenshots

Native-only Expo chat chrome; CI does not capture this screen. Skip shots rather than linking an unrelated web screenshot.

## Tests

- `vitest` on core/mobile avatar-motion, android platform contract, ui-web avatar-motion-sync
- `tsc --noEmit` for `@rakazo/mobile`, `@rakazo/core`, `@rakazo/contracts`
- Web onboarding conversation e2e updated: greeting absent; focus card still expected

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6482e20a-e48a-46cf-83e1-77285e976d1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6482e20a-e48a-46cf-83e1-77285e976d1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bots can update their own names, titles, and descriptions.
  - Bot profile changes refresh across open conversations.
  - Added clearer accessibility labels for working-status indicators.
  - Improved composer spacing when the keyboard is visible.
  - Standardized working-avatar animations across mobile and web.

- **Bug Fixes**
  - Onboarding no longer displays a personalized greeting.
  - Conversation labels stay in sync when a bot’s name changes.
  - Improved reliability when refreshing bot profile information and broadcasting profile updates.

- **Refactor**
  - Shared avatar animation behavior is reused across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->