### PR TITLE
chore(copy): shorten picker and OpenAPI blurbs

### DIFF
--- a/apps/web/e2e/new-bot-ux.spec.ts
+++ b/apps/web/e2e/new-bot-ux.spec.ts
@@ -80,7 +80,7 @@ test("picker rows explain groups and spaces", async ({ page }, testInfo) => {
   const dialog = page.getByTestId("picker-info-dialog");
   await expect(dialog).toBeVisible();
   await expect(dialog.getByText("Groups", { exact: true })).toBeVisible();
-  await expect(dialog).toContainText("shared thread");
+  await expect(dialog).toContainText("same thread");
   await expect(page.getByTestId("side-panel")).not.toHaveAttribute("data-panel", "create-group");
   await captureScreenshot(page, testInfo, "picker-group-info-dialog");
   await dialog.getByRole("button", { name: "Close" }).click();

--- a/apps/web/e2e/new-bot-ux.spec.ts
+++ b/apps/web/e2e/new-bot-ux.spec.ts
@@ -94,7 +94,7 @@ test("picker rows explain groups and spaces", async ({ page }, testInfo) => {
   await spaceInfo.click();
   await expect(dialog).toBeVisible();
   await expect(dialog.getByText("Spaces", { exact: true })).toBeVisible();
-  await expect(dialog).toContainText("private workspace");
+  await expect(dialog).toContainText("own bots and groups");
   await captureScreenshot(page, testInfo, "picker-space-info-dialog");
   await page.keyboard.press("Escape");
   await expect(dialog).toBeHidden();

--- a/apps/web/scripts/translations-de.json
+++ b/apps/web/scripts/translations-de.json
@@ -426,7 +426,6 @@
   "Provider": "Anbieter",
   "Providers": "Anbieter",
   "Queued": "In Warteschlange",
-  "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model.": "Rakazo prüft die Quelle vor dem Speichern. Zugangsdaten werden verschlüsselt und weder an Clients zurückgegeben noch dem Modell zugänglich gemacht.",
   "Read replies aloud": "Antworten vorlesen",
   "Recent": "Kürzlich",
   "Reconnect OAuth": "OAuth erneut verbinden",
@@ -585,5 +584,6 @@
   "To:": "An:",
   "Authorize this server so agents can use its tools. A popup opens.": "Autorisiere diesen Server, damit Agents seine Tools nutzen können. Ein Pop-up öffnet sich.",
   "Make sure nothing is still running on this computer.": "Stelle sicher, dass auf diesem Computer nichts mehr läuft.",
-  "Nothing is still running": "Nichts läuft mehr"
+  "Nothing is still running": "Nichts läuft mehr",
+  "Credentials are encrypted and never sent to the model.": "Zugangsdaten werden verschlüsselt und dem Modell nie gesendet."
 }

--- a/apps/web/scripts/translations-es.json
+++ b/apps/web/scripts/translations-es.json
@@ -514,7 +514,6 @@
   "Provider": "Proveedor",
   "Providers": "Proveedores",
   "Queued": "En cola",
-  "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model.": "Rakazo verifica la fuente antes de guardarla. Las credenciales se cifran y nunca se devuelven a los clientes ni se exponen al modelo.",
   "Read replies aloud": "Leer respuestas en voz alta",
   "Recent": "Recientes",
   "Reconnect OAuth": "Reconectar OAuth",
@@ -728,5 +727,6 @@
   "To:": "Para:",
   "Authorize this server so agents can use its tools. A popup opens.": "Autoriza este servidor para que tus agentes usen sus herramientas. Se abre una ventana emergente.",
   "Make sure nothing is still running on this computer.": "Asegúrate de que no quede nada en ejecución en este ordenador.",
-  "Nothing is still running": "No queda nada en ejecución"
+  "Nothing is still running": "No queda nada en ejecución",
+  "Credentials are encrypted and never sent to the model.": "Las credenciales se cifran y nunca se envían al modelo."
 }

--- a/apps/web/scripts/translations-hi.json
+++ b/apps/web/scripts/translations-hi.json
@@ -421,7 +421,6 @@
   "Provider": "प्रोवाइडर",
   "Providers": "प्रोवाइडर्स",
   "Queued": "कतार में",
-  "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model.": "Rakazo सहेजने से पहले स्रोत की पुष्टि करता है। क्रेडेंशियल एन्क्रिप्टेड होते हैं और कभी क्लाइंट को नहीं लौटाए जाते, न ही मॉडल को दिखाए जाते हैं।",
   "Read replies aloud": "उत्तर पढ़कर सुनाएं",
   "Recent": "हाल के",
   "Reconnect OAuth": "OAuth पुनः कनेक्ट करें",
@@ -588,5 +587,6 @@
   "To:": "प्रति:",
   "Authorize this server so agents can use its tools. A popup opens.": "एजेंटों को इसके टूल का उपयोग करने देने के लिए इस सर्वर को ऑथराइज़ करें। एक पॉपअप खुलता है।",
   "Make sure nothing is still running on this computer.": "सुनिश्चित करें कि इस कंप्यूटर पर कुछ भी चल नहीं रहा है।",
-  "Nothing is still running": "कुछ भी नहीं चल रहा"
+  "Nothing is still running": "कुछ भी नहीं चल रहा",
+  "Credentials are encrypted and never sent to the model.": "क्रेडेंशियल एन्क्रिप्टेड होते हैं और मॉडल को कभी नहीं भेजे जाते।"
 }

--- a/apps/web/scripts/translations-ko.json
+++ b/apps/web/scripts/translations-ko.json
@@ -426,7 +426,6 @@
   "Provider": "서비스",
   "Providers": "서비스",
   "Queued": "대기 중",
-  "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model.": "Rakazo는 저장하기 전에 연결 상태를 확인합니다. 인증 정보는 암호화되며 앱이나 AI 모델에 노출되지 않습니다.",
   "Read replies aloud": "답변을 자동으로 읽기",
   "Recent": "최근",
   "Reconnect OAuth": "OAuth 다시 연결",
@@ -585,5 +584,6 @@
   "To:": "받는 사람:",
   "Authorize this server so agents can use its tools. A popup opens.": "에이전트가 도구를 사용할 수 있도록 이 서버에 권한을 부여하세요. 팝업이 열립니다.",
   "Make sure nothing is still running on this computer.": "이 컴퓨터에서 실행 중인 작업이 없는지 확인하세요.",
-  "Nothing is still running": "실행 중인 작업 없음"
+  "Nothing is still running": "실행 중인 작업 없음",
+  "Credentials are encrypted and never sent to the model.": "인증 정보는 암호화되며 모델에 전송되지 않습니다."
 }

