### PR TITLE
Document Docker Desktop bot-to-host loopback boundary

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -194,6 +194,10 @@ RAKAZO_LOCAL_VISION_MODELS=qwen3-vl
 The loopback default is suitable when running Rakazo from a source checkout. From containers,
 prefer a stable LAN RFC1918 address (not Compose service DNS alone). On Docker Desktop,
 `host.docker.internal` also works.
+On Docker Desktop, a bot computer shell can often reach services bound to host `127.0.0.1`
+through that same hostname. Do not run sensitive unauthenticated services on loopback while
+bots run, or firewall / block that path. Linux does not get `host.docker.internal` the same
+way by default.
 Only configure an endpoint you control: prompts, attachments, and tool results sent to that model
 leave Rakazo through this URL. Leave `RAKAZO_LOCAL_MODELS` blank to disable the provider.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Self-host docs mentioned `host.docker.internal` only for model-endpoint allowlisting. Operators choosing Docker for bot computers were not told that on Docker Desktop, a bot shell can often reach services bound to host loopback (`127.0.0.1`) through that hostname.

## What changed

In `docs/self-host.md`, next to the existing `host.docker.internal` note:

- State the bot-to-host-loopback boundary on Docker Desktop
- List mitigations (avoid sensitive unauthenticated loopback services while bots run, or firewall / block the path)
- Note that Linux does not get `host.docker.internal` the same way by default

## Testing

Docs-only change; reviewed the surrounding self-host copy for tone and placement.

Fixes #817

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc98d051-a39c-440a-9124-d09c02b41bb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc98d051-a39c-440a-9124-d09c02b41bb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

