### PR TITLE
fix(screen): avoid duplicating embed websocket capability paths

### DIFF
--- a/packages/core/src/node/screen-capability.test.ts
+++ b/packages/core/src/node/screen-capability.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 import {
   openScreenCapability,
@@ -23,6 +25,44 @@ const path = (url: string, interactive = false) =>
     ),
   ).pathname;
 describe("sealed screen capabilities", () => {
+  it.each([false, true])(
+    "connects the shipped embed through one capability prefix (control=%s)",
+    (interactive) => {
+      const provider = new URL("http://127.0.0.1:49152/embed.html");
+      provider.searchParams.set("view_only", String(!interactive));
+      provider.searchParams.set("path", "websockify?token=fake-socket-token");
+      const url = new URL(
+        sealScreenCapability(provider.toString(), "fake-secret", "https://app.example", scope, 100),
+      );
+      const html = readFileSync(
+        new URL("../../../../infra/sandboxes/computer/embed.html", import.meta.url),
+        "utf8",
+      );
+      const script = html
+        .match(/<script type="module">([\s\S]*?)<\/script>/)![1]!
+        .replace(/^\s*import .*;$/gm, "");
+      let socketUrl = "";
+      runInNewContext(script, {
+        document: { location: url, getElementById: () => ({}) },
+        window: { location: url },
+        RFB: class {
+          constructor(_element: unknown, value: string) {
+            socketUrl = value;
+          }
+        },
+        attachHostClipboardPaste: () => {},
+      });
+      const socket = new URL(socketUrl);
+      expect(socket.protocol).toBe("wss:");
+      expect(socket.host).toBe(url.host);
+      expect(socket.pathname).toBe(url.pathname.replace("/embed.html", "/websockify"));
+      expect(socketUrl).not.toContain("fake-socket-token");
+      expect(openScreenCapability(socket.pathname, "fake-secret", 101)?.target).toMatchObject({
+        path: "/websockify?token=fake-socket-token",
+        interactive,
+      });
+    },
+  );
   it("hides provider credentials and binds scope and destination", () => {
     const value = path("https://screen.example/vnc.html");
     expect(value).not.toContain("fake-provider-token");

--- a/packages/core/src/node/screen-capability.ts
+++ b/packages/core/src/node/screen-capability.ts
@@ -69,7 +69,9 @@ export function sealScreenCapability(
     autoconnect: "true",
     resize: "scale",
     view_only: policy === "control" ? "false" : "true",
-    path: `${prefix.slice(1)}/websockify`,
+    // Our embed resolves the socket relative to its own capability directory;
+    // stock noVNC resolves it from the origin root.
+    path: target.pathname === "/embed.html" ? "websockify" : `${prefix.slice(1)}/websockify`,
   }).toString();
   return result.toString();
 }


### PR DESCRIPTION
## Why

Opening a Docker bot computer can show a black screen after the screen-capability change. The shipped embed page resolves its WebSocket path relative to its own directory, but the sealed URL supplies that capability directory again. The resulting double-prefix request never reaches the intended websockify endpoint.

Fixes #832.

## What

- Supply a relative `websockify` path for the shipped `/embed.html` client.
- Preserve the origin-relative capability path used by standard noVNC clients.
- Keep provider socket credentials sealed and view/control policy unchanged. No computer-image rebuild is needed for this URL-generation fix.
- Execute the actual shipped embed script in offline regressions for both view and control, then verify its socket resolves through the capability to the original provider socket path.

## Validation

- Both new regressions fail against the original URL-generation logic and pass with the fix.
- Core suite: 45 files, 458 tests passed.
- Core TypeScript check passed.
- Biome and whitespace checks passed.
- Docker/Caddy live-screen verification was not run locally. These tests verify URL construction and capability decoding, not rendered VNC pixels. No UI copy or layout changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved embedded screen connections so interactive and view-only modes consistently connect through the correct secure WebSocket endpoint.
  - Prevented socket tokens from being exposed in generated connection URLs.
  - Preserved capability-specific routing for standard screen targets while ensuring embedded clients resolve their connection path correctly.

- **Tests**
  - Added coverage for embedded screen connection behavior across supported modes, including secure protocol, host, path, and token-handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->