### PR TITLE
fix(web): show a visible control to restore the minimized bots sidebar

### DIFF
--- a/apps/web/e2e/new-bot-ux.spec.ts
+++ b/apps/web/e2e/new-bot-ux.spec.ts
@@ -49,7 +49,16 @@ test("create opens form, then empty chat; picker lists bots; sidebar collapses",
   await expect(page.getByTestId("bots-sidebar")).toHaveAttribute("data-collapsed", "true");
   const edge = page.getByTestId("bots-sidebar-edge");
   await expect(edge).toBeVisible();
+  const restore = page.getByTestId("restore-bots-sidebar");
+  await expect(restore).toBeVisible();
   await captureScreenshot(page, testInfo, "bots-sidebar-collapsed");
+
+  await restore.click();
+  await expect(page.getByTestId("bots-sidebar")).toHaveAttribute("data-collapsed", "false");
+  await expect(restore).toHaveCount(0);
+
+  await page.getByTestId("minimize-bots-sidebar").click();
+  await expect(page.getByTestId("bots-sidebar")).toHaveAttribute("data-collapsed", "true");
 
   const box = await edge.boundingBox();
   expect(box).toBeTruthy();

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -94,6 +94,7 @@ import {
   Monitor,
   MoreHorizontal,
   PanelLeftClose,
+  PanelLeftOpen,
   Paperclip,
   Plus,
   Puzzle,
@@ -3026,6 +3027,18 @@ export function ShellPage() {
             >
               <Menu size={19} strokeWidth={1.7} />
             </button>
+            {botsSidebarCollapsed ? (
+              <button
+                type="button"
+                data-testid="restore-bots-sidebar"
+                aria-label={t`Show bots`}
+                title={t`Show bots`}
+                onClick={() => setBotsSidebarCollapsedPref(false)}
+                className="app-no-drag hidden h-8 w-8 shrink-0 place-items-center rounded-lg text-foreground/75 hover:bg-accent md:grid"
+              >
+                <PanelLeftOpen size={19} strokeWidth={1.7} aria-hidden="true" />
+              </button>
+            ) : null}
             <button
               type="button"
               data-testid="bot-settings-trigger"


### PR DESCRIPTION
## Why

Minimizing the bots sidebar on desktop stranded the user: the sidebar vanished and nothing on screen offered a way back. The only restore control was the 8px edge strip, which is transparent with no border and no icon, so it stayed undiscoverable until you happened to hover the exact window edge. The visible "Minimize bots" button sits inside the sidebar and hides itself along with it, and the navigation button in the main header is mobile-only. Screen readers were fine — the edge strip carries `aria-label="Show bots"` — so this was a sighted-user gap.

Fixes #824.

## What changed

- `apps/web/src/pages/Shell.tsx`: a desktop-only panel button (`PanelLeftOpen`) renders in the main header while the sidebar is collapsed, in the slot next to the mobile navigation button. It unmounts when the sidebar expands, so it never coexists with "Minimize bots".
- The edge strip is untouched: click and drag still toggle, and it remains the resize affordance.
- No new user-facing copy. The button reuses the existing "Show bots" string that already labels the edge strip, as its `aria-label` and `title`.
- `apps/web/e2e/new-bot-ux.spec.ts`: the existing collapse test now asserts the button is visible when collapsed, restores with a click, and disappears once expanded, then re-collapses so the original drag-to-expand assertion still runs. The `bots-sidebar-collapsed` screenshot now captures the button.

## How it was tested

Biome check, the repo-wide typecheck (22 packages), and the unit suite (364 files, 3793 tests) all pass with no failures. The Playwright suite was not run locally because the harness starts Postgres through testcontainers and this machine has no Docker; CI covers it. The `bots-sidebar-collapsed` screenshot from the CI E2E job shows the new button, and I will link it on this PR once the run publishes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Show bots” control to restore the bots sidebar after it has been collapsed.
  - The restore control appears only when the sidebar is collapsed and expands it with one click.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->