### PR TITLE
fix(computer): support mobile virtual keyboards

### DIFF
--- a/apps/web/e2e/mobile-computer-keyboard.spec.ts
+++ b/apps/web/e2e/mobile-computer-keyboard.spec.ts
@@ -60,8 +60,13 @@ test("touch users can open and dismiss the remote computer keyboard", async ({
 
   await page.goto("http://keyboard.test/embed.html");
   const keyboardButton = page.getByRole("button", { name: "Show keyboard" });
+  const trackpadButton = page.getByRole("button", { name: "Use trackpad" });
   const keyboardInput = page.getByRole("textbox", { name: "Remote computer keyboard input" });
   await expect(keyboardButton).toBeVisible();
+  await expect(trackpadButton).toBeVisible();
+
+  await trackpadButton.click();
+  await expect(page.getByRole("button", { name: "Use direct touch" })).toBeVisible();
 
   await keyboardButton.click();
   await expect(page.getByRole("button", { name: "Hide keyboard" })).toBeVisible();

--- a/apps/web/e2e/mobile-computer-keyboard.spec.ts
+++ b/apps/web/e2e/mobile-computer-keyboard.spec.ts
@@ -40,6 +40,12 @@ test("touch users can open and dismiss the remote computer keyboard", async ({
 
   await page.addInitScript(() => {
     Object.defineProperty(navigator, "maxTouchPoints", { configurable: true, value: 1 });
+    const viewport = new EventTarget();
+    Object.defineProperties(viewport, {
+      height: { configurable: true, value: 420 },
+      offsetTop: { configurable: true, value: 12 },
+    });
+    Object.defineProperty(window, "visualViewport", { configurable: true, value: viewport });
   });
   await page.setViewportSize({ width: 390, height: 844 });
   await page.route("http://keyboard.test/**", async (route) => {
@@ -60,6 +66,16 @@ test("touch users can open and dismiss the remote computer keyboard", async ({
   await keyboardButton.click();
   await expect(page.getByRole("button", { name: "Hide keyboard" })).toBeVisible();
   await expect(keyboardInput).toBeFocused();
+  await expect(page.locator("html")).toHaveClass(/mobile-keyboard-open/);
+  await expect(page.locator("#screen")).toHaveCSS("height", "420px");
+  await expect
+    .poll(() =>
+      page.evaluate(() => ({
+        height: document.documentElement.style.getPropertyValue("--mobile-visual-height"),
+        top: document.documentElement.style.getPropertyValue("--mobile-visual-top"),
+      })),
+    )
+    .toEqual({ height: "420px", top: "12px" });
   await keyboardInput.pressSequentially("mobile typing");
   const forwardedKeysyms = await page.evaluate(() =>
     Reflect.get(globalThis, "__rfbKeys").map(([keysym]: [number]) => keysym),
@@ -72,4 +88,12 @@ test("touch users can open and dismiss the remote computer keyboard", async ({
   await page.getByRole("button", { name: "Hide keyboard" }).click();
   await expect(keyboardButton).toBeVisible();
   await expect(keyboardInput).not.toBeFocused();
+  await expect(page.locator("html")).not.toHaveClass(/mobile-keyboard-open/);
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        document.documentElement.style.getPropertyValue("--mobile-visual-height"),
+      ),
+    )
+    .toBe("");
 });

--- a/apps/web/e2e/mobile-computer-keyboard.spec.ts
+++ b/apps/web/e2e/mobile-computer-keyboard.spec.ts
@@ -18,8 +18,12 @@ test("touch users can open and dismiss the remote computer keyboard", async ({
     [
       "/core/rfb.js",
       `export default class RFB {
-        constructor() { this.viewOnly = false; this.focusOnClick = true; }
-        sendKey() {}
+        constructor() {
+          this.viewOnly = false;
+          this.focusOnClick = true;
+          globalThis.__rfbKeys = [];
+        }
+        sendKey(...args) { globalThis.__rfbKeys.push(args); }
       }`,
     ],
     [
@@ -57,6 +61,12 @@ test("touch users can open and dismiss the remote computer keyboard", async ({
   await expect(page.getByRole("button", { name: "Hide keyboard" })).toBeVisible();
   await expect(keyboardInput).toBeFocused();
   await keyboardInput.pressSequentially("mobile typing");
+  const forwardedKeysyms = await page.evaluate(() =>
+    Reflect.get(globalThis, "__rfbKeys").map(([keysym]: [number]) => keysym),
+  );
+  expect(forwardedKeysyms).toEqual(
+    Array.from("mobile typing", (character) => character.codePointAt(0)),
+  );
   await captureScreenshot(page, testInfo, "mobile-computer-keyboard-open");
 
   await page.getByRole("button", { name: "Hide keyboard" }).click();

--- a/apps/web/e2e/mobile-computer-keyboard.spec.ts
+++ b/apps/web/e2e/mobile-computer-keyboard.spec.ts
@@ -1,0 +1,65 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { captureScreenshot } from "./helpers";
+
+const computerRoot = path.resolve(import.meta.dirname, "../../../infra/sandboxes/computer");
+
+test("touch users can open and dismiss the remote computer keyboard", async ({
+  page,
+}, testInfo) => {
+  const assets = new Map([
+    ["/embed.html", await readFile(path.join(computerRoot, "embed.html"), "utf8")],
+    [
+      "/clipboard-bridge.js",
+      await readFile(path.join(computerRoot, "clipboard-bridge.js"), "utf8"),
+    ],
+    ["/mobile-keyboard.js", await readFile(path.join(computerRoot, "mobile-keyboard.js"), "utf8")],
+    [
+      "/core/rfb.js",
+      `export default class RFB {
+        constructor() { this.viewOnly = false; this.focusOnClick = true; }
+        sendKey() {}
+      }`,
+    ],
+    [
+      "/core/input/keyboard.js",
+      `export default class Keyboard {
+        constructor() { this.onkeyevent = null; }
+        grab() {}
+        ungrab() {}
+      }`,
+    ],
+    ["/core/input/keysym.js", "export default { XK_BackSpace: 0xff08 };"],
+    ["/core/input/keysymdef.js", "export default { lookup: (codePoint) => codePoint };"],
+  ]);
+
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "maxTouchPoints", { configurable: true, value: 1 });
+  });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.route("http://keyboard.test/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    const body = assets.get(pathname);
+    if (body == null) return route.fulfill({ status: 404, body: "Not found" });
+    return route.fulfill({
+      contentType: pathname.endsWith(".html") ? "text/html" : "text/javascript",
+      body,
+    });
+  });
+
+  await page.goto("http://keyboard.test/embed.html");
+  const keyboardButton = page.getByRole("button", { name: "Show keyboard" });
+  const keyboardInput = page.getByRole("textbox", { name: "Remote computer keyboard input" });
+  await expect(keyboardButton).toBeVisible();
+
+  await keyboardButton.click();
+  await expect(page.getByRole("button", { name: "Hide keyboard" })).toBeVisible();
+  await expect(keyboardInput).toBeFocused();
+  await keyboardInput.pressSequentially("mobile typing");
+  await captureScreenshot(page, testInfo, "mobile-computer-keyboard-open");
+
+  await page.getByRole("button", { name: "Hide keyboard" }).click();
+  await expect(keyboardButton).toBeVisible();
+  await expect(keyboardInput).not.toBeFocused();
+});

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3949,140 +3949,143 @@ export function ShellPage() {
           </div>
         </div>
       ) : computerOpen && active ? (
-        <div
-          className="fixed inset-x-0 top-0 z-30 flex flex-col bg-background"
-          style={{
-            height: computerViewport ? `${computerViewport.height}px` : "100dvh",
-            top: computerViewport ? `${computerViewport.offsetTop}px` : undefined,
-          }}
-        >
+        <div className="fixed inset-0 z-30 bg-background">
           <div
-            data-testid="computer-chrome"
-            className="flex items-center justify-between gap-4 border-b border-sidebar-border px-[18px] py-3.5"
+            data-testid="computer-viewport"
+            className="fixed inset-x-0 top-0 flex flex-col bg-background"
+            style={{
+              height: computerViewport ? `${computerViewport.height}px` : "100dvh",
+              top: computerViewport ? `${computerViewport.offsetTop}px` : undefined,
+            }}
           >
-            <div className="flex min-w-0 flex-1 items-center gap-3">
-              <BotAvatar
-                color={active.color}
-                identity={active.id}
-                size={28}
-                status={active.status}
-              />
-              {recordingSkill ? (
-                <TeachRecordingChrome
-                  recording={recordingSkill}
-                  busy={teachBusy}
-                  onStop={stopTeaching}
-                  variant="overlay"
-                />
-              ) : (
-                <span className="truncate text-[15.5px] font-medium text-foreground" dir="auto">
-                  {computerLabel(computer?.mode, active.name)}
-                </span>
-              )}
-              {!recordingSkill && hasControl ? (
-                computer?.takeoverRequested ? (
-                  <span className="rounded-full bg-warning/15 px-[11px] py-1 text-[13px] text-warning">
-                    <Trans>Needs you</Trans>
-                  </span>
-                ) : (
-                  <span className="rounded-full bg-success/15 px-[11px] py-1 text-[13px] text-success">
-                    <Trans>You have control</Trans>
-                  </span>
-                )
-              ) : null}
-            </div>
-            <div className="flex items-center gap-3">
-              {composerRunning ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  aria-label={t`Stop`}
-                  data-testid="computer-overlay-stop"
-                  onClick={() => void stopRun()}
-                  disabled={sending}
-                >
-                  <Trans>Stop</Trans>
-                </Button>
-              ) : null}
-              {recordingSkill ? (
-                <TeachStopButton busy={teachBusy} onStop={stopTeaching} />
-              ) : hasControl ? (
-                <ComputerReleaseActions
-                  takeoverRequested={Boolean(computer?.takeoverRequested)}
-                  onRelease={releaseComputer}
-                />
-              ) : null}
-              {active && !recordingSkill ? (
-                <TeachComputerOverlayControl
-                  key={active.id}
-                  botId={active.id}
-                  computer={computer}
-                  busy={teachBusy}
-                  onRefresh={refreshActiveTeaching}
-                />
-              ) : null}
-              {active && !recordingSkill ? (
-                <ComputerMaintenanceActions
-                  botId={active.id}
-                  computer={computer}
-                  onChanged={async () => {
-                    await refreshThread(active.id);
-                  }}
-                />
-              ) : null}
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className="text-muted-foreground"
-                aria-label={t`Close computer`}
-                onClick={() => setComputerOpen(false)}
-              >
-                <X size={16} strokeWidth={1.8} />
-              </Button>
-            </div>
-          </div>
-          {sendError ? (
             <div
-              role="alert"
-              className="border-b border-destructive/40 bg-destructive/10 px-[18px] py-2 text-[13px] text-destructive"
+              data-testid="computer-chrome"
+              className="flex items-center justify-between gap-4 border-b border-sidebar-border px-[18px] py-3.5"
             >
-              {sendError}
-            </div>
-          ) : null}
-          <div className="relative min-h-0 flex-1 bg-background">
-            {computer?.kind === "desktop" ? (
-              <DesktopKindEmptyState className="grid h-full place-items-center px-8 text-center text-sm text-muted-foreground/80" />
-            ) : computer?.state === "running" && embeddedScreenUrl && !computerScreenError ? (
-              <>
-                <iframe
-                  title={t`Bot screen`}
-                  src={embeddedScreenUrl}
-                  sandbox={screenIframeSandbox(embeddedScreenUrl)}
-                  className="h-full w-full border-0 bg-black"
-                  allow="clipboard-read; clipboard-write; fullscreen"
-                  style={{
-                    pointerEvents: recordingSkill || !hasControl ? "none" : "auto",
-                  }}
+              <div className="flex min-w-0 flex-1 items-center gap-3">
+                <BotAvatar
+                  color={active.color}
+                  identity={active.id}
+                  size={28}
+                  status={active.status}
                 />
-                {active ? (
-                  <TeachCaptureOverlay
-                    botId={active.id}
-                    skill={recordingSkill}
-                    enabled={Boolean(recordingSkill)}
-                    screenWidth={computer?.screenWidth}
-                    screenHeight={computer?.screenHeight}
+                {recordingSkill ? (
+                  <TeachRecordingChrome
+                    recording={recordingSkill}
+                    busy={teachBusy}
+                    onStop={stopTeaching}
+                    variant="overlay"
+                  />
+                ) : (
+                  <span className="truncate text-[15.5px] font-medium text-foreground" dir="auto">
+                    {computerLabel(computer?.mode, active.name)}
+                  </span>
+                )}
+                {!recordingSkill && hasControl ? (
+                  computer?.takeoverRequested ? (
+                    <span className="rounded-full bg-warning/15 px-[11px] py-1 text-[13px] text-warning">
+                      <Trans>Needs you</Trans>
+                    </span>
+                  ) : (
+                    <span className="rounded-full bg-success/15 px-[11px] py-1 text-[13px] text-success">
+                      <Trans>You have control</Trans>
+                    </span>
+                  )
+                ) : null}
+              </div>
+              <div className="flex items-center gap-3">
+                {composerRunning ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    aria-label={t`Stop`}
+                    data-testid="computer-overlay-stop"
+                    onClick={() => void stopRun()}
+                    disabled={sending}
+                  >
+                    <Trans>Stop</Trans>
+                  </Button>
+                ) : null}
+                {recordingSkill ? (
+                  <TeachStopButton busy={teachBusy} onStop={stopTeaching} />
+                ) : hasControl ? (
+                  <ComputerReleaseActions
+                    takeoverRequested={Boolean(computer?.takeoverRequested)}
+                    onRelease={releaseComputer}
                   />
                 ) : null}
-              </>
-            ) : (
-              <div className="grid h-full place-items-center text-sm text-muted-foreground/80">
-                {computerScreenError ??
-                  (computer?.state === "suspended"
-                    ? t`Computer is asleep`
-                    : computerLabel(computer?.mode, active.name))}
+                {active && !recordingSkill ? (
+                  <TeachComputerOverlayControl
+                    key={active.id}
+                    botId={active.id}
+                    computer={computer}
+                    busy={teachBusy}
+                    onRefresh={refreshActiveTeaching}
+                  />
+                ) : null}
+                {active && !recordingSkill ? (
+                  <ComputerMaintenanceActions
+                    botId={active.id}
+                    computer={computer}
+                    onChanged={async () => {
+                      await refreshThread(active.id);
+                    }}
+                  />
+                ) : null}
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  className="text-muted-foreground"
+                  aria-label={t`Close computer`}
+                  onClick={() => setComputerOpen(false)}
+                >
+                  <X size={16} strokeWidth={1.8} />
+                </Button>
               </div>
-            )}
+            </div>
+            {sendError ? (
+              <div
+                role="alert"
+                className="border-b border-destructive/40 bg-destructive/10 px-[18px] py-2 text-[13px] text-destructive"
+              >
+                {sendError}
+              </div>
+            ) : null}
+            <div className="relative min-h-0 flex-1 bg-background">
+              {computer?.kind === "desktop" ? (
+                <DesktopKindEmptyState className="grid h-full place-items-center px-8 text-center text-sm text-muted-foreground/80" />
+              ) : computer?.state === "running" && embeddedScreenUrl && !computerScreenError ? (
+                <>
+                  <iframe
+                    title={t`Bot screen`}
+                    src={embeddedScreenUrl}
+                    sandbox={screenIframeSandbox(embeddedScreenUrl)}
+                    className="h-full w-full border-0 bg-black"
+                    allow="clipboard-read; clipboard-write; fullscreen"
+                    style={{
+                      pointerEvents: recordingSkill || !hasControl ? "none" : "auto",
+                    }}
+                  />
+                  {active ? (
+                    <TeachCaptureOverlay
+                      botId={active.id}
+                      skill={recordingSkill}
+                      enabled={Boolean(recordingSkill)}
+                      screenWidth={computer?.screenWidth}
+                      screenHeight={computer?.screenHeight}
+                    />
+                  ) : null}
+                </>
+              ) : (
+                <div className="grid h-full place-items-center text-sm text-muted-foreground/80">
+                  {computerScreenError ??
+                    (computer?.state === "suspended"
+                      ? t`Computer is asleep`
+                      : computerLabel(computer?.mode, active.name))}
+                </div>
+              )}
+            </div>
           </div>
         </div>
       ) : null}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -512,10 +512,32 @@ export function ShellPage() {
   const [routineError, setRoutineError] = useState<string | null>(null);
   const [screenUrl, setScreenUrl] = useState<string | null>(null);
   const [computerOpen, setComputerOpen] = useState(false);
+  const [computerViewport, setComputerViewport] = useState<{
+    height: number;
+    offsetTop: number;
+  } | null>(null);
   const [computerError, setComputerError] = useState<string | null>(null);
   // Screen-load failures can sit beside a still-valid embed URL; boot and
   // takeover failures must stay visible even when a URL remains.
   const [computerErrorFromScreen, setComputerErrorFromScreen] = useState(false);
+  useEffect(() => {
+    if (!computerOpen) {
+      setComputerViewport(null);
+      return;
+    }
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+    const sync = () => {
+      setComputerViewport({ height: viewport.height, offsetTop: viewport.offsetTop });
+    };
+    sync();
+    viewport.addEventListener("resize", sync);
+    viewport.addEventListener("scroll", sync);
+    return () => {
+      viewport.removeEventListener("resize", sync);
+      viewport.removeEventListener("scroll", sync);
+    };
+  }, [computerOpen]);
   useEffect(() => {
     if (!session.data?.user) return;
     let cancelled = false;
@@ -3927,7 +3949,13 @@ export function ShellPage() {
           </div>
         </div>
       ) : computerOpen && active ? (
-        <div className="absolute inset-0 z-30 flex flex-col bg-background">
+        <div
+          className="fixed inset-x-0 top-0 z-30 flex flex-col bg-background"
+          style={{
+            height: computerViewport ? `${computerViewport.height}px` : "100dvh",
+            top: computerViewport ? `${computerViewport.offsetTop}px` : undefined,
+          }}
+        >
           <div
             data-testid="computer-chrome"
             className="flex items-center justify-between gap-4 border-b border-sidebar-border px-[18px] py-3.5"

--- a/infra/sandboxes/computer/Dockerfile
+++ b/infra/sandboxes/computer/Dockerfile
@@ -57,6 +57,7 @@ COPY --chmod=644 fluxbox.apps /etc/rakazo/fluxbox/apps
 COPY --chmod=644 fluxbox.menu /etc/rakazo/fluxbox/menu
 COPY --chmod=644 embed.html /usr/share/novnc/embed.html
 COPY --chmod=644 clipboard-bridge.js /usr/share/novnc/clipboard-bridge.js
+COPY --chmod=644 mobile-keyboard.js /usr/share/novnc/mobile-keyboard.js
 # Strip CR so shebangs work even if the build context came from a CRLF checkout.
 RUN ldconfig \
   && sed -i 's/\r$//' /usr/local/bin/rakazo-computer /usr/local/bin/rakazo-computer-control /usr/local/bin/rakazo-browser /usr/local/bin/rakazo-page-browser \

--- a/infra/sandboxes/computer/embed.html
+++ b/infra/sandboxes/computer/embed.html
@@ -13,10 +13,45 @@
         background: #0e0e10;
         overflow: hidden;
       }
+      #mobile-keyboard {
+        position: fixed;
+        right: max(12px, env(safe-area-inset-right));
+        bottom: max(12px, env(safe-area-inset-bottom));
+        z-index: 2;
+        box-sizing: border-box;
+        width: 48px;
+        height: 48px;
+        padding: 11px;
+        border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+        border-radius: 12px;
+        background: Canvas;
+        color: CanvasText;
+        box-shadow: 0 2px 10px color-mix(in srgb, CanvasText 25%, transparent);
+      }
+      #mobile-keyboard.active {
+        outline: 3px solid Highlight;
+        outline-offset: 1px;
+      }
+      #mobile-keyboard span {
+        font-size: 24px;
+        line-height: 1;
+      }
+      #mobile-keyboard-input {
+        position: fixed;
+        left: -40px;
+        width: 1px;
+        height: 1px;
+        border: 0;
+        opacity: 0;
+      }
     </style>
     <script type="module">
       import { attachHostClipboardPaste } from "./clipboard-bridge.js";
+      import Keyboard from "./core/input/keyboard.js";
+      import KeyTable from "./core/input/keysym.js";
+      import keysyms from "./core/input/keysymdef.js";
       import RFB from "./core/rfb.js";
+      import { attachMobileKeyboard, isTouchBrowser } from "./mobile-keyboard.js";
 
       function query(name, fallback) {
         const match = `${document.location.href}${window.location.hash}`.match(
@@ -39,9 +74,36 @@
       rfb.scaleViewport = true;
       rfb.clipViewport = false;
       if (!rfb.viewOnly) attachHostClipboardPaste(rfb);
+      if (!rfb.viewOnly && isTouchBrowser()) {
+        attachMobileKeyboard(rfb, {
+          button: document.getElementById("mobile-keyboard"),
+          input: document.getElementById("mobile-keyboard-input"),
+          Keyboard,
+          backspaceKeysym: KeyTable.XK_BackSpace,
+          lookupKeysym: keysyms.lookup,
+        });
+      }
     </script>
   </head>
   <body>
     <div id="screen"></div>
+    <button
+      id="mobile-keyboard"
+      type="button"
+      aria-label="Show keyboard"
+      aria-pressed="false"
+      title="Show keyboard"
+      hidden
+    >
+      <span aria-hidden="true">⌨︎</span>
+    </button>
+    <textarea
+      id="mobile-keyboard-input"
+      aria-label="Remote computer keyboard input"
+      autocapitalize="off"
+      autocomplete="off"
+      spellcheck="false"
+      tabindex="-1"
+    ></textarea>
   </body>
 </html>

--- a/infra/sandboxes/computer/embed.html
+++ b/infra/sandboxes/computer/embed.html
@@ -70,11 +70,7 @@
       import KeyTable from "./core/input/keysym.js";
       import keysyms from "./core/input/keysymdef.js";
       import RFB from "./core/rfb.js";
-      import {
-        attachMobileKeyboard,
-        attachMobileTrackpad,
-        isTouchBrowser,
-      } from "./mobile-keyboard.js";
+      import { attachMobileKeyboard, attachMobileTrackpad, isTouchBrowser } from "./mobile-keyboard.js";
 
       function query(name, fallback) {
         const match = `${document.location.href}${window.location.hash}`.match(

--- a/infra/sandboxes/computer/embed.html
+++ b/infra/sandboxes/computer/embed.html
@@ -32,9 +32,9 @@
         outline: 3px solid Highlight;
         outline-offset: 1px;
       }
-      #mobile-keyboard span {
-        font-size: 24px;
-        line-height: 1;
+      #mobile-keyboard svg {
+        width: 100%;
+        height: 100%;
       }
       #mobile-keyboard-input {
         position: fixed;
@@ -95,7 +95,10 @@
       title="Show keyboard"
       hidden
     >
-      <span aria-hidden="true">⌨︎</span>
+      <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h.01M10 12h.01M14 12h.01M18 12h.01M6 16h12" />
+      </svg>
     </button>
     <textarea
       id="mobile-keyboard-input"

--- a/infra/sandboxes/computer/embed.html
+++ b/infra/sandboxes/computer/embed.html
@@ -13,7 +13,7 @@
         background: #0e0e10;
         overflow: hidden;
       }
-      #mobile-keyboard {
+      #mobile-controls {
         position: fixed;
         right: max(12px, env(safe-area-inset-right));
         top: calc(
@@ -21,6 +21,11 @@
             env(safe-area-inset-bottom)
         );
         z-index: 2;
+        display: flex;
+        gap: 8px;
+      }
+      #mobile-keyboard,
+      #mobile-trackpad {
         box-sizing: border-box;
         width: 48px;
         height: 48px;
@@ -31,13 +36,18 @@
         color: CanvasText;
         box-shadow: 0 2px 10px color-mix(in srgb, CanvasText 25%, transparent);
       }
-      #mobile-keyboard.active {
+      #mobile-keyboard.active,
+      #mobile-trackpad.active {
         outline: 3px solid Highlight;
         outline-offset: 1px;
       }
-      #mobile-keyboard svg {
+      #mobile-keyboard svg,
+      #mobile-trackpad svg {
         width: 100%;
         height: 100%;
+      }
+      #screen.trackpad-active {
+        touch-action: none;
       }
       #mobile-keyboard-input {
         position: fixed;
@@ -60,7 +70,11 @@
       import KeyTable from "./core/input/keysym.js";
       import keysyms from "./core/input/keysymdef.js";
       import RFB from "./core/rfb.js";
-      import { attachMobileKeyboard, isTouchBrowser } from "./mobile-keyboard.js";
+      import {
+        attachMobileKeyboard,
+        attachMobileTrackpad,
+        isTouchBrowser,
+      } from "./mobile-keyboard.js";
 
       function query(name, fallback) {
         const match = `${document.location.href}${window.location.hash}`.match(
@@ -91,24 +105,44 @@
           backspaceKeysym: KeyTable.XK_BackSpace,
           lookupKeysym: keysyms.lookup,
         });
+        attachMobileTrackpad(rfb, {
+          button: document.getElementById("mobile-trackpad"),
+          surface: document.getElementById("screen"),
+        });
       }
     </script>
   </head>
   <body>
     <div id="screen"></div>
-    <button
-      id="mobile-keyboard"
-      type="button"
-      aria-label="Show keyboard"
-      aria-pressed="false"
-      title="Show keyboard"
-      hidden
-    >
-      <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <rect x="2" y="4" width="20" height="16" rx="2" />
-        <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h.01M10 12h.01M14 12h.01M18 12h.01M6 16h12" />
-      </svg>
-    </button>
+    <div id="mobile-controls">
+      <button
+        id="mobile-keyboard"
+        type="button"
+        aria-label="Show keyboard"
+        aria-pressed="false"
+        title="Show keyboard"
+        hidden
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <rect x="2" y="4" width="20" height="16" rx="2" />
+          <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M6 12h.01M10 12h.01M14 12h.01M18 12h.01M6 16h12" />
+        </svg>
+      </button>
+      <button
+        id="mobile-trackpad"
+        type="button"
+        aria-label="Use trackpad"
+        aria-pressed="false"
+        title="Use trackpad"
+        hidden
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M9 11V5a2 2 0 0 1 4 0v5" />
+          <path d="M13 10V4a2 2 0 0 1 4 0v7" />
+          <path d="M17 10V6a2 2 0 0 1 4 0v7c0 5-3 8-8 8h-1c-3 0-5-1-7-4l-2-3a2 2 0 0 1 3-2l3 2" />
+        </svg>
+      </button>
+    </div>
     <textarea
       id="mobile-keyboard-input"
       aria-label="Remote computer keyboard input"

--- a/infra/sandboxes/computer/embed.html
+++ b/infra/sandboxes/computer/embed.html
@@ -16,7 +16,10 @@
       #mobile-keyboard {
         position: fixed;
         right: max(12px, env(safe-area-inset-right));
-        bottom: max(12px, env(safe-area-inset-bottom));
+        top: calc(
+          var(--mobile-visual-top, 0px) + var(--mobile-visual-height, 100dvh) - 60px -
+            env(safe-area-inset-bottom)
+        );
         z-index: 2;
         box-sizing: border-box;
         width: 48px;
@@ -43,6 +46,12 @@
         height: 1px;
         border: 0;
         opacity: 0;
+      }
+      .mobile-keyboard-open #screen {
+        position: fixed;
+        top: var(--mobile-visual-top, 0px);
+        left: 0;
+        height: var(--mobile-visual-height, 100dvh);
       }
     </style>
     <script type="module">

--- a/infra/sandboxes/computer/mobile-keyboard.d.ts
+++ b/infra/sandboxes/computer/mobile-keyboard.d.ts
@@ -1,0 +1,26 @@
+export function mobileInputChanges(
+  oldValue: string,
+  newValue: string,
+  selectionStart?: number | null,
+): { backspaces: number; text: string };
+
+export function isTouchBrowser(
+  navigatorLike?: { maxTouchPoints?: number },
+  windowLike?: object,
+): boolean;
+
+export function attachMobileKeyboard(
+  rfb: {
+    viewOnly?: boolean;
+    focusOnClick?: boolean;
+    sendKey: (keysym: number, code?: string, down?: boolean) => void;
+  },
+  options: {
+    button: unknown;
+    input: unknown;
+    Keyboard: unknown;
+    backspaceKeysym: number;
+    lookupKeysym: (codePoint: number) => number;
+    documentTarget?: unknown;
+  },
+): () => void;

--- a/infra/sandboxes/computer/mobile-keyboard.d.ts
+++ b/infra/sandboxes/computer/mobile-keyboard.d.ts
@@ -9,6 +9,19 @@ export function isTouchBrowser(
   windowLike?: object,
 ): boolean;
 
+export function attachMobileTrackpad(
+  rfb: {
+    viewOnly?: boolean;
+    showDotCursor?: boolean;
+  },
+  options: {
+    button: unknown;
+    surface: unknown;
+    documentTarget?: unknown;
+    sensitivity?: number;
+  },
+): () => void;
+
 export function attachMobileKeyboard(
   rfb: {
     viewOnly?: boolean;
@@ -22,5 +35,6 @@ export function attachMobileKeyboard(
     backspaceKeysym: number;
     lookupKeysym: (codePoint: number) => number;
     documentTarget?: unknown;
+    windowTarget?: unknown;
   },
 ): () => void;

--- a/infra/sandboxes/computer/mobile-keyboard.js
+++ b/infra/sandboxes/computer/mobile-keyboard.js
@@ -32,12 +32,31 @@ export function isTouchBrowser(navigatorLike = globalThis.navigator, windowLike 
  */
 export function attachMobileKeyboard(
   rfb,
-  { button, input, Keyboard, backspaceKeysym, lookupKeysym, documentTarget = globalThis.document },
+  {
+    button,
+    input,
+    Keyboard,
+    backspaceKeysym,
+    lookupKeysym,
+    documentTarget = globalThis.document,
+    windowTarget = documentTarget?.defaultView ?? globalThis,
+  },
 ) {
   if (!button || !input || !Keyboard || !documentTarget || rfb.viewOnly) return () => {};
 
   let lastValue = "";
   let closeOnButtonClick = false;
+  const visualViewport = windowTarget?.visualViewport;
+  const viewportRoot = documentTarget.documentElement;
+  const updateVisibleViewport = () => {
+    if (documentTarget.activeElement !== input || !visualViewport) return;
+    viewportRoot.style.setProperty("--mobile-visual-height", `${visualViewport.height}px`);
+    viewportRoot.style.setProperty("--mobile-visual-top", `${visualViewport.offsetTop}px`);
+  };
+  const clearVisibleViewport = () => {
+    viewportRoot.style.removeProperty("--mobile-visual-height");
+    viewportRoot.style.removeProperty("--mobile-visual-top");
+  };
   const resetInput = () => {
     input.value = "_".repeat(DEFAULT_INPUT_LENGTH - 1);
     lastValue = input.value;
@@ -48,6 +67,9 @@ export function attachMobileKeyboard(
     button.setAttribute("aria-label", label);
     button.setAttribute("title", label);
     button.classList.toggle("active", open);
+    viewportRoot.classList.toggle("mobile-keyboard-open", open);
+    if (open) updateVisibleViewport();
+    else clearVisibleViewport();
     rfb.focusOnClick = !open;
   };
   const show = () => {
@@ -105,6 +127,8 @@ export function attachMobileKeyboard(
   input.addEventListener("input", onInput);
   input.addEventListener("focus", onFocus);
   input.addEventListener("blur", onBlur);
+  visualViewport?.addEventListener("resize", updateVisibleViewport);
+  visualViewport?.addEventListener("scroll", updateVisibleViewport);
   for (const type of keepOpenEvents) {
     documentTarget.documentElement.addEventListener(type, keepOpen, true);
   }
@@ -116,6 +140,10 @@ export function attachMobileKeyboard(
     input.removeEventListener("input", onInput);
     input.removeEventListener("focus", onFocus);
     input.removeEventListener("blur", onBlur);
+    visualViewport?.removeEventListener("resize", updateVisibleViewport);
+    visualViewport?.removeEventListener("scroll", updateVisibleViewport);
+    viewportRoot.classList.remove("mobile-keyboard-open");
+    clearVisibleViewport();
     for (const type of keepOpenEvents) {
       documentTarget.documentElement.removeEventListener(type, keepOpen, true);
     }

--- a/infra/sandboxes/computer/mobile-keyboard.js
+++ b/infra/sandboxes/computer/mobile-keyboard.js
@@ -79,12 +79,8 @@ export function attachMobileKeyboard(
   };
   const keepOpen = (event) => {
     if (documentTarget.activeElement !== input) return;
-    // Let the toggle control dismiss without preventDefault swallowing the tap.
-    if (event.target === button || button.contains?.(event.target)) return;
     event.preventDefault();
   };
-  // Touch/pointer first: blur can run before a synthesized mousedown on mobile.
-  const keepOpenEvents = ["pointerdown", "touchstart", "mousedown"];
 
   resetInput();
   const keyboard = new Keyboard(input);
@@ -95,9 +91,7 @@ export function attachMobileKeyboard(
   input.addEventListener("input", onInput);
   input.addEventListener("focus", onFocus);
   input.addEventListener("blur", onBlur);
-  for (const type of keepOpenEvents) {
-    documentTarget.documentElement.addEventListener(type, keepOpen, true);
-  }
+  documentTarget.documentElement.addEventListener("mousedown", keepOpen, true);
 
   return () => {
     keyboard.ungrab?.();
@@ -105,8 +99,6 @@ export function attachMobileKeyboard(
     input.removeEventListener("input", onInput);
     input.removeEventListener("focus", onFocus);
     input.removeEventListener("blur", onBlur);
-    for (const type of keepOpenEvents) {
-      documentTarget.documentElement.removeEventListener(type, keepOpen, true);
-    }
+    documentTarget.documentElement.removeEventListener("mousedown", keepOpen, true);
   };
 }

--- a/infra/sandboxes/computer/mobile-keyboard.js
+++ b/infra/sandboxes/computer/mobile-keyboard.js
@@ -37,6 +37,7 @@ export function attachMobileKeyboard(
   if (!button || !input || !Keyboard || !documentTarget || rfb.viewOnly) return () => {};
 
   let lastValue = "";
+  let closeOnButtonClick = false;
   const resetInput = () => {
     input.value = "_".repeat(DEFAULT_INPUT_LENGTH - 1);
     lastValue = input.value;
@@ -55,7 +56,15 @@ export function attachMobileKeyboard(
     input.setSelectionRange?.(length, length);
   };
   const hide = () => input.blur();
-  const onButtonClick = () => (documentTarget.activeElement === input ? hide() : show());
+  const onButtonPressStart = () => {
+    if (documentTarget.activeElement === input) closeOnButtonClick = true;
+  };
+  const onButtonClick = () => {
+    const shouldHide = closeOnButtonClick || documentTarget.activeElement === input;
+    closeOnButtonClick = false;
+    if (shouldHide) hide();
+    else show();
+  };
   const onFocus = () => setOpen(true);
   const onBlur = () => setOpen(false);
   const onInput = (event) => {
@@ -91,6 +100,7 @@ export function attachMobileKeyboard(
   keyboard.onkeyevent = (keysym, code, down) => rfb.sendKey(keysym, code, down);
   keyboard.grab();
   button.hidden = false;
+  for (const type of keepOpenEvents) button.addEventListener(type, onButtonPressStart);
   button.addEventListener("click", onButtonClick);
   input.addEventListener("input", onInput);
   input.addEventListener("focus", onFocus);
@@ -101,6 +111,7 @@ export function attachMobileKeyboard(
 
   return () => {
     keyboard.ungrab?.();
+    for (const type of keepOpenEvents) button.removeEventListener(type, onButtonPressStart);
     button.removeEventListener("click", onButtonClick);
     input.removeEventListener("input", onInput);
     input.removeEventListener("focus", onFocus);

--- a/infra/sandboxes/computer/mobile-keyboard.js
+++ b/infra/sandboxes/computer/mobile-keyboard.js
@@ -1,0 +1,104 @@
+const DEFAULT_INPUT_LENGTH = 100;
+
+/** Return the remote key changes represented by a mobile input event. */
+export function mobileInputChanges(oldValue, newValue, selectionStart = newValue.length) {
+  const newLength = Math.max(selectionStart ?? newValue.length, newValue.length);
+  const oldLength = oldValue.length;
+  let inputCount = newLength - oldLength;
+  let backspaces = inputCount < 0 ? -inputCount : 0;
+
+  for (let index = 0; index < Math.min(oldLength, newLength); index += 1) {
+    if (newValue.charAt(index) !== oldValue.charAt(index)) {
+      inputCount = newLength - index;
+      backspaces = oldLength - index;
+      break;
+    }
+  }
+
+  return {
+    backspaces,
+    text: newValue.slice(newLength - inputCount, newLength),
+  };
+}
+
+/** True for browsers that can present a touch keyboard. */
+export function isTouchBrowser(navigatorLike = globalThis.navigator, windowLike = globalThis) {
+  return Boolean(navigatorLike?.maxTouchPoints > 0 || "ontouchstart" in windowLike);
+}
+
+/**
+ * Connect a hidden text field to noVNC so iOS and Android keyboards can type
+ * into the remote desktop. This follows noVNC's full-interface keyboard flow.
+ */
+export function attachMobileKeyboard(
+  rfb,
+  { button, input, Keyboard, backspaceKeysym, lookupKeysym, documentTarget = globalThis.document },
+) {
+  if (!button || !input || !Keyboard || !documentTarget || rfb.viewOnly) return () => {};
+
+  let lastValue = "";
+  const resetInput = () => {
+    input.value = "_".repeat(DEFAULT_INPUT_LENGTH - 1);
+    lastValue = input.value;
+  };
+  const setOpen = (open) => {
+    const label = open ? "Hide keyboard" : "Show keyboard";
+    button.setAttribute("aria-pressed", String(open));
+    button.setAttribute("aria-label", label);
+    button.setAttribute("title", label);
+    button.classList.toggle("active", open);
+    rfb.focusOnClick = !open;
+  };
+  const show = () => {
+    input.focus();
+    const length = input.value.length;
+    input.setSelectionRange?.(length, length);
+  };
+  const hide = () => input.blur();
+  const onButtonClick = () => (documentTarget.activeElement === input ? hide() : show());
+  const onFocus = () => setOpen(true);
+  const onBlur = () => setOpen(false);
+  const onInput = (event) => {
+    if (!lastValue) resetInput();
+    const newValue = event.target.value;
+    const changes = mobileInputChanges(lastValue, newValue, event.target.selectionStart);
+    for (let index = 0; index < changes.backspaces; index += 1) {
+      rfb.sendKey(backspaceKeysym, "Backspace");
+    }
+    for (const character of changes.text) rfb.sendKey(lookupKeysym(character.codePointAt(0)));
+
+    if (newValue.length > 2 * DEFAULT_INPUT_LENGTH) {
+      resetInput();
+    } else if (newValue.length < 1) {
+      resetInput();
+      input.blur();
+      setTimeout(() => input.focus(), 0);
+    } else {
+      lastValue = newValue;
+    }
+  };
+  const keepOpen = (event) => {
+    if (documentTarget.activeElement !== input) return;
+    event.preventDefault();
+  };
+
+  resetInput();
+  const keyboard = new Keyboard(input);
+  keyboard.onkeyevent = (keysym, code, down) => rfb.sendKey(keysym, code, down);
+  keyboard.grab();
+  button.hidden = false;
+  button.addEventListener("click", onButtonClick);
+  input.addEventListener("input", onInput);
+  input.addEventListener("focus", onFocus);
+  input.addEventListener("blur", onBlur);
+  documentTarget.documentElement.addEventListener("mousedown", keepOpen, true);
+
+  return () => {
+    keyboard.ungrab?.();
+    button.removeEventListener("click", onButtonClick);
+    input.removeEventListener("input", onInput);
+    input.removeEventListener("focus", onFocus);
+    input.removeEventListener("blur", onBlur);
+    documentTarget.documentElement.removeEventListener("mousedown", keepOpen, true);
+  };
+}

--- a/infra/sandboxes/computer/mobile-keyboard.js
+++ b/infra/sandboxes/computer/mobile-keyboard.js
@@ -79,8 +79,12 @@ export function attachMobileKeyboard(
   };
   const keepOpen = (event) => {
     if (documentTarget.activeElement !== input) return;
+    // Let the toggle control dismiss without preventDefault swallowing the tap.
+    if (event.target === button || button.contains?.(event.target)) return;
     event.preventDefault();
   };
+  // Touch/pointer first: blur can run before a synthesized mousedown on mobile.
+  const keepOpenEvents = ["pointerdown", "touchstart", "mousedown"];
 
   resetInput();
   const keyboard = new Keyboard(input);
@@ -91,7 +95,9 @@ export function attachMobileKeyboard(
   input.addEventListener("input", onInput);
   input.addEventListener("focus", onFocus);
   input.addEventListener("blur", onBlur);
-  documentTarget.documentElement.addEventListener("mousedown", keepOpen, true);
+  for (const type of keepOpenEvents) {
+    documentTarget.documentElement.addEventListener(type, keepOpen, true);
+  }
 
   return () => {
     keyboard.ungrab?.();
@@ -99,6 +105,8 @@ export function attachMobileKeyboard(
     input.removeEventListener("input", onInput);
     input.removeEventListener("focus", onFocus);
     input.removeEventListener("blur", onBlur);
-    documentTarget.documentElement.removeEventListener("mousedown", keepOpen, true);
+    for (const type of keepOpenEvents) {
+      documentTarget.documentElement.removeEventListener(type, keepOpen, true);
+    }
   };
 }

--- a/infra/sandboxes/computer/mobile-keyboard.js
+++ b/infra/sandboxes/computer/mobile-keyboard.js
@@ -26,6 +26,112 @@ export function isTouchBrowser(navigatorLike = globalThis.navigator, windowLike 
   return Boolean(navigatorLike?.maxTouchPoints > 0 || "ontouchstart" in windowLike);
 }
 
+/** Add a relative touch trackpad that drives noVNC's mouse canvas. */
+export function attachMobileTrackpad(
+  rfb,
+  { button, surface, documentTarget = globalThis.document, sensitivity = 1.5 },
+) {
+  if (!button || !surface || !documentTarget || rfb.viewOnly) return () => {};
+
+  let enabled = false;
+  let pointerId = null;
+  let lastX = 0;
+  let lastY = 0;
+  let cursorX = null;
+  let cursorY = null;
+  let moved = false;
+
+  const canvas = () => surface.querySelector("canvas");
+  const mouse = (type, buttonNumber = 0) => {
+    const target = canvas();
+    if (!target || cursorX == null || cursorY == null) return;
+    target.dispatchEvent(
+      new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        clientX: cursorX,
+        clientY: cursorY,
+        button: buttonNumber,
+        buttons: type === "mousedown" ? 1 : 0,
+      }),
+    );
+  };
+  const positionCursor = (deltaX = 0, deltaY = 0) => {
+    const target = canvas();
+    if (!target) return;
+    const bounds = target.getBoundingClientRect();
+    cursorX ??= bounds.left + bounds.width / 2;
+    cursorY ??= bounds.top + bounds.height / 2;
+    cursorX = Math.max(bounds.left, Math.min(bounds.right - 1, cursorX + deltaX * sensitivity));
+    cursorY = Math.max(bounds.top, Math.min(bounds.bottom - 1, cursorY + deltaY * sensitivity));
+    mouse("mousemove");
+  };
+  const setEnabled = (next) => {
+    enabled = next;
+    const label = enabled ? "Use direct touch" : "Use trackpad";
+    button.setAttribute("aria-pressed", String(enabled));
+    button.setAttribute("aria-label", label);
+    button.setAttribute("title", label);
+    button.classList.toggle("active", enabled);
+    surface.classList.toggle("trackpad-active", enabled);
+    rfb.showDotCursor = enabled;
+    if (enabled) positionCursor();
+  };
+  const onButtonClick = () => setEnabled(!enabled);
+  const shouldHandle = (event) => enabled && event.pointerType !== "mouse";
+  const consume = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+  const onPointerDown = (event) => {
+    if (!shouldHandle(event) || pointerId !== null) return;
+    consume(event);
+    pointerId = event.pointerId;
+    lastX = event.clientX;
+    lastY = event.clientY;
+    moved = false;
+    event.target.setPointerCapture?.(event.pointerId);
+  };
+  const onPointerMove = (event) => {
+    if (!shouldHandle(event) || event.pointerId !== pointerId) return;
+    consume(event);
+    const deltaX = event.clientX - lastX;
+    const deltaY = event.clientY - lastY;
+    if (Math.abs(deltaX) + Math.abs(deltaY) > 1) moved = true;
+    positionCursor(deltaX, deltaY);
+    lastX = event.clientX;
+    lastY = event.clientY;
+  };
+  const finishPointer = (event, click) => {
+    if (!shouldHandle(event) || event.pointerId !== pointerId) return;
+    consume(event);
+    if (click && !moved) {
+      mouse("mousedown");
+      mouse("mouseup");
+    }
+    pointerId = null;
+  };
+  const onPointerUp = (event) => finishPointer(event, true);
+  const onPointerCancel = (event) => finishPointer(event, false);
+
+  button.hidden = false;
+  button.addEventListener("click", onButtonClick);
+  surface.addEventListener("pointerdown", onPointerDown, true);
+  surface.addEventListener("pointermove", onPointerMove, true);
+  surface.addEventListener("pointerup", onPointerUp, true);
+  surface.addEventListener("pointercancel", onPointerCancel, true);
+
+  return () => {
+    button.removeEventListener("click", onButtonClick);
+    surface.removeEventListener("pointerdown", onPointerDown, true);
+    surface.removeEventListener("pointermove", onPointerMove, true);
+    surface.removeEventListener("pointerup", onPointerUp, true);
+    surface.removeEventListener("pointercancel", onPointerCancel, true);
+    surface.classList.remove("trackpad-active");
+    rfb.showDotCursor = false;
+  };
+}
+
 /**
  * Connect a hidden text field to noVNC so iOS and Android keyboards can type
  * into the remote desktop. This follows noVNC's full-interface keyboard flow.

--- a/infra/sandboxes/computer/start.sh
+++ b/infra/sandboxes/computer/start.sh
@@ -81,6 +81,10 @@ if [[ ! -f "$NOVNC_ROOT/clipboard-bridge.js" ]]; then
   echo "noVNC clipboard-bridge.js is missing from the computer image" >&2
   exit 1
 fi
+if [[ ! -f "$NOVNC_ROOT/mobile-keyboard.js" ]]; then
+  echo "noVNC mobile-keyboard.js is missing from the computer image" >&2
+  exit 1
+fi
 websockify --heartbeat=30 --web="$NOVNC_ROOT" --token-plugin=TokenFile --token-source=/tmp/rakazo/view-target-1 0.0.0.0:6080 >/tmp/rakazo/novnc.log 2>&1 &
 
 while kill -0 "$XVFB_PID" 2>/dev/null; do

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -833,6 +833,7 @@ async function ensureComputerImage() {
             "rakazo-browser.desktop",
             "embed.html",
             "clipboard-bridge.js",
+            "mobile-keyboard.js",
             "fluxbox.init",
             "fluxbox.apps",
             "fluxbox.menu",

--- a/infra/sandboxes/supervisor/src/mobile-keyboard.test.ts
+++ b/infra/sandboxes/supervisor/src/mobile-keyboard.test.ts
@@ -33,11 +33,11 @@ describe("mobile computer keyboard", () => {
   });
 
   it("enables a visible relative-pointer mode", () => {
-    const listeners = new Map<string, EventListener>();
+    const listeners = new Map<string, () => void>();
     const classes = new Set<string>();
     const button = {
       hidden: true,
-      addEventListener: (type: string, listener: EventListener) => listeners.set(type, listener),
+      addEventListener: (type: string, listener: () => void) => listeners.set(type, listener),
       removeEventListener: () => {},
       setAttribute: () => {},
       classList: {
@@ -52,7 +52,7 @@ describe("mobile computer keyboard", () => {
     };
     const rfb = { viewOnly: false, showDotCursor: false };
     const detach = attachMobileTrackpad(rfb, { button, surface, documentTarget: {} });
-    listeners.get("click")?.(new Event("click"));
+    listeners.get("click")?.();
     expect(button.hidden).toBe(false);
     expect(rfb.showDotCursor).toBe(true);
     expect(classes.has("active")).toBe(true);

--- a/infra/sandboxes/supervisor/src/mobile-keyboard.test.ts
+++ b/infra/sandboxes/supervisor/src/mobile-keyboard.test.ts
@@ -37,6 +37,8 @@ describe("mobile computer keyboard", () => {
     expect(dockerfile).toMatch(/mobile-keyboard\.js/);
     expect(embed).toMatch(/attachMobileKeyboard/);
     expect(embed).toMatch(/mobile-keyboard-input/);
+    expect(embed).toMatch(/mobile-keyboard-open #screen/);
+    expect(embed).toMatch(/--mobile-visual-height/);
     expect(start).toMatch(/mobile-keyboard\.js/);
     expect(supervisor).toMatch(/"mobile-keyboard\.js"/);
   });

--- a/infra/sandboxes/supervisor/src/mobile-keyboard.test.ts
+++ b/infra/sandboxes/supervisor/src/mobile-keyboard.test.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { isTouchBrowser, mobileInputChanges } from "../../computer/mobile-keyboard.js";
+import {
+  attachMobileTrackpad,
+  isTouchBrowser,
+  mobileInputChanges,
+} from "../../computer/mobile-keyboard.js";
 
 describe("mobile computer keyboard", () => {
   it("translates inserted and deleted text", () => {
@@ -28,6 +32,34 @@ describe("mobile computer keyboard", () => {
     expect(isTouchBrowser({ maxTouchPoints: 0 }, {})).toBe(false);
   });
 
+  it("enables a visible relative-pointer mode", () => {
+    const listeners = new Map<string, EventListener>();
+    const classes = new Set<string>();
+    const button = {
+      hidden: true,
+      addEventListener: (type: string, listener: EventListener) => listeners.set(type, listener),
+      removeEventListener: () => {},
+      setAttribute: () => {},
+      classList: {
+        toggle: (name: string, on: boolean) => (on ? classes.add(name) : classes.delete(name)),
+      },
+    };
+    const surface = {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      querySelector: () => null,
+      classList: { toggle: () => {}, remove: () => {} },
+    };
+    const rfb = { viewOnly: false, showDotCursor: false };
+    const detach = attachMobileTrackpad(rfb, { button, surface, documentTarget: {} });
+    listeners.get("click")?.(new Event("click"));
+    expect(button.hidden).toBe(false);
+    expect(rfb.showDotCursor).toBe(true);
+    expect(classes.has("active")).toBe(true);
+    detach();
+    expect(rfb.showDotCursor).toBe(false);
+  });
+
   it("ships and initializes the keyboard bridge in the computer image", () => {
     const root = path.resolve(import.meta.dirname, "../../computer");
     const dockerfile = readFileSync(path.join(root, "Dockerfile"), "utf8");
@@ -37,6 +69,8 @@ describe("mobile computer keyboard", () => {
     expect(dockerfile).toMatch(/mobile-keyboard\.js/);
     expect(embed).toMatch(/attachMobileKeyboard/);
     expect(embed).toMatch(/mobile-keyboard-input/);
+    expect(embed).toMatch(/attachMobileTrackpad/);
+    expect(embed).toMatch(/mobile-trackpad/);
     expect(embed).toMatch(/mobile-keyboard-open #screen/);
     expect(embed).toMatch(/--mobile-visual-height/);
     expect(start).toMatch(/mobile-keyboard\.js/);

--- a/infra/sandboxes/supervisor/src/mobile-keyboard.test.ts
+++ b/infra/sandboxes/supervisor/src/mobile-keyboard.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isTouchBrowser, mobileInputChanges } from "../../computer/mobile-keyboard.js";
+
+describe("mobile computer keyboard", () => {
+  it("translates inserted and deleted text", () => {
+    expect(mobileInputChanges("___", "___a", 4)).toEqual({
+      backspaces: 0,
+      text: "a",
+    });
+    expect(mobileInputChanges("___a", "___", 3)).toEqual({
+      backspaces: 1,
+      text: "",
+    });
+  });
+
+  it("replaces corrected text instead of duplicating it", () => {
+    expect(mobileInputChanges("___teh", "___the", 6)).toEqual({
+      backspaces: 2,
+      text: "he",
+    });
+  });
+
+  it("only enables the control in touch browsers", () => {
+    expect(isTouchBrowser({ maxTouchPoints: 1 }, {})).toBe(true);
+    expect(isTouchBrowser({ maxTouchPoints: 0 }, { ontouchstart: null })).toBe(true);
+    expect(isTouchBrowser({ maxTouchPoints: 0 }, {})).toBe(false);
+  });
+
+  it("ships and initializes the keyboard bridge in the computer image", () => {
+    const root = path.resolve(import.meta.dirname, "../../computer");
+    const dockerfile = readFileSync(path.join(root, "Dockerfile"), "utf8");
+    const embed = readFileSync(path.join(root, "embed.html"), "utf8");
+    const start = readFileSync(path.join(root, "start.sh"), "utf8");
+    const supervisor = readFileSync(path.join(import.meta.dirname, "index.ts"), "utf8");
+    expect(dockerfile).toMatch(/mobile-keyboard\.js/);
+    expect(embed).toMatch(/attachMobileKeyboard/);
+    expect(embed).toMatch(/mobile-keyboard-input/);
+    expect(start).toMatch(/mobile-keyboard\.js/);
+    expect(supervisor).toMatch(/"mobile-keyboard\.js"/);
+  });
+});

--- a/packages/core/src/node/screen-capability.test.ts
+++ b/packages/core/src/node/screen-capability.test.ts
@@ -52,10 +52,11 @@ describe("sealed screen capabilities", () => {
         },
         attachHostClipboardPaste: () => {},
         // Embed imports are stripped for this smoke; stub the touch-keyboard
-        // bridge the same way as clipboard. Returning false skips Keyboard /
-        // KeyTable / keysyms, which this harness does not provide.
+        // and trackpad bridges the same way as clipboard. Returning false
+        // skips Keyboard / KeyTable / keysyms, which this harness does not provide.
         isTouchBrowser: () => false,
         attachMobileKeyboard: () => {},
+        attachMobileTrackpad: () => {},
       });
       const socket = new URL(socketUrl);
       expect(socket.protocol).toBe("wss:");

--- a/packages/core/src/node/screen-capability.test.ts
+++ b/packages/core/src/node/screen-capability.test.ts
@@ -40,7 +40,7 @@ describe("sealed screen capabilities", () => {
       );
       const script = html
         .match(/<script type="module">([\s\S]*?)<\/script>/)![1]!
-        .replace(/^\s*import .*;$/gm, "");
+        .replace(/^\s*import[\s\S]*?;\s*$/gm, "");
       let socketUrl = "";
       runInNewContext(script, {
         document: { location: url, getElementById: () => ({}) },

--- a/packages/core/src/node/screen-capability.test.ts
+++ b/packages/core/src/node/screen-capability.test.ts
@@ -51,6 +51,11 @@ describe("sealed screen capabilities", () => {
           }
         },
         attachHostClipboardPaste: () => {},
+        // Embed imports are stripped for this smoke; stub the touch-keyboard
+        // bridge the same way as clipboard. Returning false skips Keyboard /
+        // KeyTable / keysyms, which this harness does not provide.
+        isTouchBrowser: () => false,
+        attachMobileKeyboard: () => {},
       });
       const socket = new URL(socketUrl);
       expect(socket.protocol).toBe("wss:");


### PR DESCRIPTION
## Why

The chrome-less noVNC computer embed only exposes a canvas. Mobile browsers cannot infer that a remote pixel is a text field, so tapping a field does not open the iOS or Android keyboard.

## Change

- Show a keyboard control only on touch-capable, non-view-only computer sessions.
- Use noVNC's keyboard and input-event flow to forward mobile typing, backspace, corrections, and special keys to the remote computer.
- Keep the keyboard active while the user taps within the remote screen, and allow a second tap on the control to dismiss it.
- Ship and validate the bridge as part of locally built computer images.
- Add a CI Playwright screenshot of the active touch-keyboard state.

## Interface copy

- **“Show keyboard”** tells touch users that the control opens their device keyboard, which the remote canvas cannot trigger from a remote text-field tap.
- **“Hide keyboard”** replaces that label while active so the same control clearly dismisses the keyboard.

## Tests

- `vitest run --root . infra/sandboxes/supervisor/src packages/core/src/node/screen-capability.test.ts` (202 passed, 3 skipped)
- `playwright test apps/web/e2e/mobile-computer-keyboard.spec.ts` (1 passed; captures `mobile-computer-keyboard-open.png` for the CI gallery)
- TypeScript checks for web and sandbox supervisor
- Biome checks on changed JS/TS/HTML files
- `bash -n infra/sandboxes/computer/start.sh`
- Built the complete computer image successfully.
- Browser-level touch emulation against a live image: opened the keyboard control, typed and submitted `MOBILE_KEYBOARD_OK` in an xterm inside the VNC desktop, then dismissed the keyboard with a second tap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-screen keyboard for remote desktop sessions on touch-enabled browsers.
  * Added a keyboard toggle control for entering text and backspaces remotely.
  * The keyboard is available in interactive sessions and remains unavailable in view-only sessions.
  * Improved keyboard toggling so users can open and dismiss it reliably while entering text.

* **Tests**
  * Added coverage for text editing, touch-browser detection, keyboard availability, and keyboard interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->