### PR TITLE
fix(desktop): keep macOS traffic lights clear of bot header

### DIFF
--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -70,6 +70,12 @@ describe("window chrome", () => {
     expect(shell).toContain('className="app-no-drag flex min-w-0 items-center gap-3"');
     expect(shell.match(/className="app-no-drag grid h-\[30px\] w-\[34px\]/g)).toHaveLength(1);
   });
+
+  it("moves window chrome into the conversation header when the bots sidebar is collapsed", () => {
+    const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "../pages");
+    const shell = readFileSync(path.join(root, "Shell.tsx"), "utf8");
+    expect(shell).toContain("{botsSidebarCollapsed && desktopBridge() ? <WindowChrome /> : null}");
+  });
 });
 
 describe("captured OAuth callbacks", () => {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -153,6 +153,7 @@ import {
   shouldNotifyBrowser,
 } from "../lib/browser-notifications";
 import { loadComputerScreen } from "../lib/computer-screen";
+import { desktopBridge } from "../lib/desktop";
 import { scheduleFocusPrompt } from "../lib/focus-prompt";
 import { localTimezone } from "../lib/local-timezone";
 import { copyableMessageText } from "../lib/message-text";
@@ -3019,6 +3020,8 @@ export function ShellPage() {
       >
         <div className="app-drag flex items-center justify-between border-b border-sidebar-border px-3 py-[17px] md:px-[22px]">
           <div className="flex min-w-0 items-center gap-2">
+            {/* Collapsed bots sidebar: this header is the leading edge for window chrome. */}
+            {botsSidebarCollapsed && desktopBridge() ? <WindowChrome /> : null}
             <button
               type="button"
               aria-label={t`Open navigation`}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

On macOS Electron with a `hiddenInset` title bar, collapsing the bots sidebar moves the conversation header to the window’s leading edge. Native traffic lights then sat on top of the bot avatar and name.

## What changed

- When the bots sidebar is collapsed and the desktop bridge is present, render the existing `WindowChrome` spacer/controls at the start of the conversation header (same pattern already used in the bots sidebar and welcome surface).
- Browser layout is unchanged (`desktopBridge()` is absent).
- Windows/Linux keep working: the same chrome supplies the in-app window buttons when the sidebar is no longer the leading edge.
- Unit test asserts the collapsed-sidebar chrome placement.

## Testing

- `vitest run apps/web/src/lib/desktop.test.ts` (12 passed)
- `pnpm --filter @rakazo/web check` (tsc clean)
- Biome check on touched files

No agent-machine UI screenshots. This overlap is Electron/macOS-native title-bar chrome; web E2E cannot show native traffic lights, and the desktop Playwright suite does not assert macOS traffic-light geometry in CI. Say so rather than linking an unrelated web frame.

## Screenshots

N/A (Electron-only macOS title-bar inset; CI has no harness that captures native traffic lights against this header).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28cafb4e-9238-4c1a-8f88-932499d74489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28cafb4e-9238-4c1a-8f88-932499d74489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

