### PR TITLE
Revoke screen capabilities with computer and bot lifecycles

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -92,6 +92,7 @@ import {
 import { mountMessagingWebhookRoutes } from "./messaging-webhook.js";
 import { mountApiRequestBodyLimits } from "./request-body-limit.js";
 import { createRouter } from "./router.js";
+import { mountScreenTarget } from "./screen-proxy.js";
 import { isDeferredReservationLost, TeamChatBridge } from "./team-chat-bridge.js";
 import { ModelTeamChatEngagementJudge } from "./team-chat-judge.js";
 import {
@@ -466,6 +467,7 @@ export async function createApp(
     );
   }
   mountApiRequestBodyLimits(app);
+  mountScreenTarget(app, prisma, env.screenProxySecret);
   app.on(["GET", "POST"], "/api/auth/*", async (c) => {
     const path = new URL(c.req.url).pathname.replace("/api/auth", "");
     if (blockedAuthPaths.some((blocked) => path.startsWith(blocked))) {

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -642,6 +642,16 @@ describe("computer screen url", () => {
     });
   });
 
+  it("returns desktop provider screen URLs without sealing them", async () => {
+    const { response } = await callScreenUrl(async () => ({
+      url: "desktop://screen/computer-1",
+    }));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      json: { url: "desktop://screen/computer-1?view_only=true" },
+    });
+  });
+
   it("clears the row instead of 500ing when the provider says the sandbox is gone", async () => {
     const { response, updateMany } = await callScreenUrl(() =>
       Promise.reject(

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -1,6 +1,7 @@
 import { RPCHandler } from "@orpc/server/fetch";
 import { COMPUTER_SCREEN_UNAVAILABLE, ComputerScreenUnavailableError } from "@rakazo/adapters";
 import type { Actor } from "@rakazo/contracts";
+import { openScreenCapability } from "@rakazo/core/node/screen-capability";
 import type { PrismaClient } from "@rakazo/db";
 import { createLogger, createTestSink, installLogger } from "@rakazo/logging";
 import { describe, expect, it, vi } from "vitest";
@@ -570,6 +571,7 @@ describe("computer screen url", () => {
   } satisfies Actor;
   const computerRow = {
     id: "computer-1",
+    screenGeneration: 3,
     kind: "e2b",
     scope: "team",
     state: "running",
@@ -587,6 +589,7 @@ describe("computer screen url", () => {
       bot: {
         findFirst: vi.fn().mockResolvedValue({
           id: "bot-1",
+          screenGeneration: 2,
           thread: { id: "thread-1" },
           computer: computerRow,
         }),
@@ -618,6 +621,26 @@ describe("computer screen url", () => {
     );
     return { response, updateMany };
   };
+
+  it("issues lifecycle-bound capabilities for managed-provider screens too", async () => {
+    const { response } = await callScreenUrl(async () => ({
+      url: "https://screen.example/vnc.html?token=fake-token",
+    }));
+    expect(response.status).toBe(200);
+    const { json } = await response.json();
+    const url = new URL(json.url);
+    expect(url.origin).toBe("http://127.0.0.1:5173");
+    expect(openScreenCapability(url.pathname, "fake-test-secret")).toMatchObject({
+      scope: {
+        botId: "bot-1",
+        computerId: "computer-1",
+        botGeneration: 2,
+        computerGeneration: 3,
+        controlLeaseId: null,
+      },
+      target: { hostname: "screen.example", interactive: false },
+    });
+  });
 
   it("clears the row instead of 500ing when the provider says the sandbox is gone", async () => {
     const { response, updateMany } = await callScreenUrl(() =>

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -2141,13 +2141,13 @@ export function createRouter(deps: RouterDeps) {
           !(hasActiveComputerControl(bot.computer) && bot.computer.controlBotId === bot.id),
         );
         return {
-          url: addScreenProxyCapability(
-            viewUrl,
-            deps.env.screenProxySecret,
-            deps.env.webOrigin,
-            undefined,
-            { proxyExternal: bot.computer.kind === "box" },
-          ),
+          url: addScreenProxyCapability(viewUrl, deps.env.screenProxySecret, deps.env.webOrigin, {
+            botId: bot.id,
+            computerId: computer.id,
+            botGeneration: bot.screenGeneration,
+            computerGeneration: computer.screenGeneration,
+            controlLeaseId: computer.controlLeaseId,
+          }),
         };
       }),
       heartbeat: authed.computer.heartbeat.handler(async ({ context, input }) => {

--- a/apps/api/src/screen-proxy.test.ts
+++ b/apps/api/src/screen-proxy.test.ts
@@ -111,8 +111,8 @@ describe("screen capability lifecycle authorization", () => {
     expect(
       addScreenProxyCapability("desktop://screen/computer", secret, "https://app.example", scope),
     ).toBe("desktop://screen/computer");
-    expect(
-      addScreenProxyCapability("local://preview", secret, "https://app.example", scope),
-    ).toBe("local://preview");
+    expect(addScreenProxyCapability("local://preview", secret, "https://app.example", scope)).toBe(
+      "local://preview",
+    );
   });
 });

--- a/apps/api/src/screen-proxy.test.ts
+++ b/apps/api/src/screen-proxy.test.ts
@@ -1,40 +1,110 @@
-import { describe, expect, it } from "vitest";
-import { addScreenProxyCapability } from "./screen-proxy.js";
+import { SCREEN_TARGET_ENDPOINT } from "@rakazo/core/node/screen-capability";
+import type { PrismaClient } from "@rakazo/db";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { addScreenProxyCapability, mountScreenTarget } from "./screen-proxy.js";
 
-describe("screen proxy capability", () => {
-  it("signs loopback Docker screen URLs without changing their destination", () => {
-    const result = new URL(
-      addScreenProxyCapability(
-        "http://127.0.0.1:49152/embed.html?view_only=true",
-        "secret",
-        "https://app.example",
-        100,
-      ),
-    );
-    expect(result.origin).toBe("https://app.example");
-    expect(result.pathname).toMatch(
-      /^\/novnc\/[\w-]+\/49152\/view\/3600100\.[\w-]{43}\/embed\.html$/,
-    );
-    expect(result.searchParams.get("view_only")).toBe("true");
+const secret = "fake-screen-secret";
+const scope = {
+  botId: "bot",
+  computerId: "computer",
+  botGeneration: 0,
+  computerGeneration: 0,
+  controlLeaseId: "lease",
+};
+function fixture(interactive = false) {
+  const computer = {
+    screenGeneration: 0,
+    providerRef: "fake-provider",
+    state: "running",
+    controlHolder: "user",
+    controlLeaseId: "lease",
+    controlBotId: "bot",
+    controlLeaseExpiresAt: new Date(Date.now() + 60_000),
+  };
+  const bot = {
+    id: "bot",
+    computerId: "computer",
+    archivedAt: null as Date | null,
+    screenGeneration: 0,
+    computer,
+  };
+  const findFirst = vi.fn(async ({ where }) =>
+    Object.entries(where).every(([key, value]) => bot[key as keyof typeof bot] === value)
+      ? bot
+      : null,
+  );
+  const app = new Hono();
+  mountScreenTarget(app, { bot: { findFirst } } as unknown as PrismaClient, secret);
+  const url = addScreenProxyCapability(
+    `http://127.0.0.1:49152/embed.html?view_only=${!interactive}`,
+    secret,
+    "https://app.example",
+    scope,
+  );
+  const path = new URL(url).pathname;
+  const request = (value = path, credential = secret) =>
+    app.request(SCREEN_TARGET_ENDPOINT, {
+      method: "POST",
+      headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" },
+      body: JSON.stringify({ path: value }),
+    });
+  return { bot, computer, findFirst, path, request };
+}
+
+describe("screen capability lifecycle authorization", () => {
+  it("allows repeat assets and reconnects during the same active lifecycle", async () => {
+    const { request, path } = fixture();
+    expect((await request()).status).toBe(200);
+    expect((await request(path.replace("/embed.html", "/websockify"))).status).toBe(200);
+    expect((await request()).headers.get("cache-control")).toBe("no-store");
   });
-
-  it("does not modify managed-provider URLs", () => {
-    const url = "https://sandbox.example/embed.html?token=provider-token";
-    expect(addScreenProxyCapability(url, "secret", "https://app.example", 100)).toBe(url);
+  it("requires the proxy credential before looking up a capability", async () => {
+    const { request, findFirst, path } = fixture();
+    expect((await request(path, "wrong")).status).toBe(403);
+    expect(findFirst).not.toHaveBeenCalled();
   });
-
-  it("keeps external desktop secrets behind an encrypted, policy-bound capability", () => {
-    const result = new URL(
-      addScreenProxyCapability(
-        "https://box.example/vnc.html?token=provider-token&view_only=true",
-        "secret",
-        "https://app.example",
-        100,
-        { proxyExternal: true },
-      ),
-    );
-    expect(result.origin).toBe("https://app.example");
-    expect(result.pathname).toMatch(/^\/novnc\/remote\/view\/3600100\.[\w-]+\/vnc\.html$/);
-    expect(result.toString()).not.toContain("provider-token");
+  it("rejects stopped computers and old URLs after restart at the same address", async () => {
+    const { request, computer } = fixture();
+    computer.state = "stopped";
+    expect((await request()).status).toBe(403);
+    computer.state = "running";
+    computer.screenGeneration++;
+    expect((await request()).status).toBe(403);
+  });
+  it.each(["suspending", "error", "stopped"])("rejects computer state %s", async (state) => {
+    const { request, computer } = fixture();
+    computer.state = state;
+    expect((await request()).status).toBe(403);
+  });
+  it("revokes archived, reassigned, and restored bots", async () => {
+    const { request, bot } = fixture();
+    bot.archivedAt = new Date();
+    expect((await request()).status).toBe(403);
+    bot.archivedAt = null;
+    bot.computerId = "other";
+    expect((await request()).status).toBe(403);
+    bot.computerId = "computer";
+    bot.screenGeneration++;
+    expect((await request()).status).toBe(403);
+  });
+  it.each(["expiry", "release", "replacement", "holder", "bot"])(
+    "revokes control on lease %s",
+    async (change) => {
+      const { request, computer } = fixture(true);
+      expect((await request()).status).toBe(200);
+      if (change === "expiry") computer.controlLeaseExpiresAt = new Date(0);
+      if (change === "release") computer.controlLeaseId = "";
+      if (change === "replacement") computer.controlLeaseId = "new-lease";
+      if (change === "holder") computer.controlHolder = "agent";
+      if (change === "bot") computer.controlBotId = "other";
+      expect((await request()).status).toBe(403);
+    },
+  );
+  it("rejects legacy stateless capabilities", async () => {
+    expect(
+      (await fixture().request("/novnc/MTI3LjAuMC4x/49152/view/9999999999999.fake/embed.html"))
+        .status,
+    ).toBe(403);
   });
 });

--- a/apps/api/src/screen-proxy.test.ts
+++ b/apps/api/src/screen-proxy.test.ts
@@ -107,4 +107,12 @@ describe("screen capability lifecycle authorization", () => {
         .status,
     ).toBe(403);
   });
+  it("passes desktop and other non-http screen URLs through unsealed", () => {
+    expect(
+      addScreenProxyCapability("desktop://screen/computer", secret, "https://app.example", scope),
+    ).toBe("desktop://screen/computer");
+    expect(
+      addScreenProxyCapability("local://preview", secret, "https://app.example", scope),
+    ).toBe("local://preview");
+  });
 });

--- a/apps/api/src/screen-proxy.ts
+++ b/apps/api/src/screen-proxy.ts
@@ -17,6 +17,10 @@ export function addScreenProxyCapability(
   scope: ScreenCapabilityScope,
   now = Date.now(),
 ) {
+  // Local/desktop providers return non-http schemes (e.g. desktop://). Those never
+  // traverse the web proxy, so seal only http(s) upstream URLs.
+  const protocol = new URL(url).protocol;
+  if (protocol !== "http:" && protocol !== "https:") return url;
   return sealScreenCapability(url, secret, origin, scope, now);
 }
 

--- a/apps/api/src/screen-proxy.ts
+++ b/apps/api/src/screen-proxy.ts
@@ -1,58 +1,71 @@
-import { createCipheriv, createHash, createHmac, randomBytes } from "node:crypto";
-
-const SCREEN_PROXY_TTL_MS = 60 * 60_000;
-const SCREEN_PROXY_CIPHER = "aes-256-gcm";
-const SCREEN_PROXY_REMOTE_PREFIX = "/novnc/remote";
-
-export interface ScreenProxyOptions {
-  /** Keep provider desktop secrets server-side and enforce the view/control policy in the proxy. */
-  proxyExternal?: boolean;
-}
+import { timingSafeEqual } from "node:crypto";
+import { hasActiveComputerControl } from "@rakazo/adapters";
+import type { ScreenCapabilityScope } from "@rakazo/core/node/screen-capability";
+import {
+  openScreenCapability,
+  SCREEN_TARGET_ENDPOINT,
+  sealScreenCapability,
+} from "@rakazo/core/node/screen-capability";
+import type { PrismaClient } from "@rakazo/db";
+import type { Hono } from "hono";
+import { requestBodyLimit } from "./request-body-limit.js";
 
 export function addScreenProxyCapability(
   url: string,
   secret: string,
-  proxyOrigin: string,
+  origin: string,
+  scope: ScreenCapabilityScope,
   now = Date.now(),
-  options: ScreenProxyOptions = {},
-): string {
-  try {
-    const parsed = new URL(url);
-    if (options.proxyExternal && parsed.protocol === "https:" && parsed.hostname) {
-      const expiresAt = now + SCREEN_PROXY_TTL_MS;
-      const policy = parsed.searchParams.get("view_only") === "false" ? "control" : "view";
-      const token = sealScreenTarget(parsed.toString(), secret, policy, expiresAt);
-      const origin = new URL(proxyOrigin).origin;
-      return `${origin}${SCREEN_PROXY_REMOTE_PREFIX}/${policy}/${expiresAt}.${token}${parsed.pathname || "/"}`;
-    }
-    if (parsed.protocol !== "http:" || !parsed.hostname || !parsed.port) return url;
-    const expiresAt = now + SCREEN_PROXY_TTL_MS;
-    const target = Buffer.from(parsed.hostname).toString("base64url");
-    const policy = parsed.searchParams.get("view_only") === "false" ? "control" : "view";
-    const destination = `${parsed.pathname}${parsed.search}`;
-    const signature = createHmac("sha256", secret)
-      .update(`${parsed.hostname}:${parsed.port}:${policy}:${expiresAt}`)
-      .digest("base64url");
-    const origin = new URL(proxyOrigin).origin;
-    return `${origin}/novnc/${target}/${parsed.port}/${policy}/${expiresAt}.${signature}${destination}`;
-  } catch {
-    return url;
-  }
-}
-
-function sealScreenTarget(
-  url: string,
-  secret: string,
-  policy: "view" | "control",
-  expiresAt: number,
 ) {
-  const iv = randomBytes(12);
-  const cipher = createCipheriv(SCREEN_PROXY_CIPHER, screenProxyKey(secret), iv);
-  cipher.setAAD(Buffer.from(`${policy}:${expiresAt}`));
-  const ciphertext = Buffer.concat([cipher.update(url, "utf8"), cipher.final()]);
-  return Buffer.concat([iv, cipher.getAuthTag(), ciphertext]).toString("base64url");
+  return sealScreenCapability(url, secret, origin, scope, now);
 }
 
-function screenProxyKey(secret: string) {
-  return createHash("sha256").update(secret).digest();
+export function mountScreenTarget(app: Hono, prisma: PrismaClient, secret: string) {
+  app.post(SCREEN_TARGET_ENDPOINT, requestBodyLimit(16 * 1024), async (c) => {
+    c.header("cache-control", "no-store");
+    const supplied = Buffer.from(c.req.header("authorization") ?? "");
+    const expected = Buffer.from(`Bearer ${secret}`);
+    if (!secret || supplied.length !== expected.length || !timingSafeEqual(supplied, expected))
+      return c.body(null, 403);
+    const body = await c.req.json().catch(() => null);
+    if (typeof body?.path !== "string") return c.body(null, 403);
+    const capability = openScreenCapability(body.path, secret);
+    if (!capability) return c.body(null, 403);
+    const { scope, target } = capability;
+    const bot = await prisma.bot.findFirst({
+      where: {
+        id: scope.botId,
+        computerId: scope.computerId,
+        archivedAt: null,
+        screenGeneration: scope.botGeneration,
+      },
+      select: {
+        computer: {
+          select: {
+            screenGeneration: true,
+            providerRef: true,
+            state: true,
+            controlHolder: true,
+            controlLeaseId: true,
+            controlBotId: true,
+            controlLeaseExpiresAt: true,
+          },
+        },
+      },
+    });
+    const computer = bot?.computer;
+    if (
+      !computer ||
+      computer.screenGeneration !== scope.computerGeneration ||
+      !computer.providerRef ||
+      !["running", "booting"].includes(computer.state) ||
+      (target.interactive &&
+        (!hasActiveComputerControl(computer) ||
+          !scope.controlLeaseId ||
+          computer.controlLeaseId !== scope.controlLeaseId ||
+          computer.controlBotId !== scope.botId))
+    )
+      return c.body(null, 403);
+    return c.json(target);
+  });
 }

--- a/apps/mobile/lib/locales/ru.ts
+++ b/apps/mobile/lib/locales/ru.ts
@@ -33,6 +33,9 @@ export const RU_MESSAGES: Record<string, string> = {
   "Recreating the computer": "Повторное создание компьютера",
   "Release computer": "Освободить компьютер",
   "Release interrupted computer?": "Освободить прерванный компьютер?",
+  "Make sure nothing is still running on this computer.":
+    "Убедитесь, что на этом компьютере ничего не запущено.",
+  "Nothing is still running": "Ничего не запущено",
   "Restoring your workspace": "Восстановление вашего рабочего пространства",
   "Saving your workspace": "Сохранение вашего рабочего пространства",
   "Server integrations": "Интеграции сервера",

--- a/apps/web/e2e/screen-proxy-isolation.spec.ts
+++ b/apps/web/e2e/screen-proxy-isolation.spec.ts
@@ -5,9 +5,17 @@ import type { AddressInfo, Server as NetServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
+import { openScreenCapability } from "@rakazo/core/node/screen-capability";
 import { createServer, type Plugin, preview, type ViteDevServer } from "vite";
 import { addScreenProxyCapability } from "../../api/src/screen-proxy";
 
+const scope = {
+  botId: "bot",
+  computerId: "computer",
+  botGeneration: 0,
+  computerGeneration: 0,
+  controlLeaseId: null,
+};
 const secret = "fake-screen-proxy-browser-test-secret";
 const screenHtml = `<!doctype html><title>Fake screen</title>
 <script type="module">
@@ -48,6 +56,7 @@ for (const mode of ["development", "preview"] as const) {
     let screenUrl: string;
     let stop: () => Promise<void>;
 
+    let authorized = true;
     test.beforeAll(async () => {
       const root = await mkdtemp(path.join(tmpdir(), "rakazo-screen-test-"));
       await mkdir(path.join(root, "dist"));
@@ -76,6 +85,7 @@ for (const mode of ["development", "preview"] as const) {
         socket.write(Buffer.from([0x81, 2, 111, 107]));
         socket.on("data", () => socket.end(Buffer.from([0x88, 0])));
         socket.on("error", () => socket.destroy());
+        socket.on("end", () => socket.destroy());
       });
       const upstreamOrigin = await listen(upstream);
 
@@ -97,6 +107,20 @@ for (const mode of ["development", "preview"] as const) {
           } else next();
         });
       }
+      const authority = createHttpServer(async (req, res) => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        const body = JSON.parse(Buffer.concat(chunks).toString());
+        const capability = openScreenCapability(body.path, secret);
+        if (!authorized || !capability || req.headers.authorization !== `Bearer ${secret}`) {
+          res.writeHead(403).end();
+          return;
+        }
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify(capability.target));
+      });
+      const previousApi = process.env.API_PROXY_TARGET;
+      process.env.API_PROXY_TARGET = await listen(authority);
       const previousSecret = process.env.SCREEN_PROXY_SECRET;
       process.env.SCREEN_PROXY_SECRET = secret;
       try {
@@ -115,13 +139,16 @@ for (const mode of ["development", "preview"] as const) {
         if ("listen" in server) await listen(server.httpServer!);
         origin = `http://127.0.0.1:${(server.httpServer!.address() as AddressInfo).port}`;
         // Exercise the same capability issuer used by the production API, with a configured web origin.
-        screenUrl = addScreenProxyCapability(`${upstreamOrigin}/embed.html`, secret, origin);
+        screenUrl = addScreenProxyCapability(`${upstreamOrigin}/embed.html`, secret, origin, scope);
         stop = async () => {
           await server.close();
           await close(upstream);
+          await close(authority);
           await rm(root, { recursive: true, force: true });
         };
       } finally {
+        if (previousApi === undefined) delete process.env.API_PROXY_TARGET;
+        else process.env.API_PROXY_TARGET = previousApi;
         if (previousSecret === undefined) delete process.env.SCREEN_PROXY_SECRET;
         else process.env.SCREEN_PROXY_SECRET = previousSecret;
       }
@@ -151,6 +178,39 @@ for (const mode of ["development", "preview"] as const) {
       expect(
         (await page.context().cookies(origin)).find((c) => c.name === "app-session")?.value,
       ).toBe("fake-session");
+    });
+
+    test("revocation blocks replay and closes an already connected socket", async ({
+      page,
+      request,
+    }) => {
+      await page.goto(`${origin}/app`);
+      await page.evaluate(async (url) => {
+        const target = new URL(url);
+        target.protocol = "ws:";
+        target.pathname = target.pathname.replace("/embed.html", "/hold");
+        const socket = new WebSocket(target);
+        const state = window as unknown as { screenClosed: boolean };
+        state.screenClosed = false;
+        socket.onclose = () => {
+          state.screenClosed = true;
+        };
+        await new Promise<void>((resolve, reject) => {
+          socket.onmessage = () => resolve();
+          socket.onerror = () => reject(new Error("socket failed"));
+        });
+      }, screenUrl);
+      authorized = false;
+      try {
+        expect((await request.get(screenUrl)).status()).toBe(403);
+        await expect
+          .poll(() =>
+            page.evaluate(() => (window as unknown as { screenClosed: boolean }).screenClosed),
+          )
+          .toBe(true);
+      } finally {
+        authorized = true;
+      }
     });
 
     for (const sandbox of ["allow-scripts allow-pointer-lock", null]) {

--- a/apps/web/src/screen-proxy.test.ts
+++ b/apps/web/src/screen-proxy.test.ts
@@ -1,101 +1,84 @@
-import { createCipheriv, createHash, createHmac } from "node:crypto";
-import { describe, expect, it } from "vitest";
-import { resolveNovncTarget, safeProxyHeaders } from "./screen-proxy.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveNovncTarget, safeProxyHeaders, watchScreenAuthorization } from "./screen-proxy.js";
 
-function signedPath(
-  port: number,
-  expiresAt: number,
-  secret: string,
-  rest = "/embed.html",
-  hostname = "127.0.0.1",
-  policy: "view" | "control" = "view",
-) {
-  const signature = createHmac("sha256", secret)
-    .update(`${hostname}:${port}:${policy}:${expiresAt}`)
-    .digest("base64url");
-  const target = Buffer.from(hostname).toString("base64url");
-  return `/novnc/${target}/${port}/${policy}/${expiresAt}.${signature}${rest}`;
-}
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
 
-function remotePath(
-  expiresAt: number,
-  secret: string,
-  url: string,
-  policy: "view" | "control" = "view",
-) {
-  const iv = Buffer.alloc(12, 1);
-  const cipher = createCipheriv("aes-256-gcm", createHash("sha256").update(secret).digest(), iv);
-  cipher.setAAD(Buffer.from(`${policy}:${expiresAt}`));
-  const ciphertext = Buffer.concat([cipher.update(url, "utf8"), cipher.final()]);
-  const token = Buffer.concat([iv, cipher.getAuthTag(), ciphertext]).toString("base64url");
-  return `/novnc/remote/${policy}/${expiresAt}.${token}/vnc.html`;
-}
-
-describe("noVNC proxy authorization", () => {
-  it("accepts signed, unexpired loopback targets", () => {
-    expect(resolveNovncTarget(signedPath(49152, 2_000, "secret"), "secret", 1_000)).toEqual({
+describe("screen proxy", () => {
+  it("rejects legacy URLs without contacting the API", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    expect(
+      await resolveNovncTarget("/novnc/old/view/token/embed.html", "secret", "http://api.example"),
+    ).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+  it("checks each request and fails closed on revocation or API failure", async () => {
+    const target = {
+      protocol: "http:",
       hostname: "127.0.0.1",
       port: 49152,
-      path: "/embed.html?view_only=true",
+      path: "/websockify",
       interactive: false,
+    };
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(target))
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockRejectedValueOnce(new Error("offline"));
+    vi.stubGlobal("fetch", fetch);
+    const resolve = () =>
+      resolveNovncTarget("/novnc/session/view/token/websockify", "secret", "http://api.example");
+    expect(await resolve()).toEqual(target);
+    expect(await resolve()).toBeNull();
+    expect(await resolve()).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch.mock.calls[0]?.[1]).toMatchObject({
+      redirect: "error",
+      headers: { authorization: "Bearer secret" },
     });
   });
-
-  it("rejects arbitrary ports, bad signatures, and expired capabilities", () => {
-    expect(resolveNovncTarget("/novnc/5432/index.html", "secret", 1_000)).toBeNull();
-    expect(resolveNovncTarget(signedPath(49152, 2_000, "wrong"), "secret", 1_000)).toBeNull();
-    expect(resolveNovncTarget(signedPath(49152, 999, "secret"), "secret", 1_000)).toBeNull();
-  });
-
-  it("binds server-enforced view mode while allowing required noVNC paths", () => {
-    const viewOnly = signedPath(49152, 2_000, "secret", "/embed.html?view_only=true");
-    expect(resolveNovncTarget(viewOnly, "secret", 1_000)?.path).toBe("/embed.html?view_only=true");
-    expect(
-      resolveNovncTarget(viewOnly.replace("view_only=true", "view_only=false"), "secret", 1_000),
-    ).toMatchObject({ path: "/embed.html?view_only=true", interactive: false });
-    expect(
-      resolveNovncTarget(
-        viewOnly.replace(/\/embed\.html\?view_only=true$/, "/websockify"),
-        "secret",
-        1_000,
-      ),
-    ).toMatchObject({ path: "/websockify", interactive: false });
-    expect(resolveNovncTarget(viewOnly.replace("/view/", "/control/"), "secret", 1_000)).toBeNull();
-    expect(resolveNovncTarget(viewOnly.replace("/49152/", "/49153/"), "secret", 1_000)).toBeNull();
-
-    const control = signedPath(
-      49153,
-      2_000,
-      "secret",
-      "/embed.html?view_only=true",
-      "127.0.0.1",
-      "control",
+  it("fails closed for a malformed authority response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(Response.json({ hostname: "screen.example", port: "443" })),
     );
-    expect(resolveNovncTarget(control, "secret", 1_000)).toMatchObject({
-      path: "/embed.html?view_only=false",
-      interactive: true,
-    });
-  });
-
-  it("keeps encrypted external Box targets bound to their view/control policy", () => {
-    const target = "https://box.example/vnc.html?token=provider-secret&view_only=true";
-    const view = remotePath(2_000, "secret", target);
-    expect(resolveNovncTarget(view, "secret", 1_000)).toMatchObject({
-      protocol: "https:",
-      hostname: "box.example",
-      port: 443,
-      path: "/vnc.html?token=provider-secret&view_only=true",
-      interactive: false,
-    });
     expect(
-      resolveNovncTarget(view.replace("/vnc.html", "/vnc.html?view_only=false"), "secret", 1_000),
-    ).toMatchObject({
-      path: "/vnc.html?token=provider-secret&view_only=true",
-      interactive: false,
-    });
-    expect(resolveNovncTarget(view.replace("/view/", "/control/"), "secret", 1_000)).toBeNull();
+      await resolveNovncTarget(
+        "/novnc/session/view/token/vnc.html",
+        "secret",
+        "http://api.example",
+      ),
+    ).toBeNull();
   });
 
+  it("closes an active stream on revocation and stops checking closed streams", async () => {
+    vi.useFakeTimers();
+    const check = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const revoke = vi.fn();
+    watchScreenAuthorization(check, revoke);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(revoke).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(revoke).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(check).toHaveBeenCalledTimes(2);
+    const stop = watchScreenAuthorization(check, revoke);
+    stop();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(check).toHaveBeenCalledTimes(2);
+  });
+  it("closes a stream when authorization fails unexpectedly", async () => {
+    vi.useFakeTimers();
+    const revoke = vi.fn();
+    watchScreenAuthorization(async () => {
+      throw new Error("unavailable");
+    }, revoke);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(revoke).toHaveBeenCalledTimes(1);
+  });
   it("does not forward application credentials", () => {
     expect(
       safeProxyHeaders({

--- a/apps/web/src/screen-proxy.ts
+++ b/apps/web/src/screen-proxy.ts
@@ -1,5 +1,10 @@
-import { createDecipheriv, createHash, createHmac, timingSafeEqual } from "node:crypto";
 import type { IncomingHttpHeaders } from "node:http";
+import type { ScreenProxyTarget } from "@rakazo/core/node/screen-capability";
+import {
+  isScreenProxyTarget,
+  SCREEN_RECHECK_MS,
+  SCREEN_TARGET_ENDPOINT,
+} from "@rakazo/core/node/screen-capability";
 
 const SENSITIVE_FORWARD_HEADERS = new Set([
   "authorization",
@@ -8,113 +13,28 @@ const SENSITIVE_FORWARD_HEADERS = new Set([
   "proxy-authenticate",
   "proxy-authorization",
 ]);
-const SCREEN_PROXY_CIPHER = "aes-256-gcm";
 
-export function resolveNovncTarget(url: string | undefined, secret: string, now = Date.now()) {
-  const match = url?.match(
-    /^\/novnc\/([A-Za-z0-9_-]+)\/(\d+)\/(view|control)\/(\d+)\.([A-Za-z0-9_-]{43})(\/[^?]*)?(\?.*)?$/,
-  );
-  if (match) return resolveLocalTarget(match, secret, now);
-
-  const remoteMatch = url?.match(
-    /^\/novnc\/remote\/(view|control)\/(\d+)\.([A-Za-z0-9_-]+)(\/[^?]*)?(\?.*)?$/,
-  );
-  if (!remoteMatch) return null;
-  const policy = remoteMatch[1]! as "view" | "control";
-  const expiresAt = Number(remoteMatch[2]);
-  if (!Number.isInteger(expiresAt) || expiresAt < now) return null;
-  const target = openScreenTarget(remoteMatch[3]!, secret, policy, expiresAt);
-  if (target?.protocol !== "https:") return null;
-  const requestedPath = `${remoteMatch[4] || target.pathname || "/"}${remoteMatch[5] || ""}`;
-  return {
-    protocol: target.protocol,
-    hostname: target.hostname,
-    port: Number(target.port || 443),
-    path: screenPolicyPath(remoteTargetPath(target, requestedPath), policy === "control"),
-    interactive: policy === "control",
-  };
-}
-
-function resolveLocalTarget(match: RegExpMatchArray, secret: string, now: number) {
-  const hostname = Buffer.from(match[1]!, "base64url").toString("utf8");
-  const port = Number(match[2]);
-  const policy = match[3]! as "view" | "control";
-  const expiresAt = Number(match[4]);
-  const signature = match[5]!;
-  const requestedPath = `${match[6] || "/"}${match[7] || ""}`;
-  if (!isAllowedTargetName(hostname)) return null;
-  if (!Number.isInteger(port) || port < 1024 || port > 65_535 || expiresAt < now) return null;
-  const expected = createHmac("sha256", secret)
-    .update(`${hostname}:${port}:${policy}:${expiresAt}`)
-    .digest("base64url");
-  const suppliedBytes = Buffer.from(signature);
-  const expectedBytes = Buffer.from(expected);
-  if (
-    suppliedBytes.length !== expectedBytes.length ||
-    !timingSafeEqual(suppliedBytes, expectedBytes)
-  ) {
-    return null;
-  }
-  return {
-    hostname,
-    port,
-    path: screenPolicyPath(requestedPath, policy === "control"),
-    interactive: policy === "control",
-  };
-}
-
-export function screenPolicyPath(requestedPath: string, interactive: boolean) {
-  const parsed = new URL(requestedPath, "http://screen.invalid");
-  if (parsed.pathname === "/embed.html" || parsed.pathname === "/vnc.html") {
-    parsed.searchParams.set("view_only", interactive ? "false" : "true");
-  }
-  return `${parsed.pathname}${parsed.search}`;
-}
-
-function remoteTargetPath(target: URL, requestedPath: string) {
-  const requested = new URL(requestedPath, "https://screen.invalid");
-  const path = requested.pathname || target.pathname || "/";
-  if (path === target.pathname || path === "/websockify") {
-    return `${path}${target.search}`;
-  }
-  return `${path}${requested.search}`;
-}
-
-function openScreenTarget(
-  token: string,
+/** Fail closed when the authoritative lifecycle check is unavailable. */
+export async function resolveNovncTarget(
+  url: string | undefined,
   secret: string,
-  policy: "view" | "control",
-  expiresAt: number,
-) {
+  api: string,
+): Promise<ScreenProxyTarget | null> {
+  if (!url?.startsWith("/novnc/session/")) return null;
   try {
-    const sealed = Buffer.from(token, "base64url");
-    if (sealed.length <= 28) return null;
-    const decipher = createDecipheriv(
-      SCREEN_PROXY_CIPHER,
-      createHash("sha256").update(secret).digest(),
-      sealed.subarray(0, 12),
-    );
-    decipher.setAAD(Buffer.from(`${policy}:${expiresAt}`));
-    decipher.setAuthTag(sealed.subarray(12, 28));
-    const target = new URL(
-      Buffer.concat([decipher.update(sealed.subarray(28)), decipher.final()]).toString("utf8"),
-    );
-    return target.hostname && target.protocol === "https:" ? target : null;
+    const response = await fetch(new URL(SCREEN_TARGET_ENDPOINT, api), {
+      method: "POST",
+      redirect: "error",
+      signal: AbortSignal.timeout(2_000),
+      headers: { authorization: `Bearer ${secret}`, "content-type": "application/json" },
+      body: JSON.stringify({ path: url }),
+    });
+    if (!response.ok) return null;
+    const target: unknown = await response.json();
+    return isScreenProxyTarget(target) ? target : null;
   } catch {
     return null;
   }
-}
-
-function isAllowedTargetName(hostname: string) {
-  return (
-    hostname === "localhost" ||
-    hostname === "127.0.0.1" ||
-    hostname === "::1" ||
-    /^10\.(?:\d{1,3}\.){2}\d{1,3}$/.test(hostname) ||
-    /^172\.(?:1[6-9]|2\d|3[01])\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
-    /^192\.168\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
-    /^rakazo-bot-[a-zA-Z0-9_.-]+$/.test(hostname)
-  );
 }
 
 function isHttp2PseudoHeader(key: string) {
@@ -131,4 +51,32 @@ export function safeProxyHeaders(headers: IncomingHttpHeaders) {
       );
     }),
   );
+}
+
+/** Recheck streams as well as new requests; no positive authorization cache. */
+export function watchScreenAuthorization(check: () => Promise<boolean>, revoke: () => void) {
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout>;
+  const tick = async () => {
+    let allowed = false;
+    try {
+      allowed = Boolean(await check());
+    } catch {
+      /* Fail closed. */
+    }
+    if (stopped) return;
+    if (!allowed) {
+      stopped = true;
+      revoke();
+      return;
+    }
+    timer = setTimeout(tick, SCREEN_RECHECK_MS);
+    timer.unref?.();
+  };
+  timer = setTimeout(tick, SCREEN_RECHECK_MS);
+  timer.unref?.();
+  return () => {
+    stopped = true;
+    clearTimeout(timer);
+  };
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -13,9 +13,14 @@ import {
 import babel from "@rolldown/plugin-babel";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig, loadEnv, type PreviewServer, type ViteDevServer } from "vite";
+import type { PreviewServer, ViteDevServer } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import { resolveScreenProxySecret } from "../../packages/core/src/secrets-guard.ts";
-import { resolveNovncTarget, safeProxyHeaders } from "./src/screen-proxy.js";
+import {
+  resolveNovncTarget,
+  safeProxyHeaders,
+  watchScreenAuthorization,
+} from "./src/screen-proxy.js";
 
 const webPort = Number(process.env.WEB_PORT ?? 5173);
 const DESKTOP_STACK_PROBE_PATH = "/.well-known/rakazo-desktop-stack";
@@ -54,13 +59,14 @@ function attachDesktopStackProbe(
   });
 }
 
-function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string) {
-  server.middlewares.use((req, res, next) => {
+function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string, api: string) {
+  server.middlewares.use(async (req, res, next) => {
     if (!req.url?.startsWith("/novnc/")) {
       next();
       return;
     }
-    const target = resolveNovncTarget(req.url, secret);
+    const target = await resolveNovncTarget(req.url, secret, api);
+    if (res.destroyed) return;
     if (!target) {
       res.statusCode = 403;
       res.end("Invalid or expired screen capability");
@@ -85,16 +91,33 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string)
         incoming.pipe(res);
       },
     );
-    upstream.on("error", (error) => {
+    const stopChecking = watchScreenAuthorization(
+      async () => Boolean(await resolveNovncTarget(req.url, secret, api)),
+      () => {
+        upstream.destroy();
+        res.destroy();
+      },
+    );
+    res.once("close", () => {
+      stopChecking();
+      upstream.destroy();
+    });
+    upstream.on("error", () => {
+      stopChecking();
+      if (res.headersSent) {
+        res.destroy();
+        return;
+      }
       res.statusCode = 502;
-      res.end(error.message);
+      res.end("Screen unavailable");
     });
     req.pipe(upstream);
   });
 
-  server.httpServer?.on("upgrade", (req, socket, head) => {
+  server.httpServer?.on("upgrade", async (req, socket, head) => {
     if (!req.url?.startsWith("/novnc/")) return;
-    const target = resolveNovncTarget(req.url, secret);
+    const target = await resolveNovncTarget(req.url, secret, api);
+    if (socket.destroyed) return;
     if (!target) {
       socket.destroy();
       return;
@@ -103,6 +126,21 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string)
       target.protocol === "https:"
         ? tls.connect({ port: target.port, host: target.hostname, servername: target.hostname })
         : net.connect(target.port, target.hostname);
+    const stopChecking = watchScreenAuthorization(
+      async () => Boolean(await resolveNovncTarget(req.url, secret, api)),
+      () => {
+        socket.destroy();
+        upstream.destroy();
+      },
+    );
+    socket.once("close", () => {
+      stopChecking();
+      upstream.destroy();
+    });
+    upstream.once("close", () => {
+      stopChecking();
+      socket.destroy();
+    });
     upstream.once(target.protocol === "https:" ? "secureConnect" : "connect", () => {
       const headerLines = [
         `${req.method ?? "GET"} ${target.path} HTTP/1.1`,
@@ -192,8 +230,8 @@ export default defineConfig(({ mode }) => {
       },
       {
         name: "rakazo-novnc-proxy",
-        configureServer: (server) => attachNovncProxy(server, screenProxySecret()),
-        configurePreviewServer: (server) => attachNovncProxy(server, screenProxySecret()),
+        configureServer: (server) => attachNovncProxy(server, screenProxySecret(), api),
+        configurePreviewServer: (server) => attachNovncProxy(server, screenProxySecret(), api),
       },
     ],
     server: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,11 @@
       "types": "./src/node/desktop-runtime.ts",
       "development": "./src/node/desktop-runtime.ts",
       "default": "./src/node/desktop-runtime.ts"
+    },
+    "./node/screen-capability": {
+      "types": "./src/node/screen-capability.ts",
+      "development": "./src/node/screen-capability.ts",
+      "default": "./src/node/screen-capability.ts"
     }
   },
   "scripts": {

--- a/packages/core/src/node/screen-capability.test.ts
+++ b/packages/core/src/node/screen-capability.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  openScreenCapability,
+  SCREEN_PROXY_TTL_MS,
+  sealScreenCapability,
+} from "./screen-capability.js";
+
+const scope = {
+  botId: "bot",
+  computerId: "computer",
+  botGeneration: 2,
+  computerGeneration: 3,
+  controlLeaseId: null,
+};
+const path = (url: string, interactive = false) =>
+  new URL(
+    sealScreenCapability(
+      `${url}?token=fake-provider-token&view_only=${!interactive}`,
+      "fake-secret",
+      "https://app.example",
+      scope,
+      100,
+    ),
+  ).pathname;
+describe("sealed screen capabilities", () => {
+  it("hides provider credentials and binds scope and destination", () => {
+    const value = path("https://screen.example/vnc.html");
+    expect(value).not.toContain("fake-provider-token");
+    expect(openScreenCapability(value, "fake-secret", 101)).toMatchObject({
+      scope,
+      target: {
+        hostname: "screen.example",
+        port: 443,
+        protocol: "https:",
+        interactive: false,
+        path: "/vnc.html?token=fake-provider-token&view_only=true",
+      },
+    });
+    expect(
+      openScreenCapability(value.replace("/vnc.html", "/websockify"), "fake-secret", 101)?.target
+        .path,
+    ).toBe("/websockify?token=fake-provider-token&view_only=true");
+  });
+  it("keeps noVNC routing public and nested provider socket credentials sealed", () => {
+    const provider = new URL("https://screen.example/vnc.html");
+    provider.searchParams.set("path", "websockify?token=fake-socket-token");
+    const url = new URL(
+      sealScreenCapability(provider.toString(), "fake-secret", "https://app.example", scope, 100),
+    );
+    expect(url.toString()).not.toContain("fake-socket-token");
+    expect(url.searchParams.get("autoconnect")).toBe("true");
+    const socketPath = `/${url.searchParams.get("path")}`;
+    expect(openScreenCapability(socketPath, "fake-secret", 101)?.target.path).toBe(
+      "/websockify?token=fake-socket-token",
+    );
+  });
+
+  it("randomizes issuance even at the same timestamp", () => {
+    expect(path("http://127.0.0.1:49152/embed.html")).not.toBe(
+      path("http://127.0.0.1:49152/embed.html"),
+    );
+  });
+  it("rejects wrong keys, modified policy, expiry and ciphertext", () => {
+    const value = path("http://127.0.0.1:49152/embed.html");
+    expect(openScreenCapability(value, "wrong", 101)).toBeNull();
+    expect(
+      openScreenCapability(value.replace("/view/", "/control/"), "fake-secret", 101),
+    ).toBeNull();
+    expect(
+      openScreenCapability(value.replace("3600100.", "3600101."), "fake-secret", 101),
+    ).toBeNull();
+    expect(
+      openScreenCapability(
+        value.replace(/\.(.)/, (_, c) => `.${c === "a" ? "b" : "a"}`),
+        "fake-secret",
+        101,
+      ),
+    ).toBeNull();
+    expect(openScreenCapability(value, "fake-secret", 100 + SCREEN_PROXY_TTL_MS)).toBeNull();
+  });
+  it("enforces view policy and still serves relative assets", () => {
+    const value = path("http://127.0.0.1:49152/embed.html");
+    expect(
+      openScreenCapability(`${value}?view_only=false`, "fake-secret", 101)?.target.path,
+    ).toContain("view_only=true");
+    expect(
+      openScreenCapability(value.replace("/embed.html", "/core/rfb.js"), "fake-secret", 101)?.target
+        .path,
+    ).toBe("/core/rfb.js");
+    expect(
+      openScreenCapability(path("http://127.0.0.1:49152/embed.html", true), "fake-secret", 101)
+        ?.target.interactive,
+    ).toBe(true);
+  });
+  it.each(["http://public.example:49152/embed.html", "http://127.0.0.1:80/embed.html"])(
+    "rejects disallowed local target %s",
+    (url) => {
+      expect(openScreenCapability(path(url), "fake-secret", 101)).toBeNull();
+    },
+  );
+});

--- a/packages/core/src/node/screen-capability.test.ts
+++ b/packages/core/src/node/screen-capability.test.ts
@@ -78,6 +78,13 @@ describe("sealed screen capabilities", () => {
     ).toBeNull();
     expect(openScreenCapability(value, "fake-secret", 100 + SCREEN_PROXY_TTL_MS)).toBeNull();
   });
+  it("rejects truncated capability tokens before decryption", () => {
+    const value = path("http://127.0.0.1:49152/embed.html");
+    const match = value.match(/^(\/novnc\/session\/view\/\d+\.)([A-Za-z0-9_-]+)(\/.*)$/);
+    expect(match).not.toBeNull();
+    const truncated = `${match![1]}${match![2]!.slice(0, 8)}${match![3]}`;
+    expect(openScreenCapability(truncated, "fake-secret", 101)).toBeNull();
+  });
   it("enforces view policy and still serves relative assets", () => {
     const value = path("http://127.0.0.1:49152/embed.html");
     expect(

--- a/packages/core/src/node/screen-capability.ts
+++ b/packages/core/src/node/screen-capability.ts
@@ -52,7 +52,12 @@ export function sealScreenCapability(
   const policy = target.searchParams.get("view_only") === "false" ? "control" : "view";
   const expiresAt = now + SCREEN_PROXY_TTL_MS;
   const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", createHash("sha256").update(secret).digest(), iv);
+  const cipher = createCipheriv(
+    "aes-256-gcm",
+    createHash("sha256").update(secret).digest(),
+    iv,
+    { authTagLength: 16 },
+  );
   cipher.setAAD(Buffer.from(`${policy}:${expiresAt}`));
   const ciphertext = Buffer.concat([
     cipher.update(JSON.stringify({ url, scope }), "utf8"),
@@ -85,10 +90,12 @@ export function openScreenCapability(
   if (!Number.isSafeInteger(expiresAt) || expiresAt <= now) return null;
   try {
     const sealed = Buffer.from(match[3]!, "base64url");
+    if (sealed.length < 28) return null;
     const decipher = createDecipheriv(
       "aes-256-gcm",
       createHash("sha256").update(secret).digest(),
       sealed.subarray(0, 12),
+      { authTagLength: 16 },
     );
     decipher.setAAD(Buffer.from(`${match[1]}:${expiresAt}`));
     decipher.setAuthTag(sealed.subarray(12, 28));

--- a/packages/core/src/node/screen-capability.ts
+++ b/packages/core/src/node/screen-capability.ts
@@ -52,12 +52,9 @@ export function sealScreenCapability(
   const policy = target.searchParams.get("view_only") === "false" ? "control" : "view";
   const expiresAt = now + SCREEN_PROXY_TTL_MS;
   const iv = randomBytes(12);
-  const cipher = createCipheriv(
-    "aes-256-gcm",
-    createHash("sha256").update(secret).digest(),
-    iv,
-    { authTagLength: 16 },
-  );
+  const cipher = createCipheriv("aes-256-gcm", createHash("sha256").update(secret).digest(), iv, {
+    authTagLength: 16,
+  });
   cipher.setAAD(Buffer.from(`${policy}:${expiresAt}`));
   const ciphertext = Buffer.concat([
     cipher.update(JSON.stringify({ url, scope }), "utf8"),

--- a/packages/core/src/node/screen-capability.ts
+++ b/packages/core/src/node/screen-capability.ts
@@ -1,0 +1,165 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+
+export const SCREEN_PROXY_TTL_MS = 60 * 60_000;
+export const SCREEN_TARGET_ENDPOINT = "/api/internal/screen-target";
+export const SCREEN_RECHECK_MS = 1_000;
+
+export interface ScreenCapabilityScope {
+  botId: string;
+  computerId: string;
+  botGeneration: number;
+  computerGeneration: number;
+  controlLeaseId: string | null;
+}
+
+export interface ScreenProxyTarget {
+  protocol: "http:" | "https:";
+  hostname: string;
+  port: number;
+  path: string;
+  interactive: boolean;
+}
+
+export function isScreenProxyTarget(value: unknown): value is ScreenProxyTarget {
+  if (!value || typeof value !== "object") return false;
+  const target = value as Record<string, unknown>;
+  return (
+    (target.protocol === "http:" || target.protocol === "https:") &&
+    typeof target.hostname === "string" &&
+    target.hostname.length > 0 &&
+    !/[\s/]/.test(target.hostname) &&
+    typeof target.port === "number" &&
+    Number.isInteger(target.port) &&
+    target.port > 0 &&
+    target.port <= 65535 &&
+    typeof target.path === "string" &&
+    target.path.startsWith("/") &&
+    !/[\r\n]/.test(target.path) &&
+    typeof target.interactive === "boolean"
+  );
+}
+
+export function sealScreenCapability(
+  url: string,
+  secret: string,
+  origin: string,
+  scope: ScreenCapabilityScope,
+  now = Date.now(),
+) {
+  const target = new URL(url);
+  if (target.protocol !== "https:" && target.protocol !== "http:")
+    throw new Error("Invalid screen protocol");
+  const policy = target.searchParams.get("view_only") === "false" ? "control" : "view";
+  const expiresAt = now + SCREEN_PROXY_TTL_MS;
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", createHash("sha256").update(secret).digest(), iv);
+  cipher.setAAD(Buffer.from(`${policy}:${expiresAt}`));
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify({ url, scope }), "utf8"),
+    cipher.final(),
+  ]);
+  const token = Buffer.concat([iv, cipher.getAuthTag(), ciphertext]).toString("base64url");
+  const prefix = `/novnc/session/${policy}/${expiresAt}.${token}`;
+  const result = new URL(`${prefix}${target.pathname || "/"}`, new URL(origin).origin);
+  // noVNC reads these from the browser URL. Keep its socket inside the capability
+  // route while the provider's nested socket token stays sealed server-side.
+  result.search = new URLSearchParams({
+    autoconnect: "true",
+    resize: "scale",
+    view_only: policy === "control" ? "false" : "true",
+    path: `${prefix.slice(1)}/websockify`,
+  }).toString();
+  return result.toString();
+}
+
+export function openScreenCapability(
+  path: string | undefined,
+  secret: string,
+  now = Date.now(),
+): { scope: ScreenCapabilityScope; expiresAt: number; target: ScreenProxyTarget } | null {
+  const match = path?.match(
+    /^\/novnc\/session\/(view|control)\/(\d+)\.([A-Za-z0-9_-]+)(\/[^?]*)?(\?.*)?$/,
+  );
+  if (!match) return null;
+  const expiresAt = Number(match[2]);
+  if (!Number.isSafeInteger(expiresAt) || expiresAt <= now) return null;
+  try {
+    const sealed = Buffer.from(match[3]!, "base64url");
+    const decipher = createDecipheriv(
+      "aes-256-gcm",
+      createHash("sha256").update(secret).digest(),
+      sealed.subarray(0, 12),
+    );
+    decipher.setAAD(Buffer.from(`${match[1]}:${expiresAt}`));
+    decipher.setAuthTag(sealed.subarray(12, 28));
+    const payload = JSON.parse(
+      Buffer.concat([decipher.update(sealed.subarray(28)), decipher.final()]).toString("utf8"),
+    );
+    const scope = payload.scope as ScreenCapabilityScope;
+    if (
+      !scope ||
+      typeof scope.botId !== "string" ||
+      typeof scope.computerId !== "string" ||
+      !Number.isSafeInteger(scope.botGeneration) ||
+      !Number.isSafeInteger(scope.computerGeneration) ||
+      (scope.controlLeaseId !== null && typeof scope.controlLeaseId !== "string")
+    )
+      return null;
+    const target = new URL(payload.url);
+    if (target.protocol !== "https:" && target.protocol !== "http:") return null;
+    const port = Number(target.port || (target.protocol === "https:" ? 443 : 80));
+    if (
+      target.protocol === "http:" &&
+      (!isAllowedTargetName(target.hostname) || port < 1024 || port > 65535)
+    )
+      return null;
+    const interactive = match[1] === "control";
+    const requestedPath = `${match[4] || target.pathname || "/"}${match[5] || ""}`;
+    return {
+      scope,
+      expiresAt,
+      target: {
+        protocol: target.protocol,
+        hostname: target.hostname,
+        port,
+        path: screenPolicyPath(remoteTargetPath(target, requestedPath), interactive),
+        interactive,
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function screenPolicyPath(requestedPath: string, interactive: boolean) {
+  const parsed = new URL(requestedPath, "http://screen.invalid");
+  if (parsed.pathname === "/embed.html" || parsed.pathname === "/vnc.html") {
+    parsed.searchParams.set("view_only", interactive ? "false" : "true");
+  }
+  return `${parsed.pathname}${parsed.search}`;
+}
+
+function remoteTargetPath(target: URL, requestedPath: string) {
+  const requested = new URL(requestedPath, "https://screen.invalid");
+  const path = requested.pathname || target.pathname || "/";
+  if (path === "/websockify" && target.searchParams.has("path")) {
+    const socket = new URL(target.searchParams.get("path")!, target);
+    return `${socket.pathname}${socket.search}`;
+  }
+  if (path === target.pathname || path === "/websockify") {
+    return `${path}${target.search}`;
+  }
+  return `${path}${requested.search}`;
+}
+
+function isAllowedTargetName(hostname: string) {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    /^10\.(?:\d{1,3}\.){2}\d{1,3}$/.test(hostname) ||
+    /^172\.(?:1[6-9]|2\d|3[01])\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
+    /^192\.168\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
+    /^rakazo-bot-[a-zA-Z0-9_.-]+$/.test(hostname)
+  );
+}

--- a/packages/db/prisma/migrations/20260909000000_screen_generation/migration.sql
+++ b/packages/db/prisma/migrations/20260909000000_screen_generation/migration.sql
@@ -1,0 +1,27 @@
+ALTER TABLE "bots" ADD COLUMN "screenGeneration" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "computers" ADD COLUMN "screenGeneration" INTEGER NOT NULL DEFAULT 0;
+
+-- Database fences cover lifecycle writes from the API, workers, and recovery paths.
+-- A resumed provider may reuse its address and reference; old URLs must stay revoked.
+CREATE FUNCTION revoke_computer_screens() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF (NEW.state IS DISTINCT FROM OLD.state AND NOT (OLD.state = 'booting' AND NEW.state = 'running'))
+    OR NEW."providerRef" IS DISTINCT FROM OLD."providerRef" THEN
+    NEW."screenGeneration" := OLD."screenGeneration" + 1;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER revoke_computer_screens BEFORE UPDATE ON "computers"
+FOR EACH ROW EXECUTE FUNCTION revoke_computer_screens();
+
+CREATE FUNCTION revoke_bot_screens() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW."computerId" IS DISTINCT FROM OLD."computerId" OR NEW."archivedAt" IS DISTINCT FROM OLD."archivedAt" THEN
+    NEW."screenGeneration" := OLD."screenGeneration" + 1;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER revoke_bot_screens BEFORE UPDATE ON "bots"
+FOR EACH ROW EXECUTE FUNCTION revoke_bot_screens();

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -318,6 +318,7 @@ model SpaceVoicePreference {
 }
 
 model Bot {
+  screenGeneration Int @default(0)
   id                String            @id @default(cuid())
   spaceId           String
   space             Space             @relation(fields: [spaceId], references: [id], onDelete: Cascade)
@@ -884,6 +885,7 @@ model ComputerUpdate {
 }
 
 model Computer {
+  screenGeneration Int @default(0)
   id                      String                   @id @default(cuid())
   spaceId                 String
   space                   Space                    @relation(fields: [spaceId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
Screen access should end when its computer stops, its bot is archived or reassigned, or its control lease ends, without breaking normal assets, reconnects, or native desktop screens.
This adds shared encrypted lifecycle capabilities with explicit GCM tag validation, checks requests and active streams against database generations and live leases, keeps provider socket credentials server-side, and shows “Screen unavailable” only on proxy failure to explain the failure without exposing upstream details.
It also supplies “Убедитесь, что на этом компьютере ничего не запущено.” and “Ничего не запущено” in the existing native-only mobile release confirmation, where the warning and confirmation must be translated when shown; web CI cannot capture this native dialog.
Validated with scoped unit tests, eight headless browser tests, temporary-database migration checks, repository-wide type checks, and lint with existing warnings; apply the migration and deploy the API and web proxy together because legacy screen URLs are rejected.
