### PR TITLE
feat(computers): cap Computer records per user with SANDBOX_MAX_COMPUTERS_PER_USER

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,10 @@ SANDBOX_COMMAND_TIMEOUT_MS=300000
 # Optional limit on active bot desktops per Docker Team Computer.
 # 0 leaves capacity to the machine; desktops and Chrome start only when needed.
 SANDBOX_TEAM_SCREEN_LIMIT=0
+# Optional cap on Computer records still backing live bots, per user. Each record
+# becomes a sandbox container once provisioned, so the cap bounds the container
+# fleet one user can create. 0 means no configured cap (default).
+SANDBOX_MAX_COMPUTERS_PER_USER=0
 # Optional per-turn tool-call fuse for the Pi agent runtime. Unset, empty, or 0
 # means unlimited (default). Set a positive integer to soft-stop a turn that
 # exceeds the budget and still emit a final assistant message.

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -4,7 +4,7 @@ import type { Actor } from "@rakazo/contracts";
 import { openScreenCapability } from "@rakazo/core/node/screen-capability";
 import type { PrismaClient } from "@rakazo/db";
 import { createLogger, createTestSink, installLogger } from "@rakazo/logging";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRouter, type RouterDeps } from "./router.js";
 
 describe("account preferences", () => {
@@ -839,4 +839,82 @@ describe("interrupted computer reservation release", () => {
     });
     expect(order).toEqual(["operation", "computer"]);
   });
