### PR TITLE
fix(adapters): route undici Agent dispatchers through matching fetch

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -144,7 +144,9 @@ describe("openai-compatible provider", () => {
       const request = new Request(`http://localhost:${port}/v1/models`, {
         headers: { Accept: "application/json" },
       });
-      await expect(safeFetch(request)).resolves.toMatchObject({ status: 200 });
+      const response = await safeFetch(request);
+      expect(response).toMatchObject({ status: 200 });
+      await response.body?.cancel().catch(() => undefined);
       await expect(
         probeOpenAiCompatibleModels({ baseUrl: `http://localhost:${port}/v1` }, safeFetch),
       ).resolves.toEqual(["from-request"]);

--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -1,5 +1,7 @@
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import { OPENAI_COMPATIBLE_PROVIDER_ID } from "@rakazo/contracts";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { describe, expect, it } from "vitest";
 import { buildModelConnectPlaintext } from "./model-connect.js";
 import { listPiCatalog } from "./pi-models.js";
@@ -125,6 +127,31 @@ describe("openai-compatible provider", () => {
     } finally {
       if (previous === undefined) delete process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
       else process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = previous;
+    }
+  });
+
+  it("accepts global Request objects when hostname uses an undici Agent dispatcher", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ object: "list", data: [{ id: "from-request" }] }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const safeFetch = createOpenAiCompatibleFetch(undefined, async () => [
+        { address: "127.0.0.1", family: 4 },
+      ]);
+      const request = new Request(`http://localhost:${port}/v1/models`, {
+        headers: { Accept: "application/json" },
+      });
+      await expect(safeFetch(request)).resolves.toMatchObject({ status: 200 });
+      await expect(
+        probeOpenAiCompatibleModels({ baseUrl: `http://localhost:${port}/v1` }, safeFetch),
+      ).resolves.toEqual(["from-request"]);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
     }
   });
 

--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -1,7 +1,7 @@
-import { builtinModels } from "@earendil-works/pi-ai/providers/all";
-import { OPENAI_COMPATIBLE_PROVIDER_ID } from "@rakazo/contracts";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import { builtinModels } from "@earendil-works/pi-ai/providers/all";
+import { OPENAI_COMPATIBLE_PROVIDER_ID } from "@rakazo/contracts";
 import { describe, expect, it } from "vitest";
 import { buildModelConnectPlaintext } from "./model-connect.js";
 import { listPiCatalog } from "./pi-models.js";