--- a/apps/web/scripts/translations-pt-BR.json
+++ b/apps/web/scripts/translations-pt-BR.json
@@ -421,7 +421,6 @@
   "Provider": "Provedor",
   "Providers": "Provedores",
   "Queued": "Na fila",
-  "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model.": "Rakazo verifica a fonte antes de salvá-la. As credenciais são criptografadas e nunca são devolvidas aos clientes ou expostas ao modelo.",
   "Read replies aloud": "Leia as respostas em voz alta",
   "Recent": "Recente",
   "Reconnect OAuth": "Reconectar OAuth",
@@ -587,5 +586,6 @@
   "To:": "Para:",
   "Authorize this server so agents can use its tools. A popup opens.": "Autorize este servidor para que os agentes usem suas ferramentas. Uma janela pop-up será aberta.",
   "Make sure nothing is still running on this computer.": "Confirme que nada ainda está em execução neste computador.",
-  "Nothing is still running": "Nada ainda está em execução"
+  "Nothing is still running": "Nada ainda está em execução",
+  "Credentials are encrypted and never sent to the model.": "As credenciais são criptografadas e nunca são enviadas ao modelo."
 }

--- a/apps/web/scripts/translations-tr.json
+++ b/apps/web/scripts/translations-tr.json
@@ -424,7 +424,6 @@
   "Provider": "Sağlayıcı",
   "Providers": "Sağlayıcılar",
   "Queued": "Kuyrukta",
-  "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model.": "Rakazo kaynağı kaydetmeden önce doğrular. Kimlik bilgileri şifrelenir; istemcilere asla geri gönderilmez ve modele gösterilmez.",
   "Read replies aloud": "Yanıtları sesli oku",
   "Recent": "Son",
   "Reconnect OAuth": "OAuth'u yeniden bağla",