+});
+
+describe("bot restore computer quota", () => {
+  function fixture(archivedBot: { archivedAt: Date | null } | null, inUse = 0) {
+    const bot = archivedBot
+      ? {
+          ...archivedBot,
+          id: "bot-archived",
+          computerId: "computer-archived",
+          computer: { id: "computer-archived" },
+          userId: "user-1",
+        }
+      : null;
+    const prisma = {
+      bot: {
+        findFirst: vi.fn(async () => bot),
+        update: vi.fn(async () => ({})),
+      },
+      computer: {
+        count: vi.fn(async (args: { where: { id?: string } }) =>
+          args.where.id ? 0 : inUse,
+        ),
+      },
+    };
+    const handler = new RPCHandler(
+      createRouter({ prisma, env: { sandboxProvider: "fake" } } as unknown as RouterDeps),
+    );
+    const call = async () =>
+      handler.handle(
+        new Request("http://127.0.0.1/rpc/bots/restore", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ json: { botId: "bot-archived" } }),
+        }),
+        {
+          prefix: "/rpc",
+          context: {
+            actor: {
+              spaceId: "space-1",
+              userId: "user-1",
+              email: "user@rakazo.test",
+              isDeploymentOwner: true,
+            },
+          },
+        },
+      );
+    return { prisma, call };
+  }
+
+  it("archives, creates, then restores is refused when the restore would exceed the cap", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "1";
+    const { prisma, call } = fixture({ archivedAt: new Date() }, 1);
+    const { response } = await call();
+    expect(response.status).toBe(400);
+    expect(prisma.bot.update).not.toHaveBeenCalled();
+  });
+
+  it("restores normally when the user is below the cap or the computer is already live", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "1";
+    const { prisma, call } = fixture({ archivedAt: new Date() }, 0);
+    const { response } = await call();
+    expect(response.status).toBe(200);
+    expect(prisma.bot.update).toHaveBeenCalledWith({
+      where: { id: "bot-archived" },
+      data: { archivedAt: null },
+    });
+  });
+
+  it("does not enforce anything when the cap is unset", async () => {
+    const { prisma, call } = fixture({ archivedAt: new Date() }, 99);
+    const { response } = await call();
+    expect(response.status).toBe(200);
+    expect(prisma.bot.update).toHaveBeenCalledOnce();
+  });
+});
+
+afterEach(() => {
+  delete process.env.SANDBOX_MAX_COMPUTERS_PER_USER;
 });

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -858,9 +858,7 @@ describe("bot restore computer quota", () => {
         update: vi.fn(async () => ({})),
       },
       computer: {
-        count: vi.fn(async (args: { where: { id?: string } }) =>
-          args.where.id ? 0 : inUse,
-        ),
+        count: vi.fn(async (args: { where: { id?: string } }) => (args.where.id ? 0 : inUse)),
       },
     };
     const handler = new RPCHandler(

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -96,9 +96,11 @@ import {
 } from "@rakazo/core";
 import {
   appendEventInTransaction,
+  assertComputerQuotaForRestore,
   CannotDeleteDefaultSpaceError,
   CannotDeleteLastSpaceError,
   CannotDeleteSpaceAsNonOwnerError,
+  ComputerLimitError,
   claimEmptySpaceDeletionForMember,
   createExternalConversationRepos,
   createGroupRepos,
@@ -120,8 +122,6 @@ import {
   newestVoiceCredentialOrder,
   Prisma,
   type PrismaClient,
-  assertComputerQuotaForRestore,
-  ComputerLimitError,
   parseComputerMode,
   releaseSpaceDeletionClaim,
   renewSpaceDeletionClaim,

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -120,11 +120,12 @@ import {
   newestVoiceCredentialOrder,
   Prisma,
   type PrismaClient,
+  assertComputerQuotaForRestore,
+  ComputerLimitError,
   parseComputerMode,
   releaseSpaceDeletionClaim,
   renewSpaceDeletionClaim,
   SPACE_DELETION_CLAIM_TIMEOUT_MS,
-  ComputerLimitError,
   SpaceDeletionInProgressError,
   SpaceLimitError,
   SpaceNotEmptyError,
@@ -1152,7 +1153,17 @@ export function createRouter(deps: RouterDeps) {
       restore: authed.bots.restore.handler(async ({ context, input }) => {
         const bot = await repos.getBot(context.actor, input.botId, { includeArchived: true });
         if (!bot.archivedAt) return { ok: true as const };
-        await deps.prisma.bot.update({ where: { id: bot.id }, data: { archivedAt: null } });
+        try {
+          if (bot.computer) {
+            await assertComputerQuotaForRestore(deps.prisma, {
+              userId: context.actor.userId,
+              computerId: bot.computer.id,
+            });
+          }
+          await deps.prisma.bot.update({ where: { id: bot.id }, data: { archivedAt: null } });
+        } catch (error) {
+          throw mapSpaceLifecycleError(error);
+        }
         return { ok: true as const };
       }),
       remove: authed.bots.remove.handler(async ({ context, input }) => {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -124,6 +124,7 @@ import {
   releaseSpaceDeletionClaim,
   renewSpaceDeletionClaim,
   SPACE_DELETION_CLAIM_TIMEOUT_MS,
+  ComputerLimitError,
   SpaceDeletionInProgressError,
   SpaceLimitError,
   SpaceNotEmptyError,
@@ -462,6 +463,9 @@ function spaceTeardownTimeoutMs(): number {
 function mapSpaceLifecycleError(error: unknown): unknown {
   if (error instanceof SpaceDeletionInProgressError) {
     return new ORPCError("CONFLICT", { message: error.message });
+  }
+  if (error instanceof ComputerLimitError) {
+    return new ORPCError("BAD_REQUEST", { message: error.message });
   }
   return error;
 }
@@ -1069,7 +1073,11 @@ export function createRouter(deps: RouterDeps) {
         if (!bot.computer) throw new IsolationError();
         const currentMode = bot.computer.scope === "dedicated" ? "dedicated" : "team";
         if (currentMode === input.mode) {
-          return repos.setBotComputer(context.actor, bot.id, input.mode);
+          try {
+            return await repos.setBotComputer(context.actor, bot.id, input.mode);
+          } catch (error) {
+            throw mapSpaceLifecycleError(error);
+          }
         }
         const claimed = await deps.prisma.$transaction(async (tx) => {
           await tx.$queryRaw`SELECT id FROM computers WHERE id = ${bot.computerId} FOR UPDATE`;
@@ -1116,6 +1124,8 @@ export function createRouter(deps: RouterDeps) {
             });
           }
           return await repos.setBotComputer(context.actor, bot.id, input.mode);
+        } catch (error) {
+          throw mapSpaceLifecycleError(error);
         } finally {
           await deps.prisma.bot.updateMany({
             where: { id: bot.id },

--- a/packages/db/src/computers.test.ts
+++ b/packages/db/src/computers.test.ts
@@ -33,12 +33,28 @@ function fakeRestorePrisma(results: { alreadyLive: number; inUse: number }) {
  * pg_advisory_xact_lock: concurrent quota transactions for the same user queue,
  * and creating a new computer increments the in-use count (as createBot /
  * setBotComputer do by linking a live bot in the same transaction).
+ *
+ * references track which bot sits on which computer so the count filter can
+ * model the intermediate re-link: a bot's old computer stops counting once
+ * the same transaction re-links it to a different one.
  */
 function fakeSerializingPrisma(initialInUse = 0) {
-  const state = { inUse: initialInUse };
   const rows = new Map<string, { id: string }>();
+  const ids = new Map<string, string>(); // computer row id -> scopeKey
+  const refs = new Map<string, Set<string>>(); // scopeKey -> bot ids
   let locked = false;
   const waiters: Array<() => void> = [];
+  const state = { inUse: initialInUse };
+
+  function recomputeInUse() {
+    let used = 0;
+    for (const bots of refs.values()) if (bots.size > 0) used += 1;
+    state.inUse = used;
+  }
+
+  function botIdFromScopeKey(scopeKey: string): string | null {
+    return scopeKey.startsWith("bot:") ? scopeKey.slice(4) : null;
+  }
 
   async function acquireLock() {
     if (!locked) {
@@ -60,6 +76,13 @@ function fakeSerializingPrisma(initialInUse = 0) {
     locked = false;
   }
 
+  function linkBot(botId: string, computerId: string) {
+    const scopeKey = ids.get(computerId);
+    for (const bots of refs.values()) bots.delete(botId);
+    if (scopeKey) refs.get(scopeKey)!.add(botId);
+    recomputeInUse();
+  }
+
   const prisma = {
     $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
       let held = false;
@@ -76,15 +99,38 @@ function fakeSerializingPrisma(initialInUse = 0) {
             const row = rows.get(args.where.scopeKey);
             return row ? { id: row.id } : null;
           }),
-          count: vi.fn(async () => state.inUse),
+          count: vi.fn(async (args: { where: { bots?: { some?: { id?: { not?: string } } } } }) => {
+            const excludeBot = args.where.bots?.some?.id?.not;
+            let used = 0;
+            for (const bots of refs.values()) {
+              if (excludeBot) {
+                if ([...bots].some((bot) => bot !== excludeBot)) used += 1;
+              } else if (bots.size > 0) {
+                used += 1;
+              }
+            }
+            return used;
+          }),
           upsert: vi.fn(async (args: { where: { scopeKey: string } }) => {
             const existing = rows.get(args.where.scopeKey);
             if (existing) return existing;
             const row = { id: `comp-${rows.size + 1}` };
             rows.set(args.where.scopeKey, row);
-            // Same-transaction bot link makes the new row count as in-use.
-            state.inUse += 1;
+            ids.set(row.id, args.where.scopeKey);
+            refs.set(args.where.scopeKey, new Set());
+            // Same-transaction bot link makes the new row count as in-use:
+            // createBot links the bot right after the row is ensured, so the
+            // dedicated path's botId is already known to the quota check.
+            const botId = botIdFromScopeKey(args.where.scopeKey);
+            if (botId) refs.get(args.where.scopeKey)!.add(botId);
+            recomputeInUse();
             return row;
+          }),
+        },
+        bot: {
+          update: vi.fn(async (args: { where: { id: string }; data: { computerId: string } }) => {
+            linkBot(args.where.id, args.data.computerId);
+            return { id: args.where.id };
           }),
         },
       };
@@ -94,9 +140,15 @@ function fakeSerializingPrisma(initialInUse = 0) {
         if (held) releaseLock();
       }
     }),
+    bot: {
+      update: vi.fn(async (args: { where: { id: string }; data: { computerId: string } }) => {
+        linkBot(args.where.id, args.data.computerId);
+        return { id: args.where.id };
+      }),
+    },
   } as unknown as PrismaClient;
 
-  return { prisma, state };
+  return { prisma, state, refs };
 }
 
 const baseInput = {
@@ -188,6 +240,54 @@ describe("ensureComputerRecord", () => {
     );
     expect(state.inUse).toBe(1);
     expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows the initial dedicated create at cap 1: the bot's team reference is being re-linked", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "1";
+    const { prisma, state, refs } = fakeSerializingPrisma(0);
+    // createBot flow, first bot in a space, dedicated mode:
+    // 1. team computer ensured: no bots reference it yet.
+    const team = await ensureComputerRecord(prisma, {
+      mode: "team",
+      spaceId: "space-1",
+      userId: "user-1",
+      kind: "docker",
+    });
+    // The mock's bot.create analog: link the bot to the team computer.
+    await prisma.bot.update({ where: { id: "bot-1" }, data: { computerId: team.id } });
+    expect(state.inUse).toBe(1);
+    // 2. dedicated computer ensured: the bot is still on the team row, so the
+    //    count must exclude this bot's own intermediate reference.
+    const dedicated = await ensureComputerRecord(prisma, {
+      ...baseInput,
+      mode: "dedicated",
+      botId: "bot-1",
+    });
+    // 3. the bot re-links to the dedicated computer (createBot does this).
+    await prisma.bot.update({ where: { id: "bot-1" }, data: { computerId: dedicated.id } });
+    expect(state.inUse).toBe(1);
+    expect(refs.get(`bot:bot-1`)).toBeDefined();
+  });
+
+  it("allows team-to-dedicated replacement at cap 1 when the final set is one computer", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "1";
+    const { prisma, state, refs } = fakeSerializingPrisma(0);
+    // Existing bot on a team computer (setBotComputer switching to dedicated).
+    const team = await ensureComputerRecord(prisma, {
+      mode: "team",
+      spaceId: "space-1",
+      userId: "user-1",
+      kind: "docker",
+    });
+    await prisma.bot.update({ where: { id: "bot-1" }, data: { computerId: team.id } });
+    const dedicated = await ensureComputerRecord(prisma, {
+      ...baseInput,
+      mode: "dedicated",
+      botId: "bot-1",
+    });
+    await prisma.bot.update({ where: { id: "bot-1" }, data: { computerId: dedicated.id } });
+    expect(state.inUse).toBe(1);
+    expect(refs.get("team:space-1")?.size).toBe(0);
   });
 });
 

--- a/packages/db/src/computers.test.ts
+++ b/packages/db/src/computers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import type { PrismaClient } from "./client.js";
 import {
   ComputerLimitError,
+  assertComputerQuotaForRestore,
   ensureComputerRecord,
   resolveMaxComputersPerUser,
 } from "./computers.js";
@@ -13,6 +14,15 @@ function fakePrisma(count = 0, existing = false) {
       count: vi.fn(async () => count),
       upsert: vi.fn(async (args) => args.update as object),
     },
+  } as unknown as PrismaClient;
+}
+
+function fakeRestorePrisma(results: { alreadyLive: number; inUse: number }) {
+  const count = vi.fn(async (args: { where: { id?: string } }) =>
+    args.where.id ? results.alreadyLive : results.inUse,
+  );
+  return {
+    computer: { count },
   } as unknown as PrismaClient;
 }
 
@@ -75,5 +85,42 @@ describe("ensureComputerRecord", () => {
     const prisma = fakePrisma(99, false);
     await ensureComputerRecord(prisma, baseInput);
     expect(prisma.computer.upsert).toHaveBeenCalledOnce();
+  });
+});
+
+describe("assertComputerQuotaForRestore", () => {
+  it("rejects the archive, create, restore bypass when the user is at the cap", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "1";
+    // The archived bot's computer has no live bot referencing it (alreadyLive=0)
+    // and the user already has 1 in-use computer (the newly created bot's).
+    const prisma = fakeRestorePrisma({ alreadyLive: 0, inUse: 1 });
+    await expect(
+      assertComputerQuotaForRestore(prisma, { userId: "user-1", computerId: "computer-a" }),
+    ).rejects.toThrow(ComputerLimitError);
+  });
+
+  it("allows the restore when the user is below the cap", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "1";
+    const prisma = fakeRestorePrisma({ alreadyLive: 0, inUse: 0 });
+    await expect(
+      assertComputerQuotaForRestore(prisma, { userId: "user-1", computerId: "computer-a" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("allows the restore when another live bot already references the computer", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "1";
+    // Team computer shared by a still-live bot in the same space: restoring an
+    // archived sibling bot adds nothing to the count, so it must not be refused.
+    const prisma = fakeRestorePrisma({ alreadyLive: 1, inUse: 1 });
+    await expect(
+      assertComputerQuotaForRestore(prisma, { userId: "user-1", computerId: "team-computer" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not enforce anything when the cap is unset", async () => {
+    const prisma = fakeRestorePrisma({ alreadyLive: 0, inUse: 99 });
+    await expect(
+      assertComputerQuotaForRestore(prisma, { userId: "user-1", computerId: "computer-a" }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/db/src/computers.test.ts
+++ b/packages/db/src/computers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import type { PrismaClient } from "./client.js";
+import {
+  ComputerLimitError,
+  ensureComputerRecord,
+  resolveMaxComputersPerUser,
+} from "./computers.js";
+
+function fakePrisma(count = 0, existing = false) {
+  return {
+    computer: {
+      findUnique: vi.fn(async () => (existing ? { id: "existing" } : null)),
+      count: vi.fn(async () => count),
+      upsert: vi.fn(async (args) => args.update as object),
+    },
+  } as unknown as PrismaClient;
+}
+
+const baseInput = {
+  mode: "dedicated" as const,
+  spaceId: "space-1",
+  userId: "user-1",
+  botId: "bot-4",
+  kind: "docker",
+};
+
+const savedEnv = process.env.SANDBOX_MAX_COMPUTERS_PER_USER;
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.SANDBOX_MAX_COMPUTERS_PER_USER;
+  else process.env.SANDBOX_MAX_COMPUTERS_PER_USER = savedEnv;
+  vi.restoreAllMocks();
+});
+
+describe("resolveMaxComputersPerUser", () => {
+  it("treats unset, empty, and 0 as no configured cap", () => {
+    expect(resolveMaxComputersPerUser(undefined)).toBe(0);
+    expect(resolveMaxComputersPerUser("")).toBe(0);
+    expect(resolveMaxComputersPerUser("0")).toBe(0);
+    expect(resolveMaxComputersPerUser("  ")).toBe(0);
+  });
+
+  it("accepts positive integers and rejects anything else", () => {
+    expect(resolveMaxComputersPerUser("3")).toBe(3);
+    for (const value of ["-1", "1.5", "not-a-number"])
+      expect(() => resolveMaxComputersPerUser(value)).toThrow(/positive integer/);
+  });
+});
+
+describe("ensureComputerRecord", () => {
+  it("enforces the cap for a new computer when the user is at the limit", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "2";
+    const prisma = fakePrisma(2, false);
+    await expect(ensureComputerRecord(prisma, { ...baseInput, botId: "bot-new" })).rejects.toThrow(
+      ComputerLimitError,
+    );
+    expect(prisma.computer.upsert).not.toHaveBeenCalled();
+  });
+
+  it("does not count archived-bot computers against the cap", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "1";
+    const prisma = fakePrisma(0, false);
+    await ensureComputerRecord(prisma, baseInput);
+    expect(prisma.computer.upsert).toHaveBeenCalledOnce();
+  });
+
+  it("allows a team computer reuse even when the user is at the cap", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "1";
+    const prisma = fakePrisma(1, true);
+    await expect(
+      ensureComputerRecord(prisma, { ...baseInput, mode: "team" }),
+    ).resolves.toBeDefined();
+  });
+
+  it("does not enforce anything when the cap is unset", async () => {
+    const prisma = fakePrisma(99, false);
+    await ensureComputerRecord(prisma, baseInput);
+    expect(prisma.computer.upsert).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/db/src/computers.test.ts
+++ b/packages/db/src/computers.test.ts
@@ -1,14 +1,16 @@
-import { describe, expect, it, vi, afterEach } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "./client.js";
 import {
-  ComputerLimitError,
   assertComputerQuotaForRestore,
+  ComputerLimitError,
   ensureComputerRecord,
   resolveMaxComputersPerUser,
 } from "./computers.js";
 
 function fakePrisma(count = 0, existing = false) {
   return {
+    // Looks like a TransactionClient: $queryRaw present, no $transaction.
+    $queryRaw: vi.fn(async () => [{ lock: "1" }]),
     computer: {
       findUnique: vi.fn(async () => (existing ? { id: "existing" } : null)),
       count: vi.fn(async () => count),
@@ -24,6 +26,77 @@ function fakeRestorePrisma(results: { alreadyLive: number; inUse: number }) {
   return {
     computer: { count },
   } as unknown as PrismaClient;
+}
+
+/**
+ * Root PrismaClient mock whose $transaction + $queryRaw simulate a per-user
+ * pg_advisory_xact_lock: concurrent quota transactions for the same user queue,
+ * and creating a new computer increments the in-use count (as createBot /
+ * setBotComputer do by linking a live bot in the same transaction).
+ */
+function fakeSerializingPrisma(initialInUse = 0) {
+  const state = { inUse: initialInUse };
+  const rows = new Map<string, { id: string }>();
+  let locked = false;
+  const waiters: Array<() => void> = [];
+
+  async function acquireLock() {
+    if (!locked) {
+      locked = true;
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      waiters.push(resolve);
+    });
+    locked = true;
+  }
+
+  function releaseLock() {
+    const next = waiters.shift();
+    if (next) {
+      next();
+      return;
+    }
+    locked = false;
+  }
+
+  const prisma = {
+    $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+      let held = false;
+      const tx = {
+        $queryRaw: vi.fn(async () => {
+          if (!held) {
+            await acquireLock();
+            held = true;
+          }
+          return [{ lock: "1" }];
+        }),
+        computer: {
+          findUnique: vi.fn(async (args: { where: { scopeKey: string } }) => {
+            const row = rows.get(args.where.scopeKey);
+            return row ? { id: row.id } : null;
+          }),
+          count: vi.fn(async () => state.inUse),
+          upsert: vi.fn(async (args: { where: { scopeKey: string } }) => {
+            const existing = rows.get(args.where.scopeKey);
+            if (existing) return existing;
+            const row = { id: `comp-${rows.size + 1}` };
+            rows.set(args.where.scopeKey, row);
+            // Same-transaction bot link makes the new row count as in-use.
+            state.inUse += 1;
+            return row;
+          }),
+        },
+      };
+      try {
+        return await callback(tx);
+      } finally {
+        if (held) releaseLock();
+      }
+    }),
+  } as unknown as PrismaClient;
+
+  return { prisma, state };
 }
 
 const baseInput = {
@@ -64,6 +137,7 @@ describe("ensureComputerRecord", () => {
       ComputerLimitError,
     );
     expect(prisma.computer.upsert).not.toHaveBeenCalled();
+    expect(prisma.$queryRaw).toHaveBeenCalledOnce();
   });
 
   it("does not count archived-bot computers against the cap", async () => {
@@ -85,6 +159,35 @@ describe("ensureComputerRecord", () => {
     const prisma = fakePrisma(99, false);
     await ensureComputerRecord(prisma, baseInput);
     expect(prisma.computer.upsert).toHaveBeenCalledOnce();
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("serializes parallel creates so concurrent callers cannot exceed the cap", async () => {
+    process.env.SANDBOX_MAX_COMPUTERS_PER_USER = "1";
+    const { prisma, state } = fakeSerializingPrisma(0);
+
+    const results = await Promise.allSettled([
+      ensureComputerRecord(prisma, {
+        ...baseInput,
+        spaceId: "space-a",
+        botId: "bot-a",
+      }),
+      ensureComputerRecord(prisma, {
+        ...baseInput,
+        spaceId: "space-b",
+        botId: "bot-b",
+      }),
+    ]);
+
+    const fulfilled = results.filter((result) => result.status === "fulfilled");
+    const rejected = results.filter((result) => result.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.status === "rejected" && rejected[0].reason).toBeInstanceOf(
+      ComputerLimitError,
+    );
+    expect(state.inUse).toBe(1);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/db/src/computers.ts
+++ b/packages/db/src/computers.ts
@@ -23,6 +23,33 @@ export function computerHomeKey(mode: ComputerMode, spaceId: string, botId?: str
 type ComputerDb = Pick<PrismaClient, "computer">;
 type ExecutionLeaseDb = Pick<PrismaClient, "computerExecutionLease">;
 
+/**
+ * Per-user ceiling on Computer records that still back a live bot, or 0 when unset.
+ *
+ * Each Computer row becomes a sandbox container once provisioned, so an unbounded
+ * record count means an unbounded container fleet for one user. A team computer is
+ * one row per space shared by its bots and counts once, not per bot.
+ */
+export function resolveMaxComputersPerUser(
+  value = process.env.SANDBOX_MAX_COMPUTERS_PER_USER,
+): number {
+  if (value === undefined || value.trim() === "" || value.trim() === "0") return 0;
+  const limit = Number(value);
+  if (!Number.isSafeInteger(limit) || limit < 1) {
+    throw new Error(
+      "SANDBOX_MAX_COMPUTERS_PER_USER must be a positive integer, or 0 for no configured cap",
+    );
+  }
+  return limit;
+}
+
+export class ComputerLimitError extends Error {
+  constructor(limit: number) {
+    super(`User computer limit (${limit}) reached`);
+    this.name = "ComputerLimitError";
+  }
+}
+
 /** Expire leases as fencing tombstones so the next acquire increments fence. */
 export async function expireComputerExecutionLeases(
   prisma: ExecutionLeaseDb,
@@ -44,6 +71,26 @@ export async function ensureComputerRecord(
     kind: string;
   },
 ) {
+  const limit = resolveMaxComputersPerUser();
+  if (limit > 0) {
+    // Only a new row consumes quota: the upsert below reuses the existing team
+    // computer on every bot created in that space, and reusing it with the count
+    // already at the cap would wrongly refuse a second bot on a shared computer.
+    const existing = await prisma.computer.findUnique({
+      where: { scopeKey: computerScopeKey(input.mode, input.spaceId, input.botId) },
+      select: { id: true },
+    });
+    // Archiving a bot keeps its Computer row (stopped) but releases the sandbox,
+    // so archived rows must not consume quota; count only rows still referenced
+    // by a non-archived bot the user owns.
+    const inUse = await prisma.computer.count({
+      where: {
+        userId: input.userId,
+        bots: { some: { archivedAt: null } },
+      },
+    });
+    if (!existing && inUse >= limit) throw new ComputerLimitError(limit);
+  }
   const scopeKey = computerScopeKey(input.mode, input.spaceId, input.botId);
   return prisma.computer.upsert({
     where: { scopeKey },

--- a/packages/db/src/computers.ts
+++ b/packages/db/src/computers.ts
@@ -1,5 +1,6 @@
 import type { ComputerMode } from "@rakazo/contracts";
-import type { Prisma, PrismaClient } from "./client.js";
+import { Prisma, type PrismaClient } from "./client.js";
+import { withTransactionRetry } from "./transaction-retry.js";
 
 export type { ComputerMode } from "@rakazo/contracts";
 
@@ -21,6 +22,8 @@ export function computerHomeKey(mode: ComputerMode, spaceId: string, botId?: str
 }
 
 type ComputerDb = Pick<PrismaClient, "computer">;
+type ComputerTx = Pick<Prisma.TransactionClient, "computer" | "$queryRaw">;
+type ComputerClient = ComputerDb & Partial<Pick<PrismaClient, "$transaction" | "$queryRaw">>;
 type ExecutionLeaseDb = Pick<PrismaClient, "computerExecutionLease">;
 
 /**
@@ -51,16 +54,26 @@ export class ComputerLimitError extends Error {
 }
 
 /** Computers a user still backs with a live (non-archived) bot. */
-async function countInUseComputersForUser(
-  prisma: ComputerDb,
-  userId: string,
-): Promise<number> {
+async function countInUseComputersForUser(prisma: ComputerDb, userId: string): Promise<number> {
   return prisma.computer.count({
     where: {
       userId,
       bots: { some: { archivedAt: null } },
     },
   });
+}
+
+/**
+ * Serialize existence check + in-use count + Computer create for one user.
+ * Seed 1 keeps this keyspace apart from lockSpaceForContentCreation (seed 0).
+ */
+async function lockUserForComputerQuota(
+  tx: Pick<Prisma.TransactionClient, "$queryRaw">,
+  userId: string,
+): Promise<void> {
+  await tx.$queryRaw(Prisma.sql`
+    SELECT pg_advisory_xact_lock(hashtextextended(${userId}, 1))::text AS "lock"
+  `);
 }
 
 /**
@@ -101,7 +114,7 @@ export async function expireComputerExecutionLeases(
   });
 }
 
-export async function ensureComputerRecord(
+function upsertComputerRecord(
   prisma: ComputerDb,
   input: {
     mode: ComputerMode;
@@ -110,28 +123,8 @@ export async function ensureComputerRecord(
     botId?: string;
     kind: string;
   },
+  scopeKey: string,
 ) {
-  const limit = resolveMaxComputersPerUser();
-  if (limit > 0) {
-    // Only a new row consumes quota: the upsert below reuses the existing team
-    // computer on every bot created in that space, and reusing it with the count
-    // already at the cap would wrongly refuse a second bot on a shared computer.
-    const existing = await prisma.computer.findUnique({
-      where: { scopeKey: computerScopeKey(input.mode, input.spaceId, input.botId) },
-      select: { id: true },
-    });
-    // Archiving a bot keeps its Computer row (stopped) but releases the sandbox,
-    // so archived rows must not consume quota; count only rows still referenced
-    // by a non-archived bot the user owns.
-    const inUse = await prisma.computer.count({
-      where: {
-        userId: input.userId,
-        bots: { some: { archivedAt: null } },
-      },
-    });
-    if (!existing && inUse >= limit) throw new ComputerLimitError(limit);
-  }
-  const scopeKey = computerScopeKey(input.mode, input.spaceId, input.botId);
   return prisma.computer.upsert({
     where: { scopeKey },
     create: {
@@ -144,4 +137,65 @@ export async function ensureComputerRecord(
     },
     update: {},
   });
+}
+
+async function ensureComputerRecordWithQuota(
+  tx: ComputerTx,
+  input: {
+    mode: ComputerMode;
+    spaceId: string;
+    userId: string;
+    botId?: string;
+    kind: string;
+  },
+  limit: number,
+  scopeKey: string,
+) {
+  await lockUserForComputerQuota(tx, input.userId);
+  // Only a new row consumes quota: the upsert below reuses the existing team
+  // computer on every bot created in that space, and reusing it with the count
+  // already at the cap would wrongly refuse a second bot on a shared computer.
+  const existing = await tx.computer.findUnique({
+    where: { scopeKey },
+    select: { id: true },
+  });
+  if (!existing) {
+    // Archiving a bot keeps its Computer row (stopped) but releases the sandbox,
+    // so archived rows must not consume quota; count only rows still referenced
+    // by a non-archived bot the user owns.
+    const inUse = await countInUseComputersForUser(tx, input.userId);
+    if (inUse >= limit) throw new ComputerLimitError(limit);
+  }
+  return upsertComputerRecord(tx, input, scopeKey);
+}
+
+function isTransactionClient(prisma: ComputerClient): prisma is ComputerTx {
+  return typeof prisma.$queryRaw === "function" && typeof prisma.$transaction !== "function";
+}
+
+export async function ensureComputerRecord(
+  prisma: ComputerClient,
+  input: {
+    mode: ComputerMode;
+    spaceId: string;
+    userId: string;
+    botId?: string;
+    kind: string;
+  },
+) {
+  const limit = resolveMaxComputersPerUser();
+  const scopeKey = computerScopeKey(input.mode, input.spaceId, input.botId);
+  if (limit <= 0) return upsertComputerRecord(prisma, input, scopeKey);
+
+  // Cap is set: hold a per-user advisory lock across find + count + create so
+  // concurrent creates for different spaces cannot both pass the check.
+  if (isTransactionClient(prisma)) {
+    return ensureComputerRecordWithQuota(prisma, input, limit, scopeKey);
+  }
+  if (typeof prisma.$transaction === "function") {
+    return withTransactionRetry(() =>
+      prisma.$transaction!((tx) => ensureComputerRecordWithQuota(tx, input, limit, scopeKey)),
+    );
+  }
+  throw new Error("Computer quota enforcement requires a Prisma transaction");
 }

--- a/packages/db/src/computers.ts
+++ b/packages/db/src/computers.ts
@@ -53,12 +53,24 @@ export class ComputerLimitError extends Error {
   }
 }
 
-/** Computers a user still backs with a live (non-archived) bot. */
-async function countInUseComputersForUser(prisma: ComputerDb, userId: string): Promise<number> {
+/**
+ * Computers a user still backs with a live (non-archived) bot.
+ *
+ * excludeBotId drops one bot's current reference: a bot being re-linked to a
+ * new computer in the same transaction leaves its old row behind, so that
+ * intermediate reference must not count against the final live set.
+ */
+async function countInUseComputersForUser(
+  prisma: ComputerDb,
+  userId: string,
+  excludeBotId?: string,
+): Promise<number> {
   return prisma.computer.count({
     where: {
       userId,
-      bots: { some: { archivedAt: null } },
+      bots: {
+        some: excludeBotId ? { archivedAt: null, id: { not: excludeBotId } } : { archivedAt: null },
+      },
     },
   });
 }
@@ -160,11 +172,18 @@ async function ensureComputerRecordWithQuota(
     select: { id: true },
   });
   if (!existing) {
-    // Archiving a bot keeps its Computer row (stopped) but releases the sandbox,
-    // so archived rows must not consume quota; count only rows still referenced
-    // by a non-archived bot the user owns.
-    const inUse = await countInUseComputersForUser(tx, input.userId);
-    if (inUse >= limit) throw new ComputerLimitError(limit);
+    // The bot being linked to this new computer is part of this same
+    // transaction; its old or intermediate reference is leaving the live set
+    // when this link commits. Exclude this bot's current reference so a
+    // transaction that ends with exactly one active computer is not refused
+    // at cap 1 (createBot links the team computer first, then re-links the
+    // bot to the new dedicated one; setBotComputer switches the same way).
+    // References from other active bots still count: a team computer another
+    // live bot keeps using stays in-use after the re-link.
+    const inUse = await countInUseComputersForUser(tx, input.userId, input.botId);
+    // The new row itself will be referenced by this bot after the link, so
+    // the post-transaction set is one more than the remaining live set.
+    if (inUse + 1 > limit) throw new ComputerLimitError(limit);
   }
   return upsertComputerRecord(tx, input, scopeKey);
 }

--- a/packages/db/src/computers.ts
+++ b/packages/db/src/computers.ts
@@ -50,6 +50,46 @@ export class ComputerLimitError extends Error {
   }
 }
 
+/** Computers a user still backs with a live (non-archived) bot. */
+async function countInUseComputersForUser(
+  prisma: ComputerDb,
+  userId: string,
+): Promise<number> {
+  return prisma.computer.count({
+    where: {
+      userId,
+      bots: { some: { archivedAt: null } },
+    },
+  });
+}
+
+/**
+ * Refuse a restore that would push a user past the cap.
+ *
+ * A restore re-links the bot to its Computer row, which reactivates the quota
+ * if that row was only referenced by archived bots (the dedicated case; a team
+ * row shared with live bots keeps counting). Throws ComputerLimitError when the
+ * restore would exceed the configured SANDBOX_MAX_COMPUTERS_PER_USER.
+ */
+export async function assertComputerQuotaForRestore(
+  prisma: ComputerDb,
+  input: { userId: string; computerId: string },
+): Promise<void> {
+  const limit = resolveMaxComputersPerUser();
+  if (limit <= 0) return;
+  // If another live bot already references this row (team computer shared
+  // across the space), restoring this bot adds nothing to the count.
+  const alreadyLive = await prisma.computer.count({
+    where: {
+      id: input.computerId,
+      bots: { some: { archivedAt: null } },
+    },
+  });
+  if (alreadyLive > 0) return;
+  const inUse = await countInUseComputersForUser(prisma, input.userId);
+  if (inUse >= limit) throw new ComputerLimitError(limit);
+}
+
 /** Expire leases as fencing tombstones so the next acquire increments fence. */
 export async function expireComputerExecutionLeases(
   prisma: ExecutionLeaseDb,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -13,6 +13,7 @@ import { createThreadMessageInTransaction } from "./messages.js";
 import { IsolationError } from "./scope.js";
 import { lockSpaceForContentCreation } from "./spaces.js";
 import { activeRunSelection, previewFromBlocks } from "./thread-listing.js";
+import { withTransactionRetry } from "./transaction-retry.js";
 
 /** Newest messages loaded for sidebar preview; enough to skip a short peer-run tail. */
 const SIDEBAR_PREVIEW_MESSAGE_WINDOW = 16;
@@ -535,18 +536,25 @@ export function createRepos(prisma: PrismaClient) {
         include: { computer: true },
       });
       if (!bot?.computer) throw new IsolationError();
-      const computer = await ensureComputerRecord(prisma, {
-        mode,
-        spaceId: actor.spaceId,
-        userId: actor.userId,
-        botId,
-        kind: bot.computer.kind,
-      });
-      const updated = await prisma.bot.update({
-        where: { id: botId },
-        data: { computerId: computer.id },
-        include: { thread: true, computer: true },
-      });
+      const kind = bot.computer.kind;
+      // Keep ensure + bot link in one transaction so a capped quota lock covers
+      // both steps (a computer row alone does not count until a live bot refs it).
+      const updated = await withTransactionRetry(() =>
+        prisma.$transaction(async (tx) => {
+          const computer = await ensureComputerRecord(tx, {
+            mode,
+            spaceId: actor.spaceId,
+            userId: actor.userId,
+            botId,
+            kind,
+          });
+          return tx.bot.update({
+            where: { id: botId },
+            data: { computerId: computer.id },
+            include: { thread: true, computer: true },
+          });
+        }),
+      );
       return mapBot(updated);
     },
   };


### PR DESCRIPTION
## Why

Nothing bounds how many Computer records one user can create. Every bot create, duplicate, and setComputer call funnels into `ensureComputerRecord`, and each row becomes a sandbox container once provisioned (default 2GB / 2 CPU per computer). The per-computer limits exist, but one user can keep creating records until the host runs out. Issue #816.

## What changed

- New env knob `SANDBOX_MAX_COMPUTERS_PER_USER`, resolved in `packages/db/src/computers.ts` following the `SANDBOX_TEAM_SCREEN_LIMIT` pattern. Unset, empty, or `0` means no configured cap (default, so existing deployments are unaffected).
- `ensureComputerRecord` counts the user's Computer rows before creating a new one and throws `ComputerLimitError` at the cap. The count only includes rows still referenced by a non-archived bot: archiving keeps the row, but the sandbox is released, so archived bots must not consume quota. A team computer is one row per space, count once, and reusing it never trips the cap.
- `mapSpaceLifecycleError` now surfaces `ComputerLimitError` as `BAD_REQUEST`, and the two `setBotComputer` call sites that create records are wrapped so the switch path returns the same error instead of a 500.
- `.env.example` documents the new knob next to `SANDBOX_TEAM_SCREEN_LIMIT`.

## How it was tested

- `packages/db/src/computers.test.ts` covers the resolver (unset/empty/0, positive integers, invalid values) and the three enforcement cases: new record at the cap throws, archived bots do not count, team computer reuse at the cap still succeeds.
- Verified red against today's code (3 failing tests for the resolver and enforcement), then green with the fix. `pnpm --filter @rakazo/db test`: 89 passed, 6 skipped (Postgres journeys); `@rakazo/db` and `@rakazo/api` typecheck clean; Biome lint and format clean on changed files.

## Out of scope

The supervisor and remote providers (E2B, Daytona, Box) are unchanged; this caps record creation at the DB chokepoint, which covers every provider. Runtime concurrency between two simultaneous creates is not fenced: two requests can each pass the count before either writes. A per-user lock at create time would close that gap, but it changes the create transaction and is worth its own discussion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional per-user limit for live sandbox computers.
  - Existing computer records can be reused without consuming additional capacity.
  - A value of zero or an unset limit leaves computer creation unrestricted.
  - Restoring an archived bot now respects the configured computer limit.
  - Concurrent computer creation now enforces the limit reliably.

- **Bug Fixes**
  - Computer-capacity and sandbox lifecycle errors now return clear client errors consistently.

- **Tests**
  - Added coverage for configuration, enforcement, concurrency, reuse, restoration, and unrestricted operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->