### PR TITLE
Show message timestamps at the row edge on hover

### DIFF
--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -36,6 +36,7 @@ async function expectRailAtRest(
   });
   await expect(rail).toHaveCSS("opacity", "0");
   await expect(rail).toHaveCSS("pointer-events", "none");
+  await expect(row.getByTestId("message-hover-time")).toHaveCSS("opacity", "0");
 }
 
 test("message hover shows beside-bubble actions; reply links to parent", async ({
@@ -56,6 +57,14 @@ test("message hover shows beside-bubble actions; reply links to parent", async (
 
   const botRail = await revealHoverRail(botRow);
   const botToolbar = botRow.getByTestId("message-hover-actions");
+  const botTime = botRow.getByTestId("message-hover-time");
+  await expect(botTime).toHaveCSS("opacity", "1");
+  const botTimeBox = await botTime.boundingBox();
+  const botRowBox = await botRow.boundingBox();
+  expect(botTimeBox).not.toBeNull();
+  expect(botRowBox).not.toBeNull();
+  expect(Math.abs(botTimeBox!.x + botTimeBox!.width - botRowBox!.x - botRowBox!.width)).toBeLessThan(2);
+
   await expect(botToolbar.getByRole("button", { name: "Reply" })).toBeVisible();
   await expect(botToolbar.getByRole("button", { name: "More" })).toBeVisible();
   // Measure a unique visible bubble, so an oversized wrapper cannot hide a gap.
@@ -150,13 +159,18 @@ test("message hover shows beside-bubble actions; reply links to parent", async (
     })
     .toBeLessThan(8);
 
-  // Time is only visible after opening More.
-  await expect(page.getByTestId("message-hover-time")).toHaveCount(0);
+  // Time appears at the opposite row edge on hover, outside More.
   await revealHoverRail(parentRow);
+  const rowTime = parentRow.getByTestId("message-hover-time");
+  await expect(rowTime).toHaveCSS("opacity", "1");
+  await expect(rowTime).toHaveText(/\d/);
+  const timeBox = await rowTime.boundingBox();
+  const rowBox = await parentRow.boundingBox();
+  expect(timeBox).not.toBeNull();
+  expect(rowBox).not.toBeNull();
+  expect(Math.abs(timeBox!.x - rowBox!.x)).toBeLessThan(2);
   await toolbar.getByRole("button", { name: "More" }).click();
-  const moreTime = page.getByTestId("message-hover-time");
-  await expect(moreTime).toBeVisible();
-  await expect(moreTime).toHaveText(/\d/);
+  await expect(page.getByRole("menu").locator("time")).toHaveCount(0);
   // Escape closes More and restores focus to the trigger so the rail stays up.
   await page.keyboard.press("Escape");
   await expect(toolbar.getByRole("button", { name: "More" })).toBeFocused();
@@ -334,7 +348,7 @@ test.describe("touch message actions", () => {
     await expect(rail.getByRole("button", { name: "Reply", exact: true })).toBeHidden();
     await rail.getByRole("button", { name: "More" }).tap();
     await expect(page.getByRole("menuitem", { name: "Copy" })).toBeVisible();
-    await expect(page.getByTestId("message-hover-time")).toBeVisible();
+    await expect(page.getByRole("menu").locator("time")).toHaveCount(0);
     await captureScreenshot(page, testInfo, "message-actions-touch-menu");
     await page.getByRole("menuitem", { name: "Reply", exact: true }).tap();
     await expect(page.getByRole("button", { name: "Cancel reply" })).toBeVisible();

--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -63,7 +63,9 @@ test("message hover shows beside-bubble actions; reply links to parent", async (
   const botRowBox = await botRow.boundingBox();
   expect(botTimeBox).not.toBeNull();
   expect(botRowBox).not.toBeNull();
-  expect(Math.abs(botTimeBox!.x + botTimeBox!.width - botRowBox!.x - botRowBox!.width)).toBeLessThan(2);
+  expect(
+    Math.abs(botTimeBox!.x + botTimeBox!.width - botRowBox!.x - botRowBox!.width),
+  ).toBeLessThan(2);
 
   await expect(botToolbar.getByRole("button", { name: "Reply" })).toBeVisible();
   await expect(botToolbar.getByRole("button", { name: "More" })).toBeVisible();
@@ -348,6 +350,8 @@ test.describe("touch message actions", () => {
     await expect(rail.getByRole("button", { name: "Reply", exact: true })).toBeHidden();
     await rail.getByRole("button", { name: "More" }).tap();
     await expect(page.getByRole("menuitem", { name: "Copy" })).toBeVisible();
+    await expect(row.getByTestId("message-hover-time")).toHaveCSS("opacity", "1");
+    await expect(row.getByTestId("message-hover-time")).toHaveText(/\d/);
     await expect(page.getByRole("menu").locator("time")).toHaveCount(0);
     await captureScreenshot(page, testInfo, "message-actions-touch-menu");
     await page.getByRole("menuitem", { name: "Reply", exact: true }).tap();

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4216,7 +4216,7 @@ const Transcript = memo(function Transcript({
                   dateTime={message.createdAt}
                   data-testid="message-hover-time"
                   className={cn(
-                    "pointer-events-none absolute top-1 z-10 text-xs tabular-nums text-muted-foreground opacity-0 transition-opacity group-hover/message:opacity-100 group-focus-within/message:opacity-100",
+                    "pointer-events-none absolute top-1 z-10 text-xs tabular-nums text-muted-foreground opacity-0 transition-opacity group-hover/message:opacity-100 group-focus-within/message:opacity-100 group-has-[[aria-expanded=true]]/message:opacity-100",
                     message.role === "user" ? "start-0" : "end-0",
                   )}
                 >

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4211,6 +4211,21 @@ const Transcript = memo(function Transcript({
               data-message-id={message.id}
               className={peerReceipt ? "relative py-0.5" : "group/message relative hover:z-20"}
             >
+              {!peerReceipt && !message.id.startsWith("progress:") ? (
+                <time
+                  dateTime={message.createdAt}
+                  data-testid="message-hover-time"
+                  className={cn(
+                    "pointer-events-none absolute top-1 z-10 text-xs tabular-nums text-muted-foreground opacity-0 transition-opacity group-hover/message:opacity-100 group-focus-within/message:opacity-100",
+                    message.role === "user" ? "start-0" : "end-0",
+                  )}
+                >
+                  {new Date(message.createdAt).toLocaleTimeString(i18n.locale || "en", {
+                    hour: "numeric",
+                    minute: "2-digit",
+                  })}
+                </time>
+              ) : null}
               <div
                 className={
                   peerReceipt
@@ -5122,16 +5137,6 @@ function MessageHoverActions({
               <Copy size={14} strokeWidth={1.7} />
               <Trans>Copy</Trans>
             </DropdownMenuItem>
-            <time
-              dateTime={message.createdAt}
-              data-testid="message-hover-time"
-              className="block px-1.5 py-1 text-xs tabular-nums text-muted-foreground"
-            >
-              {new Date(message.createdAt).toLocaleTimeString(i18n.locale || "en", {
-                hour: "numeric",
-                minute: "2-digit",
-              })}
-            </time>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>


### PR DESCRIPTION
Message times should be available while scanning a conversation without opening More. This moves the existing timestamp to the opposite edge of each message row on hover, keyboard focus, or an expanded row control in web and Electron, and removes it from below “Copy”; no new UI copy is added. Updated web E2E coverage checks visibility, row-edge placement, touch access while More is open, and timestamp removal from the menu. Validation passed: repository lint, typechecking, unit tests, production builds, Postgres journeys, and web E2E, with CI screenshots verified for [desktop hover](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34200073930-1/screenshots/images/164-message-bot-actions-desktop.png) and [touch More](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34200073930-1/screenshots/images/163-message-actions-touch-menu.png).