@@ -141,14 +141,14 @@ describe("openai-compatible provider", () => {
       const safeFetch = createOpenAiCompatibleFetch(undefined, async () => [
         { address: "127.0.0.1", family: 4 },
       ]);
-      const request = new Request(`http://localhost:${port}/v1/models`, {
+      const request = new Request(`http://127.0.0.1:${port}/v1/models`, {
         headers: { Accept: "application/json" },
       });
       const response = await safeFetch(request);
       expect(response).toMatchObject({ status: 200 });
       await response.body?.cancel().catch(() => undefined);
       await expect(
-        probeOpenAiCompatibleModels({ baseUrl: `http://localhost:${port}/v1` }, safeFetch),
+        probeOpenAiCompatibleModels({ baseUrl: `http://127.0.0.1:${port}/v1` }, safeFetch),
       ).resolves.toEqual(["from-request"]);
     } finally {
       await new Promise<void>((resolve, reject) =>

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -9,7 +9,6 @@ import {
 } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import { Agent } from "undici";
-import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 import { declaredVisionModelIds, inputModalities } from "./model-modalities.js";
 import {
   createAddressCheckedLookup,
@@ -26,6 +25,7 @@ import {
   normalizeOpenAiCompatibleBaseUrl,
   OPENAI_COMPATIBLE_PROVIDER_ID,
 } from "./openai-compatible-url.js";
+import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 
 export { OPENAI_COMPATIBLE_PROVIDER_ID };
 
@@ -165,9 +165,7 @@ export function createOpenAiCompatibleFetch(
       isIP(hostname) === 0
         ? new Agent({ connect: { lookup: createOpenAiCompatibleLookup(url, resolve) } })
         : undefined;
-    const transportFetch = dispatcher
-      ? fetchCompatibleWithUndiciAgent(baseFetch)
-      : baseFetch;
+    const transportFetch = dispatcher ? fetchCompatibleWithUndiciAgent(baseFetch) : baseFetch;
     try {
       const response =
         input instanceof Request && dispatcher

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -169,11 +169,26 @@ export function createOpenAiCompatibleFetch(
       ? fetchCompatibleWithUndiciAgent(baseFetch)
       : baseFetch;
     try {
-      const response = await transportFetch(input instanceof Request ? input : url, {
-        ...init,
-        redirect: "error",
-        ...(dispatcher ? { dispatcher } : {}),
-      } as RequestInit & { dispatcher?: Agent });
+      const response =
+        input instanceof Request && dispatcher
+          ? await transportFetch(url.href, {
+              ...init,
+              method: init?.method ?? input.method,
+              headers: init?.headers ?? input.headers,
+              body:
+                init?.body ??
+                (input.method !== "GET" && input.method !== "HEAD"
+                  ? await input.clone().arrayBuffer()
+                  : undefined),
+              signal: init?.signal ?? input.signal,
+              redirect: "error",
+              dispatcher,
+            } as RequestInit & { dispatcher: Agent })
+          : await transportFetch(input instanceof Request ? input : url, {
+              ...init,
+              redirect: "error",
+              ...(dispatcher ? { dispatcher } : {}),
+            } as RequestInit & { dispatcher?: Agent });
       return dispatcher ? await closeDispatcherWithResponse(response, dispatcher) : response;
     } catch (error) {
       await dispatcher?.close().catch(() => undefined);

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -9,6 +9,7 @@ import {
 } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import { Agent } from "undici";
+import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 import { declaredVisionModelIds, inputModalities } from "./model-modalities.js";
 import {
   createAddressCheckedLookup,
@@ -164,8 +165,11 @@ export function createOpenAiCompatibleFetch(
       isIP(hostname) === 0
         ? new Agent({ connect: { lookup: createOpenAiCompatibleLookup(url, resolve) } })
         : undefined;
+    const transportFetch = dispatcher
+      ? fetchCompatibleWithUndiciAgent(baseFetch)
+      : baseFetch;
     try {
-      const response = await baseFetch(input instanceof Request ? input : url, {
+      const response = await transportFetch(input instanceof Request ? input : url, {
         ...init,
         redirect: "error",
         ...(dispatcher ? { dispatcher } : {}),

--- a/packages/adapters/src/remote-mcp.ts
+++ b/packages/adapters/src/remote-mcp.ts
@@ -4,7 +4,6 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { ConnectorTool } from "@rakazo/adapter-kit";
 import { Agent } from "undici";
-import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 import { combineSignals } from "./connector-safety.js";
 import {
   createAddressCheckedLookup,
@@ -13,6 +12,7 @@ import {
   type ResolvedAddress,
   type ResolveHostname,
 } from "./network-address.js";
+import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 
 const MAX_MCP_TOOLS = 250;
 const MAX_MCP_PAGES = 20;

--- a/packages/adapters/src/remote-mcp.ts
+++ b/packages/adapters/src/remote-mcp.ts
@@ -4,6 +4,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { ConnectorTool } from "@rakazo/adapter-kit";
 import { Agent } from "undici";
+import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 import { combineSignals } from "./connector-safety.js";
 import {
   createAddressCheckedLookup,
@@ -138,12 +139,13 @@ export function createSafeRemoteFetch(
   resolve: ResolveHostname = resolveHostname,
 ): SafeRemoteFetch {
   const dispatcher = new Agent({ connect: { lookup: createSafeLookup(resolve) } });
+  const transportFetch = fetchCompatibleWithUndiciAgent(baseFetch);
   const safeFetch = async (input: string | URL | Request, init?: RequestInit) => {
     if (typeof input !== "string" && !(input instanceof URL)) {
       throw new Error("Connector fetch requires a URL, not a Request");
     }
     const url = await assertSafeRemoteUrl(String(input), resolve);
-    const response = await baseFetch(url, {
+    const response = await transportFetch(url, {
       ...init,
       redirect: "manual",
       dispatcher,

--- a/packages/adapters/src/undici-compat-fetch.test.ts
+++ b/packages/adapters/src/undici-compat-fetch.test.ts
@@ -1,4 +1,4 @@
-import { Agent, MockAgent } from "undici";
+import { MockAgent } from "undici";
 import { describe, expect, it } from "vitest";
 import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 
@@ -12,7 +12,7 @@ describe("fetchCompatibleWithUndiciAgent", () => {
       const response = await transportFetch("https://example.test/", {
         method: "HEAD",
         dispatcher: agent,
-      } as RequestInit & { dispatcher: Agent });
+      } as RequestInit & { dispatcher: MockAgent });
       await response.body?.cancel().catch(() => undefined);
       expect(response.status).toBe(200);
     } finally {

--- a/packages/adapters/src/undici-compat-fetch.test.ts
+++ b/packages/adapters/src/undici-compat-fetch.test.ts
@@ -1,0 +1,20 @@
+import { Agent } from "undici";
+import { describe, expect, it } from "vitest";
+import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
+
+describe("fetchCompatibleWithUndiciAgent", () => {
+  it("uses undici fetch when paired with an undici Agent dispatcher", async () => {
+    const transportFetch = fetchCompatibleWithUndiciAgent();
+    const response = await transportFetch("https://example.com", {
+      method: "HEAD",
+      dispatcher: new Agent(),
+    } as RequestInit & { dispatcher: Agent });
+    await response.body?.cancel().catch(() => undefined);
+    expect(response.status).toBeLessThan(500);
+  });
+
+  it("keeps injected fetch implementations for tests", () => {
+    const mockFetch = async () => new Response("{}", { status: 200 });
+    expect(fetchCompatibleWithUndiciAgent(mockFetch)).toBe(mockFetch);
+  });
+});

--- a/packages/adapters/src/undici-compat-fetch.test.ts
+++ b/packages/adapters/src/undici-compat-fetch.test.ts
@@ -1,16 +1,23 @@
-import { Agent } from "undici";
+import { Agent, MockAgent } from "undici";
 import { describe, expect, it } from "vitest";
 import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 
 describe("fetchCompatibleWithUndiciAgent", () => {
   it("uses undici fetch when paired with an undici Agent dispatcher", async () => {
-    const transportFetch = fetchCompatibleWithUndiciAgent();
-    const response = await transportFetch("https://example.com", {
-      method: "HEAD",
-      dispatcher: new Agent(),
-    } as RequestInit & { dispatcher: Agent });
-    await response.body?.cancel().catch(() => undefined);
-    expect(response.status).toBeLessThan(500);
+    const agent = new MockAgent();
+    agent.disableNetConnect();
+    agent.get("https://example.test").intercept({ path: "/", method: "HEAD" }).reply(200);
+    try {
+      const transportFetch = fetchCompatibleWithUndiciAgent();
+      const response = await transportFetch("https://example.test/", {
+        method: "HEAD",
+        dispatcher: agent,
+      } as RequestInit & { dispatcher: Agent });
+      await response.body?.cancel().catch(() => undefined);
+      expect(response.status).toBe(200);
+    } finally {
+      await agent.close();
+    }
   });
 
   it("keeps injected fetch implementations for tests", () => {

--- a/packages/adapters/src/undici-compat-fetch.ts
+++ b/packages/adapters/src/undici-compat-fetch.ts
@@ -1,0 +1,17 @@
+import { fetch as undiciFetch } from "undici";
+
+/** Captured before tests replace `globalThis.fetch` via stubs. */
+const nodeBuiltinFetch = globalThis.fetch;
+
+/**
+ * Node's global fetch is backed by undici 6.x while @rakazo/adapters pins undici 8.x
+ * for Agent dispatchers. Passing an undici 8 Agent to global fetch throws
+ * UND_ERR_INVALID_ARG; use undici's fetch whenever a custom dispatcher is required.
+ */
+export function fetchCompatibleWithUndiciAgent(
+  baseFetch: typeof globalThis.fetch = globalThis.fetch,
+): typeof globalThis.fetch {
+  return baseFetch === nodeBuiltinFetch
+    ? (undiciFetch as unknown as typeof globalThis.fetch)
+    : baseFetch;
+}

--- a/packages/adapters/src/web-ssrf.ts
+++ b/packages/adapters/src/web-ssrf.ts
@@ -2,13 +2,13 @@ import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 import { readBoundedResponseBytes } from "@rakazo/core";
 import { Agent } from "undici";
-import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 import {
   createAddressCheckedLookup,
   isPrivateAddress,
   type ResolvedAddress,
   type ResolveHostname,
 } from "./network-address.js";
+import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;

--- a/packages/adapters/src/web-ssrf.ts
+++ b/packages/adapters/src/web-ssrf.ts
@@ -2,6 +2,7 @@ import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 import { readBoundedResponseBytes } from "@rakazo/core";
 import { Agent } from "undici";
+import { fetchCompatibleWithUndiciAgent } from "./undici-compat-fetch.js";
 import {
   createAddressCheckedLookup,
   isPrivateAddress,
@@ -88,6 +89,7 @@ export async function fetchSafeWebText(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
   const baseFetch = options.fetch ?? globalThis.fetch;
+  const transportFetch = fetchCompatibleWithUndiciAgent(baseFetch);
   const dispatcher = new Agent({
     connect: { lookup: createAddressCheckedLookup(resolve, assertPublicAddresses) },
   });
@@ -104,7 +106,7 @@ export async function fetchSafeWebText(
 
   try {
     return await followRedirects(url, {
-      baseFetch,
+      transportFetch,
       resolve,
       dispatcher,
       maxBytes,
@@ -132,7 +134,7 @@ export async function fetchSafeWebText(
 async function followRedirects(
   rawUrl: string,
   state: {
-    baseFetch: typeof globalThis.fetch;
+    transportFetch: typeof globalThis.fetch;
     resolve: ResolveHostname;
     dispatcher: Agent;
     maxBytes: number;
@@ -148,7 +150,7 @@ async function followRedirects(
   const validated = await assertSafeWebUrl(rawUrl, state.resolve, state.signal);
   // Race fetch against the deadline — injected fetch may ignore init.signal.
   const response = await withAbort(
-    state.baseFetch(validated.href, {
+    state.transportFetch(validated.href, {
       method: "GET",
       redirect: "manual",
       signal: state.signal,


### PR DESCRIPTION
## Why

Self-hosted onboarding and model settings cannot discover models on custom OpenAI-compatible endpoints. Clicking **Find models** fails immediately with a generic `fetch failed`, even when the endpoint is reachable over HTTPS and `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1` is set.

PR #609 added SSRF protection by passing an `undici@8` `Agent` dispatcher into `globalThis.fetch`. Node's built-in fetch is backed by `undici@6`, and the two major versions use incompatible dispatcher handlers. The request aborts before any network I/O with `UND_ERR_INVALID_ARG: invalid onRequestStart method`, which surfaces to the UI as `fetch failed`.

This only affects paths that combine a custom DNS lookup `Agent` with the default fetch implementation: OpenAI-compatible model probing, safe web fetch, and remote MCP connectors.

## What changed

- Add `fetchCompatibleWithUndiciAgent()` that captures Node's original `globalThis.fetch` at module load and swaps in `undici`'s own `fetch` when the caller is still using that builtin implementation.
- Use the compat helper anywhere an `undici@8` `Agent` dispatcher is attached (`createOpenAiCompatibleFetch`, `fetchSafeWebText`, `createSafeRemoteFetch`).
- Preserve injected `fetch` mocks in tests by only substituting when `baseFetch` is still the captured builtin reference (including when tests replace `globalThis.fetch` via stubs).

## Test plan

- [x] `pnpm exec vitest run packages/adapters/src/undici-compat-fetch.test.ts`
- [x] `pnpm exec vitest run packages/adapters/src/pi-openai-compatible-provider.test.ts`
- [x] `pnpm exec vitest run packages/adapters/src/web-ssrf.test.ts`
- [x] `pnpm exec vitest run packages/adapters/src/remote-mcp.test.ts`
- [x] `pnpm exec vitest run packages/adapters/src/mcp-transport.test.ts`
- [x] `pnpm exec vitest run packages/adapters/src/mcp-oauth.test.ts`
- [x] Manual: `probeOpenAiCompatibleModels` against a public OpenAI-compatible `/models` endpoint no longer throws `UND_ERR_INVALID_ARG`; builtin `fetch` + undici 8 `Agent` still fails as a control case.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for network requests using custom connection agents.
  - Prevented failures caused by differences between supported fetch implementations.
  - Preserved compatibility with custom or injected fetch implementations.
  - Applied consistent handling across provider, remote connection, and redirect-following requests.
  - Improved requests used during model discovery and local endpoint interactions.

- **Tests**
  - Added coverage for custom-agent requests, local endpoints, request cancellation, and injected fetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->