### PR TITLE
Fix Docker named-volume mounts for bot homes

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -6,10 +6,14 @@ The signed-in product is a long-running API, a Graphile Worker, Postgres, and a 
 
 Same as the README quick start: `.env` from `.env.example`, Postgres via Compose, `pnpm sandbox:build`, `pnpm dev`, then [http://127.0.0.1:5173](http://127.0.0.1:5173) (or `http://localhost:5173` — both loopback hosts are trusted). Electron: `pnpm --filter @rakazo/desktop dev` while that stack is up, choosing **Existing instance** with that address. The desktop app's **This computer** option instead installs and runs the published images itself with Docker Compose (see [Published images](#published-images-no-checkout)), using port 45173 by default so it can run alongside `pnpm dev`. If that port is occupied, the app selects and remembers another loopback port. The managed API gets a Docker-assigned loopback port; all desktop traffic uses the web origin.
 
+For source development in WSL, keep the checkout and `data` directory in the Linux filesystem (for example, `~/rakazo`), and run `pnpm dev` as your normal user. The host-run supervisor matches bot container UID/GID to that user. If Docker Desktop container IPs are unreachable, set `SANDBOX_CONTROL_VIA_LOOPBACK=true` in `.env`; this publishes the token-protected control service on a random loopback port. Leave this unset for the Compose-hosted supervisor.
+
+Compose bot homes mount only their own subdirectory of the application volume using Docker volume semantics. Docker's internal volume paths are never used as host bind mounts.
+
 ## Published images (no checkout)
 
 Pull Postgres and `ghcr.io/elie222/rakazo/app` into any empty folder. No clone or image build.
-Requires Docker Engine, the Compose plugin, curl, and OpenSSL.
+Requires Docker Engine 26+ (API 1.45+ for bot home volume subpaths), the Compose plugin, curl, and OpenSSL.
 
 ```bash
 mkdir -p rakazo && cd rakazo &&

--- a/infra/sandboxes/supervisor/src/computer-loopback.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-loopback.test.ts
@@ -8,6 +8,7 @@ import { computerNetworkNameFor, hostComputerUser } from "./computer-spec.js";
 
 const mocks = vi.hoisted(() => ({
   docker: {
+    version: vi.fn(),
     getImage: vi.fn(),
     getContainer: vi.fn(),
     listContainers: vi.fn(),
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
 }));
 vi.mock("dockerode", () => ({
   default: class {
+    version = mocks.docker.version;
     getImage = mocks.docker.getImage;
     getContainer = mocks.docker.getContainer;
     listContainers = mocks.docker.listContainers;
@@ -286,6 +288,52 @@ describe("provisioning network rollback", () => {
       body: JSON.stringify({ botId: "bot", spaceId: "space", homePath }),
     });
   }
+
+  it.each(["1.44", "1.45"])(
+    "provisions named-volume homes only with subpath support (%s)",
+    async (apiVersion) => {
+      fixture();
+      vi.stubEnv("SANDBOX_SCREEN_NETWORK", "internal");
+      vi.stubEnv("HOSTNAME", "supervisor");
+      mocks.docker.version.mockResolvedValue({ ApiVersion: apiVersion });
+      mocks.docker.getContainer.mockReturnValue({
+        inspect: vi.fn().mockResolvedValue({
+          NetworkSettings: { Networks: { shared: {} } },
+          Mounts: [
+            {
+              Type: "volume",
+              Name: "example_appdata",
+              Destination: process.env.DATA_DIR,
+              Source: "/var/lib/docker/volumes/example_appdata/_data",
+            },
+          ],
+        }),
+      });
+      const response = await provision();
+      if (apiVersion === "1.44") {
+        expect(response.status).toBe(500);
+        expect(mocks.docker.createContainer).not.toHaveBeenCalled();
+        expect(mocks.docker.createNetwork).not.toHaveBeenCalled();
+      } else {
+        expect(response.status).toBe(200);
+        expect(mocks.docker.createContainer).toHaveBeenCalledWith(
+          expect.objectContaining({
+            User: "1000:1000",
+            HostConfig: expect.objectContaining({
+              Mounts: [
+                expect.objectContaining({
+                  Type: "volume",
+                  Source: "example_appdata",
+                  Target: "/home/rakazo",
+                  VolumeOptions: { NoCopy: true, Subpath: "homes/bot" },
+                }),
+              ],
+            }),
+          }),
+        );
+      }
+    },
+  );
 
   it("does not allocate a network for an invalid home", async () => {
     fixture();

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -10,14 +10,18 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import type Docker from "dockerode";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  assertVolumeSubpathSupport,
   COMPUTER_IMAGE,
+  computerHomeStorage,
   computerNetworkNameFor,
   computerNetworkNamesForCleanup,
   containerCreateOptions,
   containerNameFor,
   controlPortPublicationMatches,
+  homeVolumeMatches,
   hostComputerUser,
   legacyNetworkOwnedSolelyBy,
   parseMemoryBytes,
@@ -718,5 +722,74 @@ describe("computer resource limits", () => {
 
   it("parses byte counts without a unit suffix", () => {
     expect(parseMemoryBytes("X", "1073741824")).toBe(1024 ** 3);
+  });
+});
+
+describe("computer home storage", () => {
+  const runtime = (mount: object) => ({ Mounts: [mount] }) as Docker.ContainerInspectInfo;
+  it("keeps named volumes native and exposes only the bot subdirectory", () => {
+    const storage = computerHomeStorage(
+      "/data/homes/bot",
+      "/data",
+      runtime({
+        Type: "volume",
+        Name: "example_appdata",
+        Source: "/var/lib/docker/volumes/example_appdata/_data",
+        Destination: "/data",
+      }),
+    );
+    const options = containerCreateOptions({
+      name: "bot",
+      image: "computer",
+      botId: "bot",
+      spaceId: "space",
+      ...storage,
+    });
+    expect(options.HostConfig.Binds).toBeUndefined();
+    expect(options.HostConfig.Mounts).toEqual([
+      {
+        Type: "volume",
+        Source: "example_appdata",
+        Target: "/home/rakazo",
+        VolumeOptions: { NoCopy: true, Subpath: "homes/bot" },
+      },
+    ]);
+    expect(homeVolumeMatches(options.HostConfig.Mounts, storage.homeVolume!)).toBe(true);
+    expect(homeVolumeMatches(undefined, storage.homeVolume!)).toBe(false);
+    expect(
+      homeVolumeMatches(options.HostConfig.Mounts, {
+        name: "example_appdata",
+        subpath: "homes/other",
+      }),
+    ).toBe(false);
+  });
+  it("preserves native host paths and translates supervisor bind mounts", () => {
+    expect(computerHomeStorage("/data/homes/bot", "/data", undefined)).toEqual({
+      homePath: "/data/homes/bot",
+    });
+    expect(
+      computerHomeStorage(
+        "/data/homes/bot",
+        "/data",
+        runtime({ Type: "bind", Source: "/srv/data", Destination: "/data" }),
+      ),
+    ).toEqual({ homePath: "/srv/data/homes/bot" });
+  });
+  it("rejects paths outside the volume and missing volume names", () => {
+    for (const home of ["/data", "/other", "/data/../other"])
+      expect(() => computerHomeStorage(home, "/data", undefined)).toThrow();
+    expect(() =>
+      computerHomeStorage(
+        "/data/homes/bot",
+        "/data",
+        runtime({ Type: "volume", Destination: "/data" }),
+      ),
+    ).toThrow(/no name/);
+  });
+  it("fails closed on daemons that could ignore volume subpaths", () => {
+    for (const version of ["1.44", "", "invalid", "0.99"])
+      expect(() => assertVolumeSubpathSupport(version)).toThrow(/Docker Engine 26/);
+    for (const version of ["1.45", "1.46", "2.0"])
+      expect(() => assertVolumeSubpathSupport(version)).not.toThrow();
   });
 });

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
 import { MAX_DESKTOP_DISPLAY, screenPorts } from "@rakazo/core/node/desktop-runtime";
+import type Docker from "dockerode";
 
 export const COMPUTER_IMAGE = process.env.RAKAZO_COMPUTER_IMAGE ?? "rakazo/computer:local";
 export const COMPUTER_UID = 1000;
@@ -148,12 +150,58 @@ export function computerPortBindings(publishControlPort = false) {
   return { ExposedPorts, PortBindings };
 }
 
+export function computerHomeStorage(
+  serviceHomePath: string,
+  dataDir: string,
+  info: Docker.ContainerInspectInfo | undefined,
+): { homePath: string; homeVolume?: { name: string; subpath: string } } {
+  const relative = path.relative(dataDir, serviceHomePath);
+  if (
+    !relative ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error("computer home must be inside the data directory");
+  }
+  const mount = info?.Mounts.find((entry) => entry.Destination === dataDir);
+  if (mount?.Type === "volume") {
+    if (!mount.Name) throw new Error("computer data volume has no name");
+    return { homePath: serviceHomePath, homeVolume: { name: mount.Name, subpath: relative } };
+  }
+  return { homePath: mount?.Source ? path.join(mount.Source, relative) : serviceHomePath };
+}
+
+export function assertVolumeSubpathSupport(apiVersion: string) {
+  const match = /^(\d+)\.(\d+)$/.exec(apiVersion);
+  if (!match || Number(match[1]) < 1 || (Number(match[1]) === 1 && Number(match[2]) < 45)) {
+    throw new Error("Docker Engine 26+ (API 1.45+) is required for bot home volume subpaths");
+  }
+}
+
+export function homeVolumeMatches(
+  mounts: Docker.ContainerInspectInfo["HostConfig"]["Mounts"],
+  volume: { name: string; subpath: string },
+) {
+  return (
+    mounts?.some(
+      (mount) =>
+        mount.Target === "/home/rakazo" &&
+        mount.Type === "volume" &&
+        mount.Source === volume.name &&
+        mount.VolumeOptions?.Subpath === volume.subpath &&
+        !mount.ReadOnly,
+    ) ?? false
+  );
+}
+
 export interface ComputerCreateInput {
   name: string;
   image: string;
   botId: string;
   spaceId: string;
   homePath: string;
+  homeVolume?: { name: string; subpath: string };
   user?: string;
   controlToken?: string;
   networkMode?: string;
@@ -195,7 +243,23 @@ export function containerCreateOptions(input: ComputerCreateInput) {
     },
     ExposedPorts: ports.ExposedPorts,
     HostConfig: {
-      Binds: [`${input.homePath}:/home/rakazo`],
+      ...(input.homeVolume
+        ? {
+            Binds: undefined,
+            Mounts: [
+              {
+                Type: "volume" as const,
+                Source: input.homeVolume.name,
+                Target: "/home/rakazo",
+                // Docker makes Labels and DriverConfig optional; dockerode's types do not.
+                VolumeOptions: {
+                  NoCopy: true,
+                  Subpath: input.homeVolume.subpath,
+                } as Docker.MountSettings["VolumeOptions"],
+              },
+            ],
+          }
+        : { Binds: [`${input.homePath}:/home/rakazo`], Mounts: undefined }),
       PortBindings: ports.PortBindings,
       ShmSize: 256 * 1024 * 1024,
       CapDrop: ["ALL"],

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -19,16 +19,19 @@ import { Hono, type MiddlewareHandler } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { z } from "zod";
 import {
+  assertVolumeSubpathSupport,
   COMPUTER_GID,
   COMPUTER_IMAGE,
   COMPUTER_UID,
   COMPUTER_USER,
+  computerHomeStorage,
   computerNetworkNameFor,
   computerNetworkNamesForCleanup,
   computerResourceLimits,
   containerCreateOptions,
   containerNameFor,
   controlPortPublicationMatches,
+  homeVolumeMatches,
   hostComputerUser,
   legacyNetworkOwnedSolelyBy,
   publishedLoopbackControlHostPort,
@@ -171,7 +174,10 @@ app.post("/computers", async (c) => {
       // do so as the same user, but a root supervisor must never create or chown
       // user-controlled paths at runtime; Compose data-init handles legacy data.
       if (hostUid !== 0) await mkdir(serviceHomePath, { recursive: true });
-      const homePath = hostHomePath(serviceHomePath, runtimeInfo);
+      const storage = computerHomeStorage(serviceHomePath, dataDir, runtimeInfo);
+      if (storage.homeVolume) {
+        assertVolumeSubpathSupport((await docker.version()).ApiVersion);
+      }
       const computerUser = runtimeInfo ? COMPUTER_USER : hostComputerUser(hostUid, hostGid);
       const existing = await findBotContainer(body.botId, body.spaceId);
       if (existing) {
@@ -185,7 +191,8 @@ app.post("/computers", async (c) => {
           info.Image === desired.Id &&
           (!networkMode || info.HostConfig.NetworkMode === networkMode) &&
           info.Config.User === computerUser &&
-          controlPublishOk
+          controlPublishOk &&
+          (!storage.homeVolume || homeVolumeMatches(info.HostConfig.Mounts, storage.homeVolume))
         ) {
           if (!info.State.Running) await existing.start();
           return c.json({
@@ -222,7 +229,7 @@ app.post("/computers", async (c) => {
             image: COMPUTER_IMAGE,
             botId: body.botId,
             spaceId: body.spaceId,
-            homePath,
+            ...storage,
             user: computerUser,
             networkMode,
             controlToken: randomUUID(),
@@ -943,12 +950,6 @@ function assertBotHomePath(homePath: string, botId: string) {
   if (homePath !== expected) {
     throw new Error("computer home must be the bot's home directory");
   }
-}
-
-function hostHomePath(serviceHomePath: string, info: Docker.ContainerInspectInfo | undefined) {
-  const dataMount = info?.Mounts.find((mount) => mount.Destination === dataDir);
-  if (!dataMount?.Source) return serviceHomePath;
-  return path.join(dataMount.Source, path.relative(dataDir, serviceHomePath));
 }
 
 function computerControlEndpoint(info: Docker.ContainerInspectInfo) {


### PR DESCRIPTION
Bot computers in Compose could fail to write their homes on Docker Desktop because the supervisor re-bound Docker-internal named-volume paths as host directories.
Use Docker-native volume subpaths for individual bot homes, recreate containers with legacy mounts, preserve host bind mounts and UID/GID selection, and document WSL loopback control and the Docker Engine 26+ requirement.
The error “Docker Engine 26+ (API 1.45+) is required for bot home volume subpaths” appears only when an unsupported daemon is detected; it is necessary to explain why provisioning stops instead of risking exposure of the whole volume.
Validation: supervisor TypeScript checks and 162 tests passed, with three skipped; Windows/Docker Desktop validation remains outstanding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot homes can use dedicated Docker volumes with supported subpaths, improving storage isolation.
  * Added validation to ensure configured home storage matches the existing container before reuse.
  * Added an optional loopback mode for sandbox control services when Docker Desktop networking prevents container IP access.

* **Documentation**
  * Clarified WSL development and Docker Compose storage behavior.
  * Documented the Docker Engine 26+ requirement for volume subpaths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->