@@ -582,5 +581,6 @@
   "To:": "Kime:",
   "Authorize this server so agents can use its tools. A popup opens.": "Agent'ların araçlarını kullanabilmesi için bu sunucuyu yetkilendir. Bir açılır pencere açılır.",
   "Make sure nothing is still running on this computer.": "Bu bilgisayarda hâlâ çalışan bir şey olmadığından emin ol.",
-  "Nothing is still running": "Hâlâ çalışan bir şey yok"
+  "Nothing is still running": "Hâlâ çalışan bir şey yok",
+  "Credentials are encrypted and never sent to the model.": "Kimlik bilgileri şifrelenir ve modele asla gönderilmez."
 }

--- a/apps/web/scripts/translations-zh-CN.json
+++ b/apps/web/scripts/translations-zh-CN.json
@@ -425,7 +425,6 @@
   "Provider": "提供方",
   "Providers": "提供方",
   "Queued": "排队中",
-  "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model.": "Rakazo 会在保存前校验来源。凭据已加密，不会返回给客户端，也不会暴露给模型。",
   "Read replies aloud": "朗读回复",
   "Recent": "最近",
   "Reconnect OAuth": "重新连接 OAuth",
@@ -734,5 +733,6 @@
   "To:": "至:",
   "Authorize this server so agents can use its tools. A popup opens.": "授权此服务器后，Agent 才能使用其工具。将打开弹窗。",
   "Make sure nothing is still running on this computer.": "请确认这台电脑上没有仍在运行的任务。",
-  "Nothing is still running": "没有仍在运行的任务"
+  "Nothing is still running": "没有仍在运行的任务",
+  "Credentials are encrypted and never sent to the model.": "凭据已加密，不会发送给模型。"
 }

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -141,8 +141,8 @@ msgstr "{workingBotName} arbeitet"
 msgid "@{0}"
 msgstr "@{0}"
 
-#: src/pages/shell/dialogs.tsx:140
-msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+#: src/pages/shell/dialogs.tsx:137
+msgid "Private workspace with its own bots and groups."
 msgstr ""
 
 #: src/pages/shell/bot-picker.tsx:105
@@ -2515,7 +2515,7 @@ msgid "on the 1st at {0}"
 msgstr "am 1. um {0}"
 
 #: src/pages/shell/dialogs.tsx:135
-msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgid "Shared chat with 2-6 bots. They all reply in the same thread."
 msgstr ""
 
 #: src/pages/Shell.tsx:3681
@@ -2687,8 +2687,8 @@ msgid "Queued"
 msgstr "In Warteschlange"
 
 #: src/pages/PluginsOverlay.tsx:1075
-msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
-msgstr "Rakazo prüft die Quelle vor dem Speichern. Zugangsdaten werden verschlüsselt und weder an Clients zurückgegeben noch dem Modell zugänglich gemacht."
+msgid "Credentials are encrypted and never sent to the model."
+msgstr "Zugangsdaten werden verschlüsselt und dem Modell nie gesendet."
 
 #: src/pages/shell/bot-panel.tsx:478
 msgid "Read replies aloud"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -141,9 +141,9 @@ msgstr "{workingBotName} is working"
 msgid "@{0}"
 msgstr "@{0}"
 
-#: src/pages/shell/dialogs.tsx:140
-msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
-msgstr "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+#: src/pages/shell/dialogs.tsx:137
+msgid "Private workspace with its own bots and groups."
+msgstr "Private workspace with its own bots and groups."
 
 #: src/pages/shell/bot-picker.tsx:105
 #: src/pages/shell/bot-picker.tsx:106
@@ -2515,8 +2515,8 @@ msgid "on the 1st at {0}"
 msgstr "on the 1st at {0}"
 
 #: src/pages/shell/dialogs.tsx:135
-msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
-msgstr "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgid "Shared chat with 2-6 bots. They all reply in the same thread."
+msgstr "Shared chat with 2-6 bots. They all reply in the same thread."
 
 #: src/pages/Shell.tsx:3681
 msgid "Only empty spaces can be deleted. Delete its bots and groups first."
@@ -2687,8 +2687,8 @@ msgid "Queued"
 msgstr "Queued"
 
 #: src/pages/PluginsOverlay.tsx:1075
-msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
-msgstr "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
+msgid "Credentials are encrypted and never sent to the model."
+msgstr "Credentials are encrypted and never sent to the model."
 
 #: src/pages/shell/bot-panel.tsx:478
 msgid "Read replies aloud"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -141,8 +141,8 @@ msgstr "{workingBotName} está trabajando"
 msgid "@{0}"
 msgstr "@{0}"
 
