### PR TITLE
[superseded by #830] request_secret credential XOR connectionId

### DIFF
--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -230,19 +230,33 @@ export const builtinAgentTools: ConnectorTool[] = [
     name: "request_secret",
     description:
       "Collect a credential in a masked field. Supply credential to save a named API credential for this bot and user at one HTTPS origin, or connectionId for a one-use connector code. Existing named credentials are reused unless replace is true. For website logins, CAPTCHA, passkeys, or anything that needs the live desktop, call request_takeover instead.",
+    // Exactly one destination: credential XOR connectionId. Sibling optionals
+    // looked schema-valid to models but the executor rejects both and neither.
     inputSchema: {
-      type: "object",
-      properties: {
-        label: { type: "string" },
-        purpose: { type: "string", enum: SecretAskPurpose.options },
-        connectionId: { type: "string" },
-        credential: z.toJSONSchema(BotSecretDestination),
-        replace: {
-          type: "boolean",
-          description: "Ask the user to replace an existing credential value.",
+      oneOf: [
+        {
+          type: "object",
+          properties: {
+            label: { type: "string" },
+            purpose: { type: "string", enum: SecretAskPurpose.options },
+            credential: z.toJSONSchema(BotSecretDestination),
+            replace: {
+              type: "boolean",
+              description: "Ask the user to replace an existing credential value.",
+            },
+          },
+          required: ["label", "purpose", "credential"],
         },
-      },
-      required: ["label", "purpose"],
+        {
+          type: "object",
+          properties: {
+            label: { type: "string" },
+            purpose: { type: "string", enum: SecretAskPurpose.options },
+            connectionId: { type: "string" },
+          },
+          required: ["label", "purpose", "connectionId"],
+        },
+      ],
     },
   },
   {

--- a/packages/adapters/src/pi-runtime-secret-schema.test.ts
+++ b/packages/adapters/src/pi-runtime-secret-schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { builtinAgentTools } from "./builtin-tools.js";
-import { prepareRequestSecretArguments } from "./pi-runtime.js";
+import { jsonField, prepareRequestSecretArguments } from "./pi-runtime.js";
 
 /**
  * `pi-runtime` used to re-declare `request_secret`'s parameters by hand, and the
@@ -80,5 +80,28 @@ describe("prepareRequestSecretArguments", () => {
       label: "c",
       purpose: "otp",
     });
+  });
+});
+
+describe("jsonField union handling", () => {
+  it("converts a discriminated union instead of defaulting to string", () => {
+    // BotSecretAuth converts to oneOf with no sibling `type`. Treating that as a
+    // string told the model to send `auth: "bearer"`, which the executor then
+    // rejected -- observed twice against the live deployment.
+    const authSchema = {
+      oneOf: [
+        { type: "object", properties: { type: { type: "string", const: "bearer" } } },
+        {
+          type: "object",
+          properties: { type: { type: "string", const: "header" }, name: { type: "string" } },
+        },
+      ],
+    };
+    // A string schema converts to {type:"string"}; a union must not.
+    expect((jsonField(authSchema) as { type?: string }).type).not.toBe("string");
+  });
+
+  it("still treats a plain string schema as a string", () => {
+    expect((jsonField({ type: "string" }) as { type?: string }).type).toBe("string");
   });
 });

--- a/packages/adapters/src/pi-runtime-secret-schema.test.ts
+++ b/packages/adapters/src/pi-runtime-secret-schema.test.ts
@@ -105,3 +105,19 @@ describe("jsonField union handling", () => {
     expect((jsonField({ type: "string" }) as { type?: string }).type).toBe("string");
   });
 });
+
+describe("jsonField const handling", () => {
+  it("preserves a const so the model knows the only accepted value", () => {
+    // BotSecretAuth's discriminator is {type: {type:"string", const:"bearer"}}.
+    // Degrading that to a plain string left the model guessing: recorded calls
+    // sent auth.type as "api_key" and "authorization_bearer" before this.
+    // enumUnion wraps literals, so the value lands inside a single-member union.
+    expect(JSON.stringify(jsonField({ type: "string", const: "bearer" }))).toContain(
+      '"const":"bearer"',
+    );
+  });
+
+  it("leaves a plain string alone", () => {
+    expect(JSON.stringify(jsonField({ type: "string" }))).not.toContain("const");
+  });
+});

--- a/packages/adapters/src/pi-runtime-secret-schema.test.ts
+++ b/packages/adapters/src/pi-runtime-secret-schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { builtinAgentTools } from "./builtin-tools.js";
+
+/**
+ * `pi-runtime` used to re-declare `request_secret`'s parameters by hand, and the
+ * copy omitted `credential`. The model therefore never saw the one argument that
+ * makes a credential persist: `request_secret` calls arrived with only
+ * `{label, purpose}`, the submitted value had nowhere to be stored, and the tool
+ * looked broken from the outside.
+ *
+ * These assert the canonical schema still carries what the executor requires, so
+ * a future hand-rolled override has to fail here rather than silently drop a
+ * field again.
+ */
+function toolNamed(name: string) {
+  const tool = builtinAgentTools.find((entry) => entry.name === name);
+  if (!tool) throw new Error(`missing builtin tool ${name}`);
+  return tool;
+}
+
+describe("request_secret parameters", () => {
+  it("exposes credential, because the executor only stores a value when it is present", () => {
+    const schema = toolNamed("request_secret").inputSchema as {
+      properties?: Record<string, unknown>;
+    };
+    expect(Object.keys(schema.properties ?? {})).toContain("credential");
+  });
+
+  it("describes the credential destination fields the executor validates", () => {
+    const schema = toolNamed("request_secret").inputSchema as {
+      properties?: { credential?: { properties?: Record<string, unknown> } };
+    };
+    const credential = schema.properties?.credential?.properties ?? {};
+    // normalizeSecretDestination rejects the call unless all three resolve.
+    expect(Object.keys(credential).sort()).toEqual(["auth", "name", "origin"]);
+  });
+
+  it("still offers connectionId, which is the mutually exclusive alternative", () => {
+    const schema = toolNamed("request_secret").inputSchema as {
+      properties?: Record<string, unknown>;
+    };
+    // The executor rejects a call that supplies both or neither.
+    expect(Object.keys(schema.properties ?? {})).toContain("connectionId");
+  });
+});

--- a/packages/adapters/src/pi-runtime-secret-schema.test.ts
+++ b/packages/adapters/src/pi-runtime-secret-schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { builtinAgentTools } from "./builtin-tools.js";
+import { prepareRequestSecretArguments } from "./pi-runtime.js";
 
 /**
  * `pi-runtime` used to re-declare `request_secret`'s parameters by hand, and the
@@ -42,5 +43,42 @@ describe("request_secret parameters", () => {
     };
     // The executor rejects a call that supplies both or neither.
     expect(Object.keys(schema.properties ?? {})).toContain("connectionId");
+  });
+});
+
+describe("prepareRequestSecretArguments", () => {
+  it("keeps credential, which is what makes the value persist", () => {
+    const credential = {
+      name: "github_pat",
+      origin: "https://api.github.com",
+      auth: { type: "bearer" },
+    };
+    expect(
+      prepareRequestSecretArguments({ label: "GitHub PAT", purpose: "api_key", credential }),
+    ).toEqual({ label: "GitHub PAT", purpose: "api_key", credential });
+  });
+
+  it("keeps replace, so an existing credential can be overwritten", () => {
+    const credential = { name: "x", origin: "https://api.example.com", auth: { type: "bearer" } };
+    const out = prepareRequestSecretArguments({
+      label: "x",
+      purpose: "api_key",
+      credential,
+      replace: true,
+    });
+    expect(out).toMatchObject({ replace: true, credential });
+  });
+
+  it("still passes connectionId for the connector-code path", () => {
+    const out = prepareRequestSecretArguments({ label: "c", purpose: "otp", connectionId: "abc" });
+    expect(out).toEqual({ label: "c", purpose: "otp", connectionId: "abc" });
+  });
+
+  it("omits credential and connectionId when absent rather than sending empties", () => {
+    // The executor rejects a call that carries both, so neither may be faked in.
+    expect(prepareRequestSecretArguments({ label: "c", purpose: "otp" })).toEqual({
+      label: "c",
+      purpose: "otp",
+    });
   });
 });

--- a/packages/adapters/src/pi-runtime-secret-schema.test.ts
+++ b/packages/adapters/src/pi-runtime-secret-schema.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import { builtinAgentTools } from "./builtin-tools.js";
-import { jsonField, prepareRequestSecretArguments } from "./pi-runtime.js";
+import { parseConnectorToolArgs } from "./lazy-tool-catalog.js";
+import { jsonField, jsonSchemaParameters, prepareRequestSecretArguments } from "./pi-runtime.js";
 
 /**
  * `pi-runtime` used to re-declare `request_secret`'s parameters by hand, and the
@@ -12,7 +13,8 @@ import { jsonField, prepareRequestSecretArguments } from "./pi-runtime.js";
  *
  * These assert the canonical schema still carries what the executor requires, so
  * a future hand-rolled override has to fail here rather than silently drop a
- * field again.
+ * field again — including the credential XOR connectionId exclusivity the
+ * executor enforces.
  */
 function toolNamed(name: string) {
   const tool = builtinAgentTools.find((entry) => entry.name === name);
@@ -20,42 +22,97 @@ function toolNamed(name: string) {
   return tool;
 }
 
+function requestSecretSchema() {
+  return toolNamed("request_secret").inputSchema as Record<string, unknown>;
+}
+
+function oneOfBranches(schema: Record<string, unknown>) {
+  const branches = Array.isArray(schema.oneOf) ? schema.oneOf : [];
+  return branches as Array<{
+    properties?: Record<string, { properties?: Record<string, unknown> }>;
+    required?: string[];
+  }>;
+}
+
+const sampleCredential = {
+  name: "github_pat",
+  origin: "https://api.github.com",
+  auth: { type: "bearer" },
+};
+
 describe("request_secret parameters", () => {
-  it("exposes credential, because the executor only stores a value when it is present", () => {
-    const schema = toolNamed("request_secret").inputSchema as {
-      properties?: Record<string, unknown>;
-    };
-    expect(Object.keys(schema.properties ?? {})).toContain("credential");
+  it("exposes credential on the destination branch the executor persists", () => {
+    const credentialBranch = oneOfBranches(requestSecretSchema()).find((branch) =>
+      (branch.required ?? []).includes("credential"),
+    );
+    expect(credentialBranch?.properties).toHaveProperty("credential");
   });
 
   it("describes the credential destination fields the executor validates", () => {
-    const schema = toolNamed("request_secret").inputSchema as {
-      properties?: { credential?: { properties?: Record<string, unknown> } };
-    };
-    const credential = schema.properties?.credential?.properties ?? {};
+    const credentialBranch = oneOfBranches(requestSecretSchema()).find((branch) =>
+      (branch.required ?? []).includes("credential"),
+    );
+    const credential = credentialBranch?.properties?.credential?.properties ?? {};
     // normalizeSecretDestination rejects the call unless all three resolve.
     expect(Object.keys(credential).sort()).toEqual(["auth", "name", "origin"]);
   });
 
-  it("still offers connectionId, which is the mutually exclusive alternative", () => {
-    const schema = toolNamed("request_secret").inputSchema as {
-      properties?: Record<string, unknown>;
+  it("exposes connectionId on the mutually exclusive alternative branch", () => {
+    const connectionBranch = oneOfBranches(requestSecretSchema()).find((branch) =>
+      (branch.required ?? []).includes("connectionId"),
+    );
+    expect(connectionBranch?.properties).toHaveProperty("connectionId");
+  });
+
+  it("rejects both destinations and neither, matching the executor", () => {
+    const schema = requestSecretSchema();
+    expect(() =>
+      parseConnectorToolArgs(schema, {
+        label: "GitHub PAT",
+        purpose: "api_key",
+        credential: sampleCredential,
+        connectionId: "conn_1",
+      }),
+    ).toThrow();
+    expect(() =>
+      parseConnectorToolArgs(schema, { label: "GitHub PAT", purpose: "api_key" }),
+    ).toThrow();
+    expect(
+      parseConnectorToolArgs(schema, {
+        label: "GitHub PAT",
+        purpose: "api_key",
+        credential: sampleCredential,
+      }),
+    ).toMatchObject({ credential: sampleCredential });
+    expect(
+      parseConnectorToolArgs(schema, {
+        label: "c",
+        purpose: "otp",
+        connectionId: "abc",
+      }),
+    ).toMatchObject({ connectionId: "abc" });
+  });
+
+  it("keeps exclusivity when converted for the PI model", () => {
+    const converted = jsonSchemaParameters(requestSecretSchema()) as {
+      anyOf?: unknown[];
+      oneOf?: unknown[];
     };
-    // The executor rejects a call that supplies both or neither.
-    expect(Object.keys(schema.properties ?? {})).toContain("connectionId");
+    // Type.Union serializes as anyOf; the model must still see two exclusive shapes.
+    const variants = converted.anyOf ?? converted.oneOf ?? [];
+    expect(variants.length).toBe(2);
   });
 });
 
 describe("prepareRequestSecretArguments", () => {
   it("keeps credential, which is what makes the value persist", () => {
-    const credential = {
-      name: "github_pat",
-      origin: "https://api.github.com",
-      auth: { type: "bearer" },
-    };
     expect(
-      prepareRequestSecretArguments({ label: "GitHub PAT", purpose: "api_key", credential }),
-    ).toEqual({ label: "GitHub PAT", purpose: "api_key", credential });
+      prepareRequestSecretArguments({
+        label: "GitHub PAT",
+        purpose: "api_key",
+        credential: sampleCredential,
+      }),
+    ).toEqual({ label: "GitHub PAT", purpose: "api_key", credential: sampleCredential });
   });
 
   it("keeps replace, so an existing credential can be overwritten", () => {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1124,13 +1124,6 @@ function builtinParameters(tool: ConnectorTool) {
   if (tool.name === "request_takeover") {
     return Type.Object({ reason: Type.String() });
   }
-  if (tool.name === "request_secret") {
-    return Type.Object({
-      label: Type.String(),
-      purpose: Type.Union([Type.Literal("otp"), Type.Literal("password"), Type.Literal("api_key")]),
-      connectionId: Type.Optional(Type.String()),
-    });
-  }
   if (tool.name === "ask_user") {
     return Type.Object({
       question: Type.String({ maxLength: 240 }),

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -694,6 +694,25 @@ function withoutSteeringMessages(
   return result;
 }
 
+/**
+ * Normalize `request_secret` arguments.
+ *
+ * `credential` and `replace` must survive: the executor stores a submitted value
+ * only when `credential` is present, and it validates the destination shape
+ * itself. An earlier version of this function listed only label/purpose/
+ * connectionId, so every credential the model supplied was dropped here and the
+ * saved value had nowhere to go.
+ */
+export function prepareRequestSecretArguments(raw: Record<string, unknown>) {
+  return {
+    label: String(raw.label ?? "Code"),
+    purpose: String(raw.purpose ?? "otp"),
+    ...(raw.connectionId ? { connectionId: String(raw.connectionId) } : {}),
+    ...(raw.credential ? { credential: raw.credential } : {}),
+    ...(raw.replace === true ? { replace: true } : {}),
+  };
+}
+
 function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): AgentTool {
   return {
     name: exposedName,
@@ -725,11 +744,7 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
         };
       }
       if (tool.name === "request_secret") {
-        return {
-          label: String(raw.label ?? "Code"),
-          purpose: String(raw.purpose ?? "otp"),
-          ...(raw.connectionId ? { connectionId: String(raw.connectionId) } : {}),
-        };
+        return prepareRequestSecretArguments(raw);
       }
       if (tool.name === "write_file") {
         return {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1274,11 +1274,22 @@ function enumUnion(values: readonly unknown[]) {
   return members.every((member) => member !== undefined) ? Type.Union(members) : undefined;
 }
 
-function jsonField(spec: unknown): ReturnType<typeof Type.String> {
+export function jsonField(spec: unknown): ReturnType<typeof Type.String> {
   const definition = spec && typeof spec === "object" ? (spec as Record<string, unknown>) : {};
   if (Array.isArray(definition.enum) && definition.enum.length > 0) {
     const union = enumUnion(definition.enum);
     if (union) return union as never;
+  }
+  // A discriminated union arrives as oneOf/anyOf with no sibling `type`. Without
+  // this branch it fell through to the string default, so a model was told to
+  // send an object-valued field as a bare string -- which is exactly what it did.
+  const variants = Array.isArray(definition.oneOf)
+    ? definition.oneOf
+    : Array.isArray(definition.anyOf)
+      ? definition.anyOf
+      : undefined;
+  if (variants && variants.length > 0) {
+    return Type.Union(variants.map((variant) => jsonField(variant))) as never;
   }
   const type = "type" in definition ? String(definition.type) : "string";
   if (type === "number" || type === "integer") return Type.Number() as never;

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1280,6 +1280,13 @@ export function jsonField(spec: unknown): ReturnType<typeof Type.String> {
     const union = enumUnion(definition.enum);
     if (union) return union as never;
   }
+  // A `const` names the only accepted value. Without this it degraded to a bare
+  // string, so a discriminator like {type: {const: "bearer"}} told the model
+  // nothing about which value to send -- and it guessed, twice.
+  if ("const" in definition) {
+    const literal = enumUnion([definition.const]);
+    if (literal) return literal as never;
+  }
   // A discriminated union arrives as oneOf/anyOf with no sibling `type`. Without
   // this branch it fell through to the string default, so a model was told to
   // send an object-valued field as a bare string -- which is exactly what it did.

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1248,7 +1248,9 @@ function isAgentToolExecutionResult(result: unknown): result is AgentToolExecuti
   );
 }
 
-export function jsonSchemaParameters(schema: Record<string, unknown>) {
+export function jsonSchemaParameters(
+  schema: Record<string, unknown>,
+): ReturnType<typeof Type.Object> {
   // Top-level oneOf/anyOf (e.g. request_secret's credential XOR connectionId)
   // must stay a union. Falling through to properties would drop the exclusivity
   // and re-expose both destinations as optional siblings.
@@ -1260,7 +1262,7 @@ export function jsonSchemaParameters(schema: Record<string, unknown>) {
   if (alternatives && alternatives.length > 0 && schema.properties == null) {
     return Type.Union(
       alternatives.map((variant) => jsonSchemaParameters(variant as Record<string, unknown>)),
-    );
+    ) as unknown as ReturnType<typeof Type.Object>;
   }
   const properties = (schema.properties ?? {}) as Record<string, unknown>;
   const required = new Set(Array.isArray(schema.required) ? schema.required.map(String) : []);

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1249,6 +1249,19 @@ function isAgentToolExecutionResult(result: unknown): result is AgentToolExecuti
 }
 
 export function jsonSchemaParameters(schema: Record<string, unknown>) {
+  // Top-level oneOf/anyOf (e.g. request_secret's credential XOR connectionId)
+  // must stay a union. Falling through to properties would drop the exclusivity
+  // and re-expose both destinations as optional siblings.
+  const alternatives = Array.isArray(schema.oneOf)
+    ? schema.oneOf
+    : Array.isArray(schema.anyOf)
+      ? schema.anyOf
+      : undefined;
+  if (alternatives && alternatives.length > 0 && schema.properties == null) {
+    return Type.Union(
+      alternatives.map((variant) => jsonSchemaParameters(variant as Record<string, unknown>)),
+    );
+  }
   const properties = (schema.properties ?? {}) as Record<string, unknown>;
   const required = new Set(Array.isArray(schema.required) ? schema.required.map(String) : []);
   const fields: Record<string, ReturnType<typeof Type.Optional>> = {};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Superseded by https://github.com/elie222/rakazo/pull/830 — the follow-up landed on the original fork branch `fix/tool-schema-fidelity` (`d65cf2a`).

Do not merge this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8e5da0d-003c-4f72-82e3-8157e2d59fd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8e5da0d-003c-4f72-82e3-8157e2d59fd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

