### PR TITLE
fix(adapters): preserve executor-owned Pi shell cwd defaults

### DIFF
--- a/apps/mobile/lib/locales/ru.ts
+++ b/apps/mobile/lib/locales/ru.ts
@@ -376,6 +376,7 @@ export const RU_MESSAGES: Record<string, string> = {
     "Публичным серверам требуется https://. HTTP работает только в вашей локальной сети.",
   "Questions, approvals, takeover": "Вопросы, подтверждения, передача управления",
   Queued: "В очереди",
+  React: "Реакция",
   Recent: "Недавние",
   Recover: "Восстановить",
   "Recover computer": "Восстановить компьютер",

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -443,6 +443,38 @@ describe("Pi connector tool dispatch", () => {
     else process.env.MAX_TOOL_CALLS_PER_TURN = previousMaxToolCalls;
   });
 
+  it.each([undefined, "", ".", "/home/rakazo", "subdir"])(
+    "preserves executor-owned shell cwd defaults (%j)",
+    async (cwd) => {
+      const command = "printf WORKSPACE_OK > roundtrip.txt";
+      fakeAgentState.invoke = {
+        name: "shell",
+        args: cwd === undefined ? { command } : { command, cwd },
+      };
+      const executeTool = vi.fn(async () => ({ ok: true }));
+      const runtime = new PiAgentRuntime();
+      for await (const _event of runtime.run(
+        {
+          botId: "b",
+          threadId: "t",
+          runId: "r",
+          prompt: "write the workspace test file",
+          instructions: "Use shell.",
+          history: [],
+          tools: [shellTool],
+          model: { provider: "test", id: "dispatch-test-model" },
+          executeTool,
+        },
+        { signal: new AbortController().signal },
+      )) {
+        // Exercise Pi argument preparation and execution, not just path helpers.
+      }
+      expect(executeTool.mock.calls).toStrictEqual([
+        ["shell", cwd ? { command, cwd } : { command }, "call-1"],
+      ]);
+    },
+  );
+
   it("exposes a provider-safe name while executing the original connector name", async () => {
     const executeTool = vi.fn(async () => ({ ok: true }));
     const runtime = new PiAgentRuntime();

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -757,7 +757,8 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
       if (tool.name === "shell") {
         return {
           command: String(raw.command ?? ""),
-          cwd: raw.cwd ? String(raw.cwd) : "/home/rakazo",
+          // The executor chooses the bot-scoped default, including Team workspaces.
+          ...(raw.cwd ? { cwd: String(raw.cwd) } : {}),
         };
       }
       if (tool.name === "run_subagent") {


### PR DESCRIPTION
## Why

Shell commands without an explicit working directory should use the executor's bot-scoped workspace. Pi argument preparation currently inserts `/home/rakazo`, overriding the Team-aware default and placing relative shell output outside the bot folder used by file tools.

## What changed

- Leave `cwd` omitted when the supplied value is absent or empty, so the executor chooses the default.
- Preserve explicit dot, absolute, and relative working directories.
- Add five dispatch regressions. No executor, containment, prompt, or UI changes.

## How tested

- Established red/green behavior: the absent and empty cases failed before the fix; all twenty-three dispatch tests pass afterward.
- The dispatch and computer-workspace suites pass together, covering thirty-one tests.
- `pnpm check` passes all twenty-two package checks.
- `pnpm lint` passes with existing warnings and an informational diagnostic.
- `pnpm test:pi` passes all ten deterministic real-Pi/local-model-fixture tests.
- `pnpm test:integration` passes all one hundred twenty-five tests across nineteen suites, including the real-Pi/Postgres executor file journey.
- `pnpm test:e2e -- --spec=team-computer.spec.ts` passes all four Team/Private Computer tests with the scripted runtime and fake sandbox.
- `pnpm test` finishes with three thousand six hundred ninety passing tests, one failing mobile translation test, and one hundred fifty-seven skipped tests. Restoring both changed files to the base version and rerunning `apps/mobile/lib/i18n.test.ts` reproduces the same missing `React` catalog entry. This pre-existing failure prevents an all-green local gate and is left outside this focused fix.

The existing integration journey exercises file writing, not a Team shell-write/file-read round trip. The new regression verifies dispatch arguments; it does not claim real shell execution. Docker computer replay and live-provider checks were not run: browser behavior is unchanged, and this fix uses deterministic offline validation.

### Follow-up validation

- `pnpm build` passes all five production build tasks.
- A full local `pnpm test:e2e` run passed one hundred five tests but failed the onboarding-model-labels assertion that an auto-updating alias is present. The isolated spec then passed with both changed files restored to the base version and passed again on the PR head. The failure was not reproduced in isolation; its cause remains unconfirmed, so the full local E2E run is not claimed as green.
- Current-head CI ran after the initial approval hold. Production builds, lint, typecheck, Postgres journeys, and web E2E passed; unit tests failed on the same missing mobile `React` catalog entry confirmed on the base. Automated CodeRabbit and Greptile reviews completed with no actionable correctness findings. The PR remains blocked on the fully-green requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Shell commands now use the appropriate workspace directory when no working directory is specified.
  - Commands run from Team workspaces now correctly inherit their workspace-specific default location.
  - Explicit working-directory values continue to be honored, including relative paths, empty values, and custom absolute paths.

- **Localization**
  - Added the Russian translation for the “React” action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->