### PR TITLE
fix: backfill thumbs-up reactions before dropping column

### DIFF
--- a/packages/db/prisma/migrations/20260908090000_message_reaction/migration.sql
+++ b/packages/db/prisma/migrations/20260908090000_message_reaction/migration.sql
@@ -1,1 +1,20 @@
+BEGIN;
+-- Preserve existing thumbs-ups as ordinary emoji replies before removing mutable reaction state.
+-- Mirrors reactToThreadMessage: role user, single text block "👍", replyToMessageId = parent,
+-- seq allocated from threads.nextMessageSeq (same as createThreadMessageInTransaction).
+WITH ranked AS MATERIALIZED (
+  SELECT id, "threadId", row_number() OVER (PARTITION BY "threadId" ORDER BY seq) AS position
+  FROM "messages" WHERE "thumbsUp" = true
+), allocated AS (
+  UPDATE "threads" AS thread
+  SET "nextMessageSeq" = thread."nextMessageSeq" + counts.total
+  FROM (SELECT "threadId", count(*)::integer AS total FROM ranked GROUP BY "threadId") AS counts
+  WHERE thread.id = counts."threadId"
+  RETURNING thread.id, thread."nextMessageSeq" - counts.total AS start_seq
+)
+INSERT INTO "messages" (id, "threadId", seq, role, blocks, "replyToMessageId", "createdAt")
+SELECT 'reaction-' || ranked.id, ranked."threadId", allocated.start_seq + ranked.position - 1,
+  'user', '[{"kind":"text","text":"👍"}]'::jsonb, ranked.id, CURRENT_TIMESTAMP
+FROM ranked JOIN allocated ON allocated.id = ranked."threadId";
 ALTER TABLE "messages" DROP COLUMN "thumbsUp";
+COMMIT;