-#: src/pages/shell/dialogs.tsx:140
-msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+#: src/pages/shell/dialogs.tsx:137
+msgid "Private workspace with its own bots and groups."
 msgstr ""
 
 #: src/pages/shell/bot-picker.tsx:105
@@ -2515,7 +2515,7 @@ msgid "on the 1st at {0}"
 msgstr "el día 1 a las {0}"
 
 #: src/pages/shell/dialogs.tsx:135
-msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgid "Shared chat with 2-6 bots. They all reply in the same thread."
 msgstr ""
 
 #: src/pages/Shell.tsx:3681
@@ -2687,8 +2687,8 @@ msgid "Queued"
 msgstr "En cola"
 
 #: src/pages/PluginsOverlay.tsx:1075
-msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
-msgstr "Rakazo verifica la fuente antes de guardarla. Las credenciales se cifran y nunca se devuelven a los clientes ni se exponen al modelo."
+msgid "Credentials are encrypted and never sent to the model."
+msgstr "Las credenciales se cifran y nunca se envían al modelo."
 
 #: src/pages/shell/bot-panel.tsx:478
 msgid "Read replies aloud"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -141,8 +141,8 @@ msgstr "{workingBotName} काम कर रहा है"
 msgid "@{0}"
 msgstr "@{0}"
 
-#: src/pages/shell/dialogs.tsx:140
-msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+#: src/pages/shell/dialogs.tsx:137
+msgid "Private workspace with its own bots and groups."
 msgstr ""
 
 #: src/pages/shell/bot-picker.tsx:105
@@ -2515,7 +2515,7 @@ msgid "on the 1st at {0}"
 msgstr "1 तारीख को {0} बजे"
 
 #: src/pages/shell/dialogs.tsx:135
-msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgid "Shared chat with 2-6 bots. They all reply in the same thread."
 msgstr ""
 
 #: src/pages/Shell.tsx:3681
@@ -2687,8 +2687,8 @@ msgid "Queued"
 msgstr "कतार में"
 
 #: src/pages/PluginsOverlay.tsx:1075
-msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
-msgstr "Rakazo सहेजने से पहले स्रोत की पुष्टि करता है। क्रेडेंशियल एन्क्रिप्टेड होते हैं और कभी क्लाइंट को नहीं लौटाए जाते, न ही मॉडल को दिखाए जाते हैं।"
+msgid "Credentials are encrypted and never sent to the model."
+msgstr "क्रेडेंशियल एन्क्रिप्टेड होते हैं और मॉडल को कभी नहीं भेजे जाते।"
 
 #: src/pages/shell/bot-panel.tsx:478
 msgid "Read replies aloud"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -141,8 +141,8 @@ msgstr "{workingBotName} 작업 중"
 msgid "@{0}"
 msgstr "@{0}"
 
-#: src/pages/shell/dialogs.tsx:140
-msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+#: src/pages/shell/dialogs.tsx:137
+msgid "Private workspace with its own bots and groups."
 msgstr ""
 
 #: src/pages/shell/bot-picker.tsx:105
@@ -2515,7 +2515,7 @@ msgid "on the 1st at {0}"
 msgstr "매월 1일 {0}에"
 
 #: src/pages/shell/dialogs.tsx:135
-msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgid "Shared chat with 2-6 bots. They all reply in the same thread."
 msgstr ""
 
 #: src/pages/Shell.tsx:3681
@@ -2687,8 +2687,8 @@ msgid "Queued"
 msgstr "대기 중"
 
 #: src/pages/PluginsOverlay.tsx:1075
-msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
-msgstr "Rakazo는 저장하기 전에 연결 상태를 확인합니다. 인증 정보는 암호화되며 앱이나 AI 모델에 노출되지 않습니다."
+msgid "Credentials are encrypted and never sent to the model."
+msgstr "인증 정보는 암호화되며 모델에 전송되지 않습니다."
 
 #: src/pages/shell/bot-panel.tsx:478
 msgid "Read replies aloud"

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -141,8 +141,8 @@ msgstr "{workingBotName} está trabalhando"
 msgid "@{0}"
 msgstr "@{0}"
 
