### PR TITLE
feat(web): open mobile bot sidebar with an edge swipe

### DIFF
--- a/apps/web/e2e/mobile-sidebar-swipe.spec.ts
+++ b/apps/web/e2e/mobile-sidebar-swipe.spec.ts
@@ -1,0 +1,112 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { completeOnboarding, signup } from "./helpers";
+
+test.use({
+  hasTouch: true,
+  isMobile: true,
+  viewport: { width: 390, height: 844 },
+});
+
+async function prepareOnboarding(page: Page) {
+  await page.route("**/rpc/me", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as { json: Record<string, unknown> };
+    await route.fulfill({ response, json: { json: { ...body.json, needsModel: false } } });
+  });
+  await page.route("**/rpc/integrationSetup/get", (route) =>
+    route.fulfill({
+      json: {
+        json: {
+          canConfigure: false,
+          needsSetup: false,
+          providers: [],
+          webUrl: "https://example.test/integrations/setup",
+        },
+      },
+    }),
+  );
+}
+
+async function swipe(page: Page, start: [number, number], end: [number, number]) {
+  await page.getByTestId("shell-root").evaluate(
+    (shell, { start, end }) => {
+      function touch([clientX, clientY]: [number, number]) {
+        return new Touch({ clientX, clientY, identifier: 1, target: shell });
+      }
+      const first = touch(start);
+      shell.dispatchEvent(
+        new TouchEvent("touchstart", {
+          bubbles: true,
+          cancelable: true,
+          changedTouches: [first],
+          touches: [first],
+        }),
+      );
+      const last = touch(end);
+      shell.dispatchEvent(
+        new TouchEvent("touchend", {
+          bubbles: true,
+          cancelable: true,
+          changedTouches: [last],
+          touches: [],
+        }),
+      );
+    },
+    { start, end },
+  );
+}
+
+test("swiping inward from the mobile edge opens the bots sidebar", async ({ page }) => {
+  await prepareOnboarding(page);
+  const stamp = Date.now();
+  await signup(page, `mobile-sidebar-swipe-${stamp}@rakazo.test`, "password12", "Swipe Test");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  const closeNavigation = page.getByRole("button", { name: "Close navigation" });
+  await expect(closeNavigation).toHaveCount(0);
+  await expect(page.getByTestId("mobile-sidebar-swipe-edge")).toHaveCSS("touch-action", "none");
+
+  await swipe(page, [16, 420], [92, 426]);
+
+  await expect(closeNavigation).toBeVisible();
+  await expect(page.getByTestId("mobile-sidebar-swipe-edge")).toHaveCount(0);
+  await expect(page.getByTestId("bots-sidebar")).toContainText("Chief");
+});
+
+test("the mobile edge swipe follows right-to-left layout direction", async ({ page }) => {
+  await prepareOnboarding(page);
+  const stamp = Date.now();
+  await signup(page, `mobile-sidebar-rtl-${stamp}@rakazo.test`, "password12", "Swipe Test");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+  await page.locator("html").evaluate((html) => html.setAttribute("dir", "rtl"));
+
+  const edge = page.getByTestId("mobile-sidebar-swipe-edge");
+  const edgeBox = await edge.boundingBox();
+  expect(edgeBox?.x).toBeGreaterThan(350);
+
+  await swipe(page, [374, 420], [298, 426]);
+
+  await expect(page.getByRole("button", { name: "Close navigation" })).toBeVisible();
+  await expect(page.getByTestId("bots-sidebar")).toContainText("Chief");
+});
+
+test("vertical and non-edge swipes leave the mobile sidebar closed", async ({ page }) => {
+  await prepareOnboarding(page);
+  const stamp = Date.now();
+  await signup(page, `mobile-sidebar-ignore-${stamp}@rakazo.test`, "password12", "Swipe Test");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  const closeNavigation = page.getByRole("button", { name: "Close navigation" });
+  await swipe(page, [16, 420], [35, 510]);
+  await expect(closeNavigation).toHaveCount(0);
+
+  await swipe(page, [120, 420], [205, 424]);
+  await expect(closeNavigation).toHaveCount(0);
+});

--- a/apps/web/e2e/mobile-sidebar-swipe.spec.ts
+++ b/apps/web/e2e/mobile-sidebar-swipe.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
-import { completeOnboarding, signup } from "./helpers";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
 
 test.use({
   hasTouch: true,
@@ -57,7 +57,7 @@ async function swipe(page: Page, start: [number, number], end: [number, number])
   );
 }
 
