### PR TITLE
Raise Playwright screenshot publish budget to 300

### DIFF
--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -28,7 +28,7 @@ describe("validatePlaywrightScreenshotBudget", () => {
   it("rejects the first screenshot and byte beyond their limits", () => {
     expect(() =>
       validatePlaywrightScreenshotBudget(MAX_PLAYWRIGHT_SCREENSHOT_COUNT + 1, 0),
-    ).toThrow(/251 screenshots; maximum is 250/);
+    ).toThrow(/301 screenshots; maximum is 300/);
     expect(() =>
       validatePlaywrightScreenshotBudget(1, MAX_PLAYWRIGHT_SCREENSHOT_BYTES + 1),
     ).toThrow(/maximum total size of 262144000 bytes/);

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -1,5 +1,5 @@
 const MAX_HISTORY_LENGTH = 100;
-export const MAX_PLAYWRIGHT_SCREENSHOT_COUNT = 250;
+export const MAX_PLAYWRIGHT_SCREENSHOT_COUNT = 300;
 export const MAX_PLAYWRIGHT_SCREENSHOT_BYTES = 250 * 1024 * 1024;
 const SHARED_PAGE_STYLES = `
     :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #09090b; color: #fafafa; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Playwright report publish still fails on main when the suite emits more than `MAX_PLAYWRIGHT_SCREENSHOT_COUNT` (250 on main; suite ~254). The earlier RU catalog gap is already fixed on main (#822), so this PR only raises the screenshot publish budget.

## What changed

- Raised `MAX_PLAYWRIGHT_SCREENSHOT_COUNT` from 250 to 300
- Updated the matching `packages/testkit` budget unit test expectation (`301` / `300`)
- Kept main’s RU translations for the release-dialog keys (no product UI/copy change in this tip)

## How tested

- `pnpm --filter @rakazo/mobile test` (mobile lib suite, including i18n): passed
- `pnpm exec vitest run packages/testkit/src/playwright-report-dashboard.test.ts`: passed

No UI product changes; no agent-captured screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04f76a79-4678-4340-b036-6a8023931a9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04f76a79-4678-4340-b036-6a8023931a9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the maximum number of Playwright screenshots permitted in a report from 250 to 300.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->