-#: src/pages/shell/dialogs.tsx:140
-msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+#: src/pages/shell/dialogs.tsx:137
+msgid "Private workspace with its own bots and groups."
 msgstr ""
 
 #: src/pages/shell/bot-picker.tsx:105
@@ -2515,7 +2515,7 @@ msgid "on the 1st at {0}"
 msgstr "no dia 1º às {0}"
 
 #: src/pages/shell/dialogs.tsx:135
-msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgid "Shared chat with 2-6 bots. They all reply in the same thread."
 msgstr ""
 
 #: src/pages/Shell.tsx:3681
@@ -2687,8 +2687,8 @@ msgid "Queued"
 msgstr "Na fila"
 
 #: src/pages/PluginsOverlay.tsx:1075
-msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
-msgstr "Rakazo verifica a fonte antes de salvá-la. As credenciais são criptografadas e nunca são devolvidas aos clientes ou expostas ao modelo."
+msgid "Credentials are encrypted and never sent to the model."
+msgstr "As credenciais são criptografadas e nunca são enviadas ao modelo."
 
 #: src/pages/shell/bot-panel.tsx:478
 msgid "Read replies aloud"

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -141,9 +141,9 @@ msgstr "{workingBotName} работает"
 msgid "@{0}"
 msgstr "@{0}"
 
-#: src/pages/shell/dialogs.tsx:140
-msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
-msgstr "Отдельное приватное пространство со своими ботами и группами. Используйте пространства, чтобы разделять контексты, например рабочий и личный."
+#: src/pages/shell/dialogs.tsx:137
+msgid "Private workspace with its own bots and groups."
+msgstr "Приватное пространство со своими ботами и группами."
 
 #: src/pages/shell/bot-picker.tsx:105
 #: src/pages/shell/bot-picker.tsx:106
@@ -2506,8 +2506,8 @@ msgid "on the 1st at {0}"
 msgstr "1-го числа в {0}"
 
 #: src/pages/shell/dialogs.tsx:135
-msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
-msgstr "Один общий разговор с 2–6 вашими ботами. Назовите группу, выберите ее участников — и все они будут отвечать в одном чате."
+msgid "Shared chat with 2-6 bots. They all reply in the same thread."
+msgstr "Общий чат с 2-6 ботами. Все отвечают в одной ветке."
 
 #: src/pages/Shell.tsx:3681
 msgid "Only empty spaces can be deleted. Delete its bots and groups first."
@@ -2678,8 +2678,8 @@ msgid "Queued"
 msgstr "В очереди"
 
 #: src/pages/PluginsOverlay.tsx:1075
-msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
-msgstr "Rakazo проверяет источник перед сохранением. Учётные данные зашифрованы и никогда не возвращаются клиентам и не раскрываются модели."
+msgid "Credentials are encrypted and never sent to the model."
+msgstr "Учётные данные зашифрованы и никогда не передаются модели."
 
 #: src/pages/shell/bot-panel.tsx:478
 msgid "Read replies aloud"

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -141,8 +141,8 @@ msgstr "{workingBotName} çalışıyor"
 msgid "@{0}"
 msgstr "@{0}"
 
-#: src/pages/shell/dialogs.tsx:140
-msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+#: src/pages/shell/dialogs.tsx:137
+msgid "Private workspace with its own bots and groups."
 msgstr ""
 
 #: src/pages/shell/bot-picker.tsx:105
@@ -2515,7 +2515,7 @@ msgid "on the 1st at {0}"
 msgstr "her ayın 1'inde saat {0}"
 
 #: src/pages/shell/dialogs.tsx:135
-msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgid "Shared chat with 2-6 bots. They all reply in the same thread."
 msgstr ""
 
 #: src/pages/Shell.tsx:3681
@@ -2687,8 +2687,8 @@ msgid "Queued"
 msgstr "Kuyrukta"
 
 #: src/pages/PluginsOverlay.tsx:1075
-msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
-msgstr "Rakazo kaynağı kaydetmeden önce doğrular. Kimlik bilgileri şifrelenir; istemcilere asla geri gönderilmez ve modele gösterilmez."
+msgid "Credentials are encrypted and never sent to the model."
+msgstr "Kimlik bilgileri şifrelenir ve modele asla gönderilmez."
 
 #: src/pages/shell/bot-panel.tsx:478
 msgid "Read replies aloud"

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -141,8 +141,8 @@ msgstr "{workingBotName} 正在工作"
 msgid "@{0}"
 msgstr "@{0}"
 