--- a/packages/db/src/message-reaction-migration.test.ts
+++ b/packages/db/src/message-reaction-migration.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { messageReaction } from "@rakazo/core";
+import { describe, expect, it } from "vitest";
+
+const migrationSql = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../prisma/migrations/20260908090000_message_reaction/migration.sql",
+  ),
+  "utf8",
+);
+
+type LegacyMessage = {
+  id: string;
+  threadId: string;
+  seq: number;
+  thumbsUp: boolean;
+};
+
+type Thread = { id: string; nextMessageSeq: number };
+
+type ReactionRow = {
+  id: string;
+  threadId: string;
+  seq: number;
+  role: "user";
+  blocks: [{ kind: "text"; text: "👍" }];
+  replyToMessageId: string;
+};
+
+/** In-memory stand-in for the thumbsUp → emoji-reply backfill in the migration SQL. */
+function backfillThumbsUp(threads: Thread[], messages: LegacyMessage[]) {
+  const nextThreads = threads.map((thread) => ({ ...thread }));
+  const byThread = new Map<string, LegacyMessage[]>();
+  for (const message of messages.filter((row) => row.thumbsUp)) {
+    const list = byThread.get(message.threadId) ?? [];
+    list.push(message);
+    byThread.set(message.threadId, list);
+  }
+  const inserted: ReactionRow[] = [];
+  for (const thread of nextThreads) {
+    const ranked = (byThread.get(thread.id) ?? []).sort((a, b) => a.seq - b.seq);
+    if (ranked.length === 0) continue;
+    const startSeq = thread.nextMessageSeq;
+    thread.nextMessageSeq += ranked.length;
+    for (const [index, parent] of ranked.entries()) {
+      inserted.push({
+        id: `reaction-${parent.id}`,
+        threadId: thread.id,
+        seq: startSeq + index,
+        role: "user",
+        blocks: [{ kind: "text", text: "👍" }],
+        replyToMessageId: parent.id,
+      });
+    }
+  }
+  return { threads: nextThreads, reactions: inserted };
+}
+
+describe("message_reaction thumbsUp backfill", () => {
+  it("converts thumbsUp rows into 👍 user replies before dropping the column", () => {
+    expect(migrationSql).toMatch(/FROM "messages" WHERE "thumbsUp" = true/);
+    expect(migrationSql).toMatch(
+      /INSERT INTO "messages" \(id, "threadId", seq, role, blocks, "replyToMessageId", "createdAt"\)/,
+    );
+    expect(migrationSql).toMatch(/'\[\{"kind":"text","text":"👍"\}\]'::jsonb/);
+    expect(migrationSql).toMatch(/'reaction-' \|\| ranked\.id/);
+    expect(migrationSql).toMatch(
+      /SET "nextMessageSeq" = thread\."nextMessageSeq" \+ counts\.total/,
+    );
+    expect(migrationSql).toMatch(/ALTER TABLE "messages" DROP COLUMN "thumbsUp"/);
+    const dropAt = migrationSql.indexOf('DROP COLUMN "thumbsUp"');
+    const insertAt = migrationSql.indexOf("INSERT INTO");
+    expect(insertAt).toBeGreaterThan(-1);
+    expect(dropAt).toBeGreaterThan(insertAt);
+  });
+
+  it("allocates thread seqs and shapes rows like reactToThreadMessage", () => {
+    const { threads, reactions } = backfillThumbsUp(
+      [
+        { id: "thread-a", nextMessageSeq: 10 },
+        { id: "thread-b", nextMessageSeq: 3 },
+      ],
+      [
+        { id: "msg-1", threadId: "thread-a", seq: 2, thumbsUp: true },
+        { id: "msg-2", threadId: "thread-a", seq: 5, thumbsUp: false },
+        { id: "msg-3", threadId: "thread-a", seq: 7, thumbsUp: true },
+        { id: "msg-4", threadId: "thread-b", seq: 1, thumbsUp: false },
+      ],
+    );
+    expect(threads).toEqual([
+      { id: "thread-a", nextMessageSeq: 12 },
+      { id: "thread-b", nextMessageSeq: 3 },
+    ]);
+    expect(reactions).toEqual([
+      {
+        id: "reaction-msg-1",
+        threadId: "thread-a",
+        seq: 10,
+        role: "user",
+        blocks: [{ kind: "text", text: "👍" }],
+        replyToMessageId: "msg-1",
+      },
+      {
+        id: "reaction-msg-3",
+        threadId: "thread-a",
+        seq: 11,
+        role: "user",
+        blocks: [{ kind: "text", text: "👍" }],
+        replyToMessageId: "msg-3",
+      },
+    ]);
+    for (const reaction of reactions) {
+      expect(messageReaction(reaction)).toBe("👍");
+    }
+  });
+
+  it("is a no-op when no thumbsUp rows exist", () => {
+    const { threads, reactions } = backfillThumbsUp(
+      [{ id: "thread-a", nextMessageSeq: 4 }],
+      [{ id: "msg-1", threadId: "thread-a", seq: 1, thumbsUp: false }],
+    );
+    expect(threads[0]?.nextMessageSeq).toBe(4);
+    expect(reactions).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The `message_reaction` migration dropped `messages.thumbsUp` without converting existing thumbs-ups into the emoji reply shape the app now uses. Upgrades permanently erased those reactions.

## What

- Restore an atomic backfill in `20260908090000_message_reaction` that, before the drop, inserts a user reply with blocks `[{"kind":"text","text":"👍"}]`, `replyToMessageId` pointing at the former thumbs-up parent, and seqs allocated from `threads.nextMessageSeq` (same pattern as `reactToThreadMessage` / `createThreadMessageInTransaction`).
- Fresh installs with no `thumbsUp` rows remain a no-op insert then drop.
- Add `packages/db/src/message-reaction-migration.test.ts` to lock the SQL contract and the in-memory backfill shape against `messageReaction`.

Fixes #811

## Tested

- `pnpm --filter @rakazo/db exec vitest run --root ../.. packages/db/src/message-reaction-migration.test.ts` (3 passed)

Rewrote the existing migration rather than adding a follow-up: on main the column is already removed in that file, and there is no evidence it shipped widely without the backfill. Envs that already applied the drop-only checksum will need a normal Prisma checksum reconcile; data already lost there cannot be recovered from this migration.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58f7ca97-b07c-43f7-9406-c3c5ba02adea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58f7ca97-b07c-43f7-9406-c3c5ba02adea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

