### PR TITLE
Fix guarded fetches under undici 8 and reach Tailscale MCP hosts over IPv6

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -717,11 +717,7 @@ export function createRouter(deps: RouterDeps) {
       probeOpenAiCompatible: authed.models.probeOpenAiCompatible.handler(
         async ({ context, input }) => {
           try {
-            const models = await probeOpenAiCompatibleModels(
-              input,
-              deps.remoteConnectors?.fetch,
-              context.signal,
-            );
+            const models = await probeOpenAiCompatibleModels(input, undefined, context.signal);
             return { models };
           } catch (error) {
             throw new ORPCError("BAD_REQUEST", {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -717,7 +717,11 @@ export function createRouter(deps: RouterDeps) {
       probeOpenAiCompatible: authed.models.probeOpenAiCompatible.handler(
         async ({ context, input }) => {
           try {
-            const models = await probeOpenAiCompatibleModels(input, fetch, context.signal);
+            const models = await probeOpenAiCompatibleModels(
+              input,
+              deps.remoteConnectors?.fetch,
+              context.signal,
+            );
             return { models };
           } catch (error) {
             throw new ORPCError("BAD_REQUEST", {

--- a/packages/adapters/src/graphql-connectors.ts
+++ b/packages/adapters/src/graphql-connectors.ts
@@ -295,7 +295,7 @@ export async function executeGraphqlOperation(
     if (name in args) variables[name] = args[name];
   }
 
-  const safeFetch = createSafeRemoteFetch(remote.fetch ?? globalThis.fetch, remote.resolveHostname);
+  const safeFetch = createSafeRemoteFetch(remote.fetch, remote.resolveHostname);
   try {
     const response = await safeFetch(url, {
       method: "POST",
@@ -357,7 +357,7 @@ async function introspectGraphqlEndpoint(
   signal?: AbortSignal,
   remote: RemoteGraphqlDependencies = {},
 ): Promise<Record<string, unknown>> {
-  const safeFetch = createSafeRemoteFetch(remote.fetch ?? globalThis.fetch, remote.resolveHostname);
+  const safeFetch = createSafeRemoteFetch(remote.fetch, remote.resolveHostname);
   try {
     const response = await safeFetch(url, {
       method: "POST",

--- a/packages/adapters/src/installed-connectors.ts
+++ b/packages/adapters/src/installed-connectors.ts
@@ -385,7 +385,7 @@ async function loadOpenApiDocument(
   signal?: AbortSignal,
   remote: RemoteConnectorDependencies = {},
 ): Promise<Record<string, unknown>> {
-  const safeFetch = createSafeRemoteFetch(remote.fetch ?? globalThis.fetch, remote.resolveHostname);
+  const safeFetch = createSafeRemoteFetch(remote.fetch, remote.resolveHostname);
   try {
     const response = await safeFetch(url, {
       headers,
@@ -550,7 +550,7 @@ async function executeApiOperation(
     headers["content-type"] = "application/json";
   }
   applyCredential(url, headers, config.auth, credential);
-  const safeFetch = createSafeRemoteFetch(remote.fetch ?? globalThis.fetch, remote.resolveHostname);
+  const safeFetch = createSafeRemoteFetch(remote.fetch, remote.resolveHostname);
   try {
     const response = await safeFetch(url, {
       method: operation.method,

--- a/packages/adapters/src/keyless-http-web.ts
+++ b/packages/adapters/src/keyless-http-web.ts
@@ -52,7 +52,7 @@ export const duckDuckGoHtmlSearchBackend: KeylessHtmlSearchBackend = {
  * Mozilla Readability with a lightweight HTML-strip fallback.
  */
 export class KeylessHttpWebProvider implements WebProvider {
-  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly fetchImpl?: typeof globalThis.fetch;
   private readonly resolveHostname?: ResolveHostname;
   private readonly searchBackend: KeylessHtmlSearchBackend;
   private readonly searchTimeoutMs: number;
@@ -61,7 +61,7 @@ export class KeylessHttpWebProvider implements WebProvider {
   private readonly userAgent: string;
 
   constructor(options: KeylessHttpWebOptions = {}) {
-    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.fetchImpl = options.fetch;
     this.resolveHostname = options.resolveHostname;
     this.searchBackend = options.searchBackend ?? duckDuckGoHtmlSearchBackend;
     this.searchTimeoutMs = options.searchTimeoutMs ?? 15_000;

--- a/packages/adapters/src/mcp-connector.test.ts
+++ b/packages/adapters/src/mcp-connector.test.ts
@@ -24,6 +24,12 @@ const ASSIGNMENT = {
   server: SERVER,
 };
 
+const TEST_NETWORK = {
+  // Read the global per call so a fetch stubbed after construction still wins.
+  fetch: (input: string | URL | Request, init?: RequestInit) => globalThis.fetch(input, init),
+  resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }],
+};
+
 function mcpFetch(
   state: {
     failNext: boolean;
@@ -102,7 +108,7 @@ describe("MCP connector session cache", () => {
       },
     };
     const connector = new McpConnector(prisma as never, {} as never, {
-      network: { resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }] },
+      network: TEST_NETWORK,
     });
     const context = {
       spaceId: "w1",
@@ -148,7 +154,7 @@ describe("MCP connector session cache", () => {
           },
         } as never,
         {} as never,
-        { network: { resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }] } },
+        { network: TEST_NETWORK },
       );
       const tools = await connector.discoverTools(context);
       if (count === 20) {
@@ -205,7 +211,7 @@ describe("MCP connector session cache", () => {
       },
     };
     const connector = new McpConnector(prisma as never, {} as never, {
-      network: { resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }] },
+      network: TEST_NETWORK,
     });
     const context = {
       spaceId: "w1",
@@ -364,7 +370,7 @@ describe("MCP connector session cache", () => {
       },
     };
     const connector = new McpConnector(prisma as never, {} as never, {
-      network: { resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }] },
+      network: TEST_NETWORK,
     });
     const context = {
       spaceId: "w1",
@@ -537,9 +543,7 @@ describe("MCP connector session cache", () => {
       },
     };
     const connector = new McpConnector(prisma as never, {} as never, {
-      network: {
-        resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }],
-      },
+      network: TEST_NETWORK,
     });
     const context = {
       spaceId: "w1",
@@ -581,7 +585,7 @@ describe("MCP connector session cache", () => {
       },
     };
     const connector = new McpConnector(prisma as never, {} as never, {
-      network: { resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }] },
+      network: TEST_NETWORK,
     });
     const contextFor = (spaceId: string, userId: string) =>
       ({ spaceId, userId, botId: "bot-1", signal: new AbortController().signal }) as never;

--- a/packages/adapters/src/mcp-oauth.test.ts
+++ b/packages/adapters/src/mcp-oauth.test.ts
@@ -671,7 +671,7 @@ describe("MCP OAuth", () => {
         userId: "user-1",
         redirectUri: "http://127.0.0.1:5173/mcp/oauth/callback",
       }),
-    ).rejects.toThrow(/fetch failed|Unexpected request/);
+    ).rejects.toThrow(/Could not reach private-auth\.example\.test|Unexpected request/);
 
     expect(requests).toContain(
       "GET https://mcp.example.test/.well-known/oauth-protected-resource/mcp",

--- a/packages/adapters/src/mcp-oauth.test.ts
+++ b/packages/adapters/src/mcp-oauth.test.ts
@@ -8,6 +8,8 @@ import {
 afterEach(() => vi.unstubAllGlobals());
 
 const TEST_NETWORK = {
+  // Read the global per call so a fetch stubbed after construction still wins.
+  fetch: (input: string | URL | Request, init?: RequestInit) => globalThis.fetch(input, init),
   resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }],
 };
 

--- a/packages/adapters/src/mcp-transport.test.ts
+++ b/packages/adapters/src/mcp-transport.test.ts
@@ -13,6 +13,8 @@ import {
 afterEach(() => vi.unstubAllGlobals());
 
 const TEST_NETWORK = {
+  // Read the global per call so a fetch stubbed after construction still wins.
+  fetch: (input: string | URL | Request, init?: RequestInit) => globalThis.fetch(input, init),
   resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }],
 };
 
@@ -130,7 +132,7 @@ describe("MCP transport seam", () => {
       new URL(resource),
       { allowHttpLocalhost: true, allowLocalHttpCredentials: true },
       {},
-      { fetch: fetchImpl, ...TEST_NETWORK },
+      { ...TEST_NETWORK, fetch: fetchImpl },
     );
     try {
       await expect(safeFetch(`${origin}/.well-known/oauth-protected-resource`)).rejects.toThrow(

--- a/packages/adapters/src/mcp-transport.ts
+++ b/packages/adapters/src/mcp-transport.ts
@@ -125,10 +125,7 @@ export function secureFetch(
     "cookie",
     "proxy-authorization",
   ]);
-  const safeRemoteFetch = createSafeRemoteFetch(
-    network.fetch ?? globalThis.fetch,
-    network.resolveHostname,
-  );
+  const safeRemoteFetch = createSafeRemoteFetch(network.fetch, network.resolveHostname);
   const request = async (input: Request | URL | string, init?: RequestInit): Promise<Response> => {
     const source = new Request(input, init);
     // OAuth challenges and rediscovery can supply new URLs. Only the explicitly

--- a/packages/adapters/src/network-address.ts
+++ b/packages/adapters/src/network-address.ts
@@ -8,6 +8,8 @@ const CLOUD_METADATA_IPV4 = new Set([
   ipv4ToNumber("100.100.100.200"),
 ]);
 const AWS_IMDS_IPV6 = 0xfd000ec2000000000000000000000254n;
+/** fd7a:115c:a1e0::/48 — the Tailscale IPv6 range. */
+const TAILSCALE_ULA_PREFIX = 0xfd7a115ca1e0n;
 
 export function createAddressCheckedLookup(
   resolve: ResolveHostname,
@@ -78,6 +80,22 @@ export function isCloudMetadataAddress(address: string): boolean {
   if (ipv6 === AWS_IMDS_IPV6) return true;
   const embeddedIpv4 = getEmbeddedIpv4Number(ipv6);
   return embeddedIpv4 !== undefined && isCloudMetadataIpv4Number(embeddedIpv4);
+}
+
+/** Tailscale gives every node a CGNAT 100.64.0.0/10 address and an
+ * fd7a:115c:a1e0::/48 ULA, and MagicDNS answers with both. Callers that accept
+ * a tailnet host have to accept the IPv6 half too, or the name resolves to one
+ * allowed and one blocked address and the whole host is rejected. */
+export function isTailscaleAddress(address: string): boolean {
+  const value = address.toLowerCase().replace(/^\[|\]$/g, "");
+  const mapped = value.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)?.[1];
+  const ipv4 = mapped ?? (isIP(value) === 4 ? value : undefined);
+  if (ipv4) {
+    const [a, b] = ipv4.split(".").map(Number);
+    return a === 100 && b != null && b >= 64 && b <= 127;
+  }
+  const ipv6 = parseIpv6(value);
+  return ipv6 !== undefined && ipv6 >> 80n === TAILSCALE_ULA_PREFIX;
 }
 
 export function isLinkLocalAddress(address: string): boolean {

--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -146,6 +146,49 @@ describe("openai-compatible provider", () => {
     }
   });
 
+  it("flattens a global Request so the package fetch can dispatch it", async () => {
+    // undici's fetch reads a foreign Request as "[object Request]"; reaching
+    // the lookup proves the request was dispatched with its URL instead.
+    const previous = process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
+    process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";
+    try {
+      const safeFetch = createOpenAiCompatibleFetch(undefined, async () => {
+        throw new Error("lookup reached");
+      });
+      const request = new Request("https://models.example.test/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "local" }),
+      });
+      await expect(safeFetch(request)).rejects.toMatchObject({
+        cause: { message: "lookup reached" },
+      });
+    } finally {
+      if (previous === undefined) delete process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
+      else process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = previous;
+    }
+  });
+
+  it("carries a Request's method, headers and body through as init", async () => {
+    let seen: { url: string; init?: RequestInit } | undefined;
+    const safeFetch = createOpenAiCompatibleFetch(async (input, init) => {
+      seen = { url: String(input), init };
+      return new Response("{}", { status: 200 });
+    });
+    await safeFetch(
+      new Request("http://127.0.0.1:8000/v1/models", {
+        method: "POST",
+        headers: { "x-trace": "1" },
+        body: "payload",
+      }),
+      { headers: { "x-trace": "2" } },
+    );
+    expect(seen?.url).toBe("http://127.0.0.1:8000/v1/models");
+    expect(seen?.init?.method).toBe("POST");
+    expect(new Headers(seen?.init?.headers).get("x-trace")).toBe("2");
+    expect(Buffer.from(seen?.init?.body as ArrayBuffer).toString()).toBe("payload");
+  });
+
   it("rejects public hostnames that resolve to private addresses", async () => {
     const lookup = createOpenAiCompatibleLookup(
       new URL("https://models.example.test/v1"),

--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -128,6 +128,24 @@ describe("openai-compatible provider", () => {
     }
   });
 
+  it("drives the guarded dispatcher with a fetch from the same undici", async () => {
+    // See remote-mcp.test: failing inside the lookup proves the request was
+    // dispatched through the Agent rather than rejected by a mismatched fetch.
+    const previous = process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
+    process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";
+    try {
+      const safeFetch = createOpenAiCompatibleFetch(undefined, async () => {
+        throw new Error("lookup reached");
+      });
+      await expect(safeFetch("https://models.example.test/v1/models")).rejects.toMatchObject({
+        cause: { message: "lookup reached" },
+      });
+    } finally {
+      if (previous === undefined) delete process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
+      else process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = previous;
+    }
+  });
+
   it("rejects public hostnames that resolve to private addresses", async () => {
     const lookup = createOpenAiCompatibleLookup(
       new URL("https://models.example.test/v1"),

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -173,8 +173,8 @@ export function createOpenAiCompatibleFetch(
         ? new Agent({ connect: { lookup: createOpenAiCompatibleLookup(url, resolve) } })
         : undefined;
     try {
-      const response = await baseFetch(input instanceof Request ? input : url, {
-        ...init,
+      const response = await baseFetch(url, {
+        ...(await requestInitFor(input, init)),
         redirect: "error",
         ...(dispatcher ? { dispatcher } : {}),
       } as RequestInit & { dispatcher?: Agent });
@@ -184,6 +184,18 @@ export function createOpenAiCompatibleFetch(
       throw error;
     }
   };
+}
+
+/** The base fetch comes from the undici package, which recognizes only its own
+ * Request class and reads a global Request as the string "[object Request]".
+ * Flatten Request inputs to a URL plus init, with init overriding the
+ * Request's fields the way fetch itself merges them. */
+async function requestInitFor(input: RequestInfo | URL, init?: RequestInit): Promise<RequestInit> {
+  if (!(input instanceof Request)) return init ?? {};
+  const request = new Request(input, init);
+  const body =
+    request.method === "GET" || request.method === "HEAD" ? undefined : await request.arrayBuffer();
+  return { method: request.method, headers: request.headers, body, signal: request.signal };
 }
 
 async function closeDispatcherWithResponse(

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -25,6 +25,7 @@ import {
   normalizeOpenAiCompatibleBaseUrl,
   OPENAI_COMPATIBLE_PROVIDER_ID,
 } from "./openai-compatible-url.js";
+import { dispatcherFetch } from "./undici-fetch.js";
 
 export { OPENAI_COMPATIBLE_PROVIDER_ID };
 
@@ -76,12 +77,19 @@ export function openAiCompatibleModel(
 
 function openAiCompatibleProvider(models: Model<"openai-completions">[]): Provider {
   const api = openAICompletionsApi();
-  const safeFetch = createOpenAiCompatibleFetch();
+  // Guard the fetch the caller supplied (the runtime's seam for tests) or the
+  // dispatcher-matched default; never the bare global.
   const safeApi: ProviderStreams = {
     stream: (model, context, options) =>
-      api.stream(model, context, { ...options, fetch: safeFetch }),
+      api.stream(model, context, {
+        ...options,
+        fetch: createOpenAiCompatibleFetch(options?.fetch),
+      }),
     streamSimple: (model, context, options) =>
-      api.streamSimple(model, context, { ...options, fetch: safeFetch }),
+      api.streamSimple(model, context, {
+        ...options,
+        fetch: createOpenAiCompatibleFetch(options?.fetch),
+      }),
   };
   return createProvider({
     id: OPENAI_COMPATIBLE_PROVIDER_ID,
@@ -150,7 +158,7 @@ function requestCarriesAuthorization(input: RequestInfo | URL, init?: RequestIni
 }
 
 export function createOpenAiCompatibleFetch(
-  baseFetch: typeof globalThis.fetch = globalThis.fetch,
+  baseFetch: typeof globalThis.fetch = dispatcherFetch,
   resolve: ResolveHostname = resolveHostname,
 ): typeof globalThis.fetch {
   return async (input, init) => {
@@ -363,7 +371,7 @@ async function readBoundedJson(response: Response): Promise<OpenAiCompatibleMode
 
 export async function probeOpenAiCompatibleModels(
   input: { baseUrl: string; apiKey?: string },
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl?: typeof fetch,
   signal?: AbortSignal,
 ): Promise<string[]> {
   const baseUrl = assertAllowedOpenAiCompatibleUrl(input.baseUrl);

--- a/packages/adapters/src/remote-mcp.test.ts
+++ b/packages/adapters/src/remote-mcp.test.ts
@@ -173,6 +173,25 @@ describe("remote MCP URL policy", () => {
     }
   });
 
+  it("drives the guarded dispatcher with a fetch from the same undici", async () => {
+    // A fetch from a different undici than the Agent fails at dispatch with
+    // "invalid onRequestStart method" before the lookup runs. Failing inside
+    // the lookup proves the request reached the guarded Agent.
+    let resolutions = 0;
+    const safeFetch = createSafeRemoteFetch(undefined, async () => {
+      resolutions += 1;
+      if (resolutions > 1) throw new Error("lookup reached");
+      return [{ address: "203.0.113.10", family: 4 as const }];
+    });
+    try {
+      await expect(safeFetch("https://connectors.example.test/mcp")).rejects.toThrow(
+        "Could not reach connectors.example.test: lookup reached",
+      );
+    } finally {
+      await safeFetch.close();
+    }
+  });
+
   it("rejects Request inputs instead of silently dropping their method and body", async () => {
     const safeFetch = createSafeRemoteFetch(
       async () => new Response(null, { status: 204 }),

--- a/packages/adapters/src/remote-mcp.test.ts
+++ b/packages/adapters/src/remote-mcp.test.ts
@@ -59,6 +59,36 @@ describe("remote MCP URL policy", () => {
     expect(result).toEqual({ address: "100.119.57.55", family: 4 });
   });
 
+  it("allows the IPv6 half of a MagicDNS answer", async () => {
+    // MagicDNS answers with the node's fd7a:115c:a1e0::/48 ULA alongside its
+    // CGNAT address, so rejecting the ULA rejects every tailnet host.
+    const magicDns = "https://box.tail12345.ts.net/mcp";
+    const addresses = [
+      { address: "fd7a:115c:a1e0:ab12:4843:cd96:6265:6667", family: 6 as const },
+      { address: "100.64.1.2", family: 4 as const },
+    ];
+    await expect(assertSafeRemoteUrl(magicDns, async () => addresses)).resolves.toEqual(
+      new URL(magicDns),
+    );
+
+    const safeLookup = createSafeLookup(async () => addresses);
+    const resolved = await new Promise<unknown>((resolve, reject) => {
+      safeLookup("box.tail12345.ts.net", { family: 0, all: true }, (error, entries) => {
+        if (error) reject(error);
+        else resolve(entries);
+      });
+    });
+    expect(resolved).toEqual(addresses);
+  });
+
+  it("rejects non-Tailscale IPv6 private ranges for MagicDNS hosts", async () => {
+    await expect(
+      assertSafeRemoteUrl("https://box.tail12345.ts.net/mcp", async () => [
+        { address: "fd00:1234::1", family: 6 as const },
+      ]),
+    ).rejects.toThrow("private address");
+  });
+
   it("still rejects raw Tailscale CGNAT IP literals", async () => {
     await expect(
       assertSafeRemoteUrl("https://100.64.1.2/openapi.json", publicResolver),
@@ -107,6 +137,40 @@ describe("remote MCP URL policy", () => {
       });
     });
     expect(result).toEqual({ address: "203.0.113.10", family: 4 });
+  });
+
+  it("reports why a connection failed instead of a bare fetch failure", async () => {
+    const cause = Object.assign(new Error("connect EHOSTUNREACH 100.64.1.2:443"), {
+      code: "EHOSTUNREACH",
+    });
+    const safeFetch = createSafeRemoteFetch(async () => {
+      throw new TypeError("fetch failed", { cause });
+    }, publicResolver);
+    try {
+      await expect(safeFetch("https://connectors.example.test/mcp")).rejects.toThrow(
+        "Could not reach connectors.example.test: connect EHOSTUNREACH 100.64.1.2:443",
+      );
+    } finally {
+      await safeFetch.close();
+    }
+  });
+
+  it("unwraps the per-address errors undici reports for dual-stack hosts", async () => {
+    const safeFetch = createSafeRemoteFetch(async () => {
+      throw new TypeError("fetch failed", {
+        cause: new AggregateError(
+          [new TypeError("fetch failed"), new Error("connect ECONNREFUSED 100.64.1.2:443")],
+          "",
+        ),
+      });
+    }, publicResolver);
+    try {
+      await expect(safeFetch("https://connectors.example.test/mcp")).rejects.toThrow(
+        "connect ECONNREFUSED 100.64.1.2:443",
+      );
+    } finally {
+      await safeFetch.close();
+    }
   });
 
   it("rejects Request inputs instead of silently dropping their method and body", async () => {

--- a/packages/adapters/src/remote-mcp.ts
+++ b/packages/adapters/src/remote-mcp.ts
@@ -13,6 +13,7 @@ import {
   type ResolvedAddress,
   type ResolveHostname,
 } from "./network-address.js";
+import { dispatcherFetch } from "./undici-fetch.js";
 
 const MAX_MCP_TOOLS = 250;
 const MAX_MCP_PAGES = 20;
@@ -94,7 +95,7 @@ async function withRemoteMcpClient<T>(
   );
   const signal = combineSignals(options.signal, AbortSignal.timeout(MCP_TIMEOUT_MS));
   const safeFetch = createSafeRemoteFetch(
-    options.fetch ?? globalThis.fetch,
+    options.fetch,
     options.resolveHostname ?? resolveHostname,
   );
   const transport = new StreamableHTTPClientTransport(endpoint, {
@@ -135,7 +136,7 @@ export async function assertSafeRemoteUrl(
 }
 
 export function createSafeRemoteFetch(
-  baseFetch: typeof globalThis.fetch = globalThis.fetch,
+  baseFetch: typeof globalThis.fetch = dispatcherFetch,
   resolve: ResolveHostname = resolveHostname,
 ): SafeRemoteFetch {
   const dispatcher = new Agent({ connect: { lookup: createSafeLookup(resolve) } });

--- a/packages/adapters/src/remote-mcp.ts
+++ b/packages/adapters/src/remote-mcp.ts
@@ -9,6 +9,7 @@ import {
   createAddressCheckedLookup,
   isCloudMetadataAddress,
   isPrivateAddress,
+  isTailscaleAddress,
   type ResolvedAddress,
   type ResolveHostname,
 } from "./network-address.js";
@@ -143,11 +144,19 @@ export function createSafeRemoteFetch(
       throw new Error("Connector fetch requires a URL, not a Request");
     }
     const url = await assertSafeRemoteUrl(String(input), resolve);
-    const response = await baseFetch(url, {
-      ...init,
-      redirect: "manual",
-      dispatcher,
-    } as RequestInit & { dispatcher: Agent });
+    let response: Response;
+    try {
+      response = await baseFetch(url, {
+        ...init,
+        redirect: "manual",
+        dispatcher,
+      } as RequestInit & { dispatcher: Agent });
+    } catch (error) {
+      const detail = transportFailureDetail(error);
+      throw new Error(`Could not reach ${url.host}${detail ? `: ${detail}` : ""}`, {
+        cause: error,
+      });
+    }
     if (response.status >= 300 && response.status < 400) {
       throw new Error("Connector redirects are not allowed");
     }
@@ -158,6 +167,25 @@ export function createSafeRemoteFetch(
   return result;
 }
 
+const MAX_CAUSE_DEPTH = 5;
+
+/** undici reports refused ports, unreachable hosts, DNS misses and TLS errors
+ * alike as `TypeError: fetch failed` and keeps the actionable reason in `cause`
+ * (or in the per-address errors of a happy-eyeballs AggregateError). */
+function transportFailureDetail(error: unknown, depth = 0): string | undefined {
+  if (depth >= MAX_CAUSE_DEPTH || !(error instanceof Error)) return undefined;
+  if (error instanceof AggregateError) {
+    for (const inner of error.errors) {
+      const detail = transportFailureDetail(inner, depth + 1);
+      if (detail) return detail;
+    }
+  }
+  return (
+    transportFailureDetail(error.cause, depth + 1) ??
+    (error.message === "fetch failed" ? undefined : error.message)
+  );
+}
+
 export function createSafeLookup(resolve: ResolveHostname = resolveHostname): LookupFunction {
   return createAddressCheckedLookup(resolve, assertPublicAddresses);
 }
@@ -166,16 +194,6 @@ export function createSafeLookup(resolve: ResolveHostname = resolveHostname): Lo
 function isTailscaleMagicDnsHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase().replace(/\.$/, "");
   return normalized === "ts.net" || normalized.endsWith(".ts.net");
-}
-
-/** Tailscale assigns CGNAT 100.64.0.0/10; MagicDNS may resolve there. */
-function isTailscaleCgnatAddress(address: string): boolean {
-  const value = address.toLowerCase().replace(/^\[|\]$/g, "");
-  const mapped = value.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)?.[1];
-  const ipv4 = mapped ?? (isIP(value) === 4 ? value : undefined);
-  if (!ipv4) return false;
-  const [a, b] = ipv4.split(".").map(Number);
-  return a === 100 && b != null && b >= 64 && b <= 127;
 }
 
 function isPrivateHostname(hostname: string): boolean {
@@ -200,8 +218,8 @@ function assertPublicAddresses(addresses: ResolvedAddress[], hostname?: string):
     addresses.some((entry) => {
       if (isCloudMetadataAddress(entry.address)) return true;
       if (!isPrivateAddress(entry.address)) return false;
-      // Allow only Tailscale CGNAT for MagicDNS; keep other private ranges blocked.
-      return !(magicDns && isTailscaleCgnatAddress(entry.address));
+      // Allow only Tailscale ranges for MagicDNS; keep other private ranges blocked.
+      return !(magicDns && isTailscaleAddress(entry.address));
     })
   ) {
     throw new Error("Connector URL resolves to a private address");

--- a/packages/adapters/src/undici-fetch.ts
+++ b/packages/adapters/src/undici-fetch.ts
@@ -1,0 +1,11 @@
+import { fetch as undiciFetch } from "undici";
+
+/** The fetch that must drive any `Agent` built from the `undici` package.
+ *
+ * Node's built-in fetch bundles its own undici, and the two diverge: undici 8
+ * only accepts the current handler protocol (`onRequestStart`), so a request
+ * from Node's fetch through a package `Agent` fails with "invalid
+ * onRequestStart method" before a socket opens. Pairing the package's fetch
+ * with its `Agent` keeps both on one version. Callers still inject a fetch
+ * for tests and emulators. */
+export const dispatcherFetch = undiciFetch as unknown as typeof globalThis.fetch;

--- a/packages/adapters/src/web-ssrf.test.ts
+++ b/packages/adapters/src/web-ssrf.test.ts
@@ -121,6 +121,21 @@ describe("web SSRF policy", () => {
     expect(finalHeaders.get("x-trace-id")).toBeNull();
   });
 
+  it("drives the guarded dispatcher with a fetch from the same undici", async () => {
+    // See remote-mcp.test: failing inside the lookup proves the request was
+    // dispatched through the Agent rather than rejected by a mismatched fetch.
+    let resolutions = 0;
+    await expect(
+      fetchSafeWebText("https://example.test/start", {
+        resolveHostname: async () => {
+          resolutions += 1;
+          if (resolutions > 1) throw new Error("lookup reached");
+          return [{ address: "203.0.113.10", family: 4 as const }];
+        },
+      }),
+    ).rejects.toMatchObject({ cause: { message: "lookup reached" } });
+  });
+
   it("rejects oversized Content-Length before reading", async () => {
     const fetchMock: typeof fetch = async () =>
       new Response("ignored", {

--- a/packages/adapters/src/web-ssrf.ts
+++ b/packages/adapters/src/web-ssrf.ts
@@ -8,6 +8,7 @@ import {
   type ResolvedAddress,
   type ResolveHostname,
 } from "./network-address.js";
+import { dispatcherFetch } from "./undici-fetch.js";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -87,7 +88,7 @@ export async function fetchSafeWebText(
   const resolve = options.resolveHostname ?? defaultResolveHostname;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
-  const baseFetch = options.fetch ?? globalThis.fetch;
+  const baseFetch = options.fetch ?? dispatcherFetch;
   const dispatcher = new Agent({
     connect: { lookup: createAddressCheckedLookup(resolve, assertPublicAddresses) },
   });


### PR DESCRIPTION
## Why

Adding an MCP server through Integrations, for example a self-hosted Executor, failed on connect with a bare `fetch failed`. The cause is a regression from the undici 8 pin in #789, and it breaks every guarded outbound request, not only MCP.

Remote MCP, MCP OAuth, capability and GraphQL installs, the web fetch tool and OpenAI-compatible model servers all build an `Agent` from the `undici` package so the connection is pinned to a validated DNS lookup. They then hand that Agent to Node's built-in `fetch` as its dispatcher. Node's fetch bundles its own, older undici (6.x on the Node 22 image, 7.x on Node 24) and drives an external dispatcher with the legacy handler protocol. undici 8 rejects that with `invalid onRequestStart method` before any socket opens. CI never saw it because every test injects a fetch.

Two smaller problems sat behind the same message. The OAuth handler dropped the `cause` that undici attaches to `fetch failed`, so the error never said what went wrong. And the URL policy rejected Tailscale hosts over IPv6. It allowed `*.ts.net` names to resolve into Tailscale's CGNAT range, but MagicDNS also answers with the node's `fd7a:115c:a1e0::/48` ULA, which hit the generic `fc00::/7` private check and got the whole host refused.

## What changed

**One fetch for every undici Agent.** `packages/adapters/src/undici-fetch.ts` exports the `undici` package's own `fetch` as the default base fetch for every Agent-paired path, so Agent and fetch always come from the same version. Call sites stop resolving `globalThis.fetch` themselves, which defeated the default in the keyless web provider and in the model probe in the API router. The router probe now also honors the injected connector fetch, like the other remote paths. The OpenAI-compatible provider guards the fetch a caller supplies instead of discarding it, which the runtime's own tests already relied on through a global stub.

**Readable connect failures.** The shared safe fetch unwraps the cause chain, including the per-address errors of a happy-eyeballs `AggregateError`, and throws an error that names the host and the reason. The original error stays attached as `cause`. MCP OAuth, capability installs, remote tool calls and the web fetch tool inherit it.

**Tailscale over IPv6.** The range test moved into `network-address.ts` next to the other address predicates as `isTailscaleAddress` and covers CGNAT `100.64.0.0/10` and `fd7a:115c:a1e0::/48`. Only MagicDNS names get this allowance. Other private ranges, cloud metadata addresses and raw IP literals stay blocked as before.

### User-facing copy

This adds one error message, shown in the existing alert when a connection cannot be opened:

> Could not reach `<host>`: `<reason>`

`<reason>` is the underlying network error, for example `connect EHOSTUNREACH 100.x.y.z:443`, and is omitted when there is none. The message is necessary because the previous one, `fetch failed`, gave the user nothing to act on. A wrong path, a refused port, a host the API cannot route to and a TLS problem all looked identical. It cannot be removed or shown later. It is the failure itself, appears only when the connection fails, and the reason is the part that separates a configuration mistake from an outage.

## How it was tested

- Reproduced the dispatcher mismatch directly. An undici 8 Agent under Node's fetch fails with `invalid onRequestStart method` before any network activity, while the same Agent under undici's fetch attempts the connection.
- Three regression tests (remote MCP, web fetch, OpenAI-compatible) fail on purpose inside the dispatcher's lookup, so reaching the lookup proves the request went through the guarded Agent. Run against the previous pairing they report the protocol mismatch instead, and the lookup never runs.
- Reproduced the IPv6 rejection with a resolver that returns one ULA and one CGNAT address for a MagicDNS name. The URL check refused it before the fix and accepts it after. New tests cover that answer through both the URL check and the connection lookup, a non-Tailscale IPv6 ULA still rejected for a MagicDNS name, and cause unwrapping for a plain cause and for an `AggregateError`.
- Tests that stubbed the global fetch now inject it per call. One OAuth assertion that matched the literal `fetch failed` now matches the specific message.
- The adapters and api suites pass in full. Typecheck and Biome are clean.
- On a running instance, adding an Executor server through Integrations now connects.

No UI layout changed, so there is no screenshot to link. The only visible difference is the error text above in the existing alert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recognition for Tailscale IPv4 and IPv6 addresses.
  * Expanded secure remote access to support Tailscale MagicDNS endpoints with IPv6 responses.

* **Bug Fixes**
  * Improved reliability of remote API, MCP, and web requests through consistent secure networking.
  * Remote connection failures now provide clearer host-specific details and underlying causes.
  * Improved OpenAI-compatible provider request handling, including support for caller-provided request configurations and clearer error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->