-#: src/pages/shell/dialogs.tsx:140
-msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+#: src/pages/shell/dialogs.tsx:137
+msgid "Private workspace with its own bots and groups."
 msgstr ""
 
 #: src/pages/shell/bot-picker.tsx:105
@@ -2515,7 +2515,7 @@ msgid "on the 1st at {0}"
 msgstr "每月 1 日 {0}"
 
 #: src/pages/shell/dialogs.tsx:135
-msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgid "Shared chat with 2-6 bots. They all reply in the same thread."
 msgstr ""
 
 #: src/pages/Shell.tsx:3681
@@ -2687,8 +2687,8 @@ msgid "Queued"
 msgstr "排队中"
 
 #: src/pages/PluginsOverlay.tsx:1075
-msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
-msgstr "Rakazo 会在保存前校验来源。凭据已加密，不会返回给客户端，也不会暴露给模型。"
+msgid "Credentials are encrypted and never sent to the model."
+msgstr "凭据已加密，不会发送给模型。"
 
 #: src/pages/shell/bot-panel.tsx:478
 msgid "Read replies aloud"

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -1072,10 +1072,7 @@ export function PluginsOverlay({
                           />
                         ) : null}
                         <p className="text-xs leading-5 text-muted-foreground">
-                          <Trans>
-                            Rakazo verifies the source before saving it. Credentials are encrypted
-                            and are never returned to clients or exposed to the model.
-                          </Trans>
+                          <Trans>Credentials are encrypted and never sent to the model.</Trans>
                         </p>
                         {sourceHint ? (
                           <p className="text-xs leading-5 text-muted-foreground">{sourceHint}</p>

--- a/apps/web/src/pages/shell/dialogs.tsx
+++ b/apps/web/src/pages/shell/dialogs.tsx
@@ -132,15 +132,9 @@ export function PickerInfoDialog({
           </DialogTitle>
           <DialogDescription>
             {topic === "group" ? (
-              <Trans>
-                One conversation with 2–6 of your bots in a shared thread. Name the group, pick its
-                members, and they all reply in the same chat.
-              </Trans>
+              <Trans>Shared chat with 2-6 bots. They all reply in the same thread.</Trans>
             ) : (
-              <Trans>
-                A separate, private workspace with its own bots and groups. Use spaces to keep
-                contexts apart, such as work and personal.
-              </Trans>
+              <Trans>Private workspace with its own bots and groups.</Trans>
             )}
           </DialogDescription>
         </DialogHeader>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
Three leftover explainer blurbs still read like AI helper text. Shortening them keeps the same meaning with less chrome.

## What changed
- Groups picker info: `Shared chat with 2-6 bots. They all reply in the same thread.`
- Spaces picker info: `Private workspace with its own bots and groups.`
- OpenAPI/source credential helper: `Credentials are encrypted and never sent to the model.`
- Synced Lingui catalogs and matching `apps/web/scripts/translations-*.json` seeds for the credential string. Russian picker msgstrs shortened to match. No mobile mirror of these blurbs.
- Updated picker info E2E assertions for the new Groups/Spaces sentences (`same thread`, `own bots and groups`). Playwright concatenates the dialog title and body, so a `private workspace` substring sits inside `SpacesPrivate…` and fails the match.

## How tested
- Confirmed the three English sources and catalog msgids match; ASCII hyphen in `2-6`.
- `biome check` on the touched TSX/spec files: clean.
- `pnpm --filter @rakazo/web intl:compile`: clean.
- No UI screenshots (copy-only).
- Aikido scan not run: MCP requires sign-in in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c22b879-c0d9-4e63-9f11-d1b4087cd977?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c22b879-c0d9-4e63-9f11-d1b4087cd977&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Shortened descriptions in space and group creation dialogs.
  * Updated picker information to clarify that groups use the same thread and spaces provide access to personal bots and groups.
  * Simplified the credential-security notice to state that credentials are encrypted and never sent to the model.

* **Localization**
  * Updated translated credential-security messages and dialog copy across supported languages.

* **Tests**
  * Updated end-to-end assertions to reflect the revised dialog wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->