-test("swiping inward from the mobile edge opens the bots sidebar", async ({ page }) => {
+test("swiping inward from the mobile edge opens the bots sidebar", async ({ page }, testInfo) => {
   await prepareOnboarding(page);
   const stamp = Date.now();
   await signup(page, `mobile-sidebar-swipe-${stamp}@rakazo.test`, "password12", "Swipe Test");
@@ -74,6 +74,7 @@ test("swiping inward from the mobile edge opens the bots sidebar", async ({ page
   await expect(closeNavigation).toBeVisible();
   await expect(page.getByTestId("mobile-sidebar-swipe-edge")).toHaveCount(0);
   await expect(page.getByTestId("bots-sidebar")).toContainText("Chief");
+  await captureScreenshot(page, testInfo, "mobile-sidebar-edge-swipe-open");
 });
 
 test("the mobile edge swipe follows right-to-left layout direction", async ({ page }) => {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2468,7 +2468,14 @@ export function ShellPage() {
         const swipe = mobileSidebarSwipeRef.current;
         mobileSidebarSwipeRef.current = null;
         const touch = event.changedTouches[0];
-        if (!swipe || !touch) return;
+        if (
+          !swipe ||
+          !touch ||
+          mobileSidebarOpen ||
+          window.matchMedia("(min-width: 768px)").matches
+        ) {
+          return;
+        }
         const rtl = document.documentElement.getAttribute("dir") === "rtl";
         const horizontal = rtl ? swipe.startX - touch.clientX : touch.clientX - swipe.startX;
         const vertical = Math.abs(touch.clientY - swipe.startY);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -276,6 +276,8 @@ const FALLBACK_BOT_COLOR = "#85858A";
 const THREAD_SNAPSHOT_TIMEOUT_MS = 2_000;
 /** Bound Settings leave so a hung voice status refresh cannot block dismissal. */
 const VOICE_STATUS_REFRESH_TIMEOUT_MS = 10_000;
+const MOBILE_SIDEBAR_SWIPE_EDGE_PX = 32;
+const MOBILE_SIDEBAR_SWIPE_DISTANCE_PX = 56;
 
 function threadSnapshotSignal(parent: AbortSignal): AbortSignal {
   return AbortSignal.any([parent, AbortSignal.timeout(THREAD_SNAPSHOT_TIMEOUT_MS)]);
@@ -439,6 +441,7 @@ export function ShellPage() {
     useState<ReadonlySet<string>>(readSeenRunErrorIds);
   const [menuOpen, setMenuOpen] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const mobileSidebarSwipeRef = useRef<{ startX: number; startY: number } | null>(null);
   const [draggedBotId, setDraggedBotId] = useState<string | null>(null);
   const [createMenuOpen, setCreateMenuOpen] = useState(false);
   const [botsSidebarCollapsed, setBotsSidebarCollapsed] = useState(false);
@@ -2442,6 +2445,40 @@ export function ShellPage() {
       data-testid="shell-root"
       data-ready={shellReady}
       className="relative flex h-full min-w-0 overflow-hidden bg-background text-foreground/90"
+      onTouchStartCapture={(event) => {
+        if (
+          mobileSidebarOpen ||
+          event.touches.length !== 1 ||
+          window.matchMedia("(min-width: 768px)").matches
+        ) {
+          mobileSidebarSwipeRef.current = null;
+          return;
+        }
+        const touch = event.touches[0];
+        if (!touch) return;
+        const rtl = document.documentElement.getAttribute("dir") === "rtl";
+        const startsAtEdge = rtl
+          ? touch.clientX >= window.innerWidth - MOBILE_SIDEBAR_SWIPE_EDGE_PX
+          : touch.clientX <= MOBILE_SIDEBAR_SWIPE_EDGE_PX;
+        mobileSidebarSwipeRef.current = startsAtEdge
+          ? { startX: touch.clientX, startY: touch.clientY }
+          : null;
+      }}
+      onTouchEndCapture={(event) => {
+        const swipe = mobileSidebarSwipeRef.current;
+        mobileSidebarSwipeRef.current = null;
+        const touch = event.changedTouches[0];
+        if (!swipe || !touch) return;
+        const rtl = document.documentElement.getAttribute("dir") === "rtl";
+        const horizontal = rtl ? swipe.startX - touch.clientX : touch.clientX - swipe.startX;
+        const vertical = Math.abs(touch.clientY - swipe.startY);
+        if (horizontal >= MOBILE_SIDEBAR_SWIPE_DISTANCE_PX && horizontal > vertical * 1.25) {
+          setMobileSidebarOpen(true);
+        }
+      }}
+      onTouchCancelCapture={() => {
+        mobileSidebarSwipeRef.current = null;
+      }}
     >
       <ComputerUpdateProgress
         onCompleted={() => {
@@ -2457,6 +2494,13 @@ export function ShellPage() {
           aria-label={t`Close navigation`}
           onClick={() => setMobileSidebarOpen(false)}
           className="absolute inset-y-0 end-0 start-[min(calc(100%-48px),316px)] z-30 bg-overlay md:hidden"
+        />
+      ) : null}
+      {!mobileSidebarOpen ? (
+        <div
+          data-testid="mobile-sidebar-swipe-edge"
+          aria-hidden="true"
+          className="absolute bottom-20 start-0 top-16 z-20 w-8 touch-none md:hidden"
         />
       ) : null}
       <aside


### PR DESCRIPTION
## Why

On mobile, opening the bot list currently requires reaching for the menu button. An inward swipe from the screen edge should open the same navigation drawer while leaving normal chat scrolling alone.

## What changed

- Open the existing mobile bot sidebar after a deliberate inward swipe from the leading screen edge.
- Ignore vertical gestures and swipes that begin away from the edge.
- Reserve only the narrow edge gesture area so the chat does not scroll underneath the swipe.
- Mirror the gesture for right-to-left layouts.

No new user-facing copy is added.

## Testing

- Web typecheck passes.
- Biome checks pass for the changed files.
- Mobile Playwright coverage verifies the successful edge swipe, ignored vertical and non-edge swipes, and the non-scrolling edge touch behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mobile swipe gestures for opening the sidebar from the screen edge.
  - Supports both left-to-right and right-to-left layouts.
  - Vertical and non-edge swipes do not open the sidebar.
  - Gesture support is limited to mobile-sized screens; desktop navigation remains unchanged.

- **Tests**
  - Added automated coverage for valid edge swipes, layout direction, and invalid swipe gestures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->