### PR TITLE
chore(copy): cut leftover em dashes

### DIFF
--- a/apps/api/src/messaging-inbound.test.ts
+++ b/apps/api/src/messaging-inbound.test.ts
@@ -1319,7 +1319,7 @@ describe("createMessagingInboundHandler linking", () => {
         idempotencyKey: "link:code-1",
         kind: "dm",
         identityId: "mi-linked",
-        body: 'Linked — messages here now reach "Chief".',
+        body: 'Linked. Messages here now reach "Chief".',
       }),
     ]);
   });

--- a/apps/api/src/messaging-inbound.ts
+++ b/apps/api/src/messaging-inbound.ts
@@ -318,7 +318,7 @@ async function tryRedeemLinkCode(
     deps,
     { id: redeemed.identityId },
     redeemed.confirmationKey,
-    `Linked — messages here now reach "${bot?.name ?? "your agent"}".`,
+    `Linked. Messages here now reach "${bot?.name ?? "your agent"}".`,
   );
   return true;
 }

--- a/apps/mobile/lib/locales/ru.ts
+++ b/apps/mobile/lib/locales/ru.ts
@@ -374,7 +374,7 @@ export const RU_MESSAGES: Record<string, string> = {
   Pin: "Закрепить",
   "Please try again.": "Повторите попытку.",
   "Point this app at your self-hosted Rakazo origin, the same HTTPS URL you open in a browser.":
-    "Направьте это приложение на свой собственный источник Rakazo — тот же URL-адрес HTTPS, который вы открываете в браузере.",
+    "Направьте это приложение на свой собственный источник Rakazo, тот же URL-адрес HTTPS, который вы открываете в браузере.",
   Private: "Личный",
   Providers: "Провайдеры",
   "Public servers need https://. HTTP only works on your local network.":

--- a/apps/web/scripts/translations-de.json
+++ b/apps/web/scripts/translations-de.json
@@ -70,7 +70,6 @@
   "Answered: {answer}": "Beantwortet: {answer}",
   "API key": "API-Schlüssel",
   "API key header": "API-Schlüssel-Header",
-  "Applies when you click Add server. Use the agent chips on each server card to change access at any time — the agent picks it up on its next message.": "Gilt beim Hinzufügen des Servers. Mit den Agent-Chips auf jeder Serverkarte kannst du den Zugriff jederzeit ändern. Der Agent übernimmt die Änderung mit seiner nächsten Nachricht.",
   "Approval boundaries": "Bestätigungsgrenzen",
   "Approve": "Genehmigen",
   "Approve this server to let your agent use its tools.": "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann.",

--- a/apps/web/scripts/translations-hi.json
+++ b/apps/web/scripts/translations-hi.json
@@ -64,7 +64,6 @@
   "Answered: {answer}": "उत्तर: {answer}",
   "API key": "API कुंजी",
   "API key header": "API कुंजी हेडर",
-  "Applies when you click Add server. Use the agent chips on each server card to change access at any time — the agent picks it up on its next message.": "यह तब लागू होता है जब आप 'सर्वर जोड़ें' पर क्लिक करते हैं। एक्सेस कभी भी बदलने के लिए हर सर्वर कार्ड पर एजेंट चिप का उपयोग करें — एजेंट इसे अपने अगले संदेश पर अपना लेगा।",
   "Approval boundaries": "अनुमोदन सीमाएं",
   "Approve": "अनुमोदित करें",
   "Approve this server to let your agent use its tools.": "अपने एजेंट को इसके टूल उपयोग करने देने के लिए इस सर्वर को अनुमोदित करें।",

--- a/apps/web/scripts/translations-ko.json
+++ b/apps/web/scripts/translations-ko.json
@@ -70,7 +70,6 @@
   "Answered: {answer}": "응답: {answer}",
   "API key": "API 키",
   "API key header": "API 키 헤더",
-  "Applies when you click Add server. Use the agent chips on each server card to change access at any time — the agent picks it up on its next message.": "서버를 추가할 때 적용됩니다. 각 서버 카드의 Bot 버튼으로 언제든 권한을 바꿀 수 있으며 다음 메시지부터 반영됩니다.",
   "Approval boundaries": "승인이 필요한 범위",
   "Approve": "승인",
   "Approve this server to let your agent use its tools.": "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 있습니다.",

--- a/apps/web/scripts/translations-pt-BR.json
+++ b/apps/web/scripts/translations-pt-BR.json
@@ -64,7 +64,6 @@
   "Answered: {answer}": "Respondido: {answer}",
   "API key": "Chave de API",
   "API key header": "Cabeçalho da chave API",
-  "Applies when you click Add server. Use the agent chips on each server card to change access at any time — the agent picks it up on its next message.": "Aplica-se quando você clica em Adicionar servidor. Use os chips do agente em cada placa do servidor para alterar o acesso a qualquer momento — o agente o pega na próxima mensagem.",
   "Approval boundaries": "Limites de aprovação",
   "Approve": "Aprovar",
   "Approve this server to let your agent use its tools.": "Aprove este servidor para permitir que seu agente use suas ferramentas.",

--- a/apps/web/scripts/translations-tr.json
+++ b/apps/web/scripts/translations-tr.json
@@ -64,7 +64,6 @@
   "Answered: {answer}": "Yanıtlandı: {answer}",
   "API key": "API anahtarı",
   "API key header": "API anahtarı üstbilgisi",
-  "Applies when you click Add server. Use the agent chips on each server card to change access at any time — the agent picks it up on its next message.": "Sunucu ekle'ye tıkladığında uygulanır. Erişimi istediğin zaman değiştirmek için her sunucu kartındaki agent çiplerini kullan — agent bunu bir sonraki mesajında algılar.",
   "Approval boundaries": "Onay sınırları",
   "Approve": "Onayla",
   "Approve this server to let your agent use its tools.": "Agent'ının bu sunucunun araçlarını kullanabilmesi için sunucuyu onayla.",

--- a/apps/web/scripts/translations-zh-CN.json
+++ b/apps/web/scripts/translations-zh-CN.json
@@ -70,7 +70,6 @@
   "Answered: {answer}": "已回答：{answer}",
   "API key": "API 密钥",
   "API key header": "API 密钥请求头",
-  "Applies when you click Add server. Use the agent chips on each server card to change access at any time — the agent picks it up on its next message.": "在点击「添加服务器」时生效。可随时用每张服务器卡片上的 Agent 标签改权限，Agent 会在下一条消息时采用。",
   "Approval boundaries": "审批边界",
   "Approve": "批准",
   "Approve this server to let your agent use its tools.": "批准此服务器后，Agent 才能使用它的工具。",

--- a/packages/adapters/src/cartesia-voice.ts
+++ b/packages/adapters/src/cartesia-voice.ts
@@ -49,7 +49,7 @@ export class CartesiaVoiceProvider implements VoiceProvider {
     } catch {
       return {
         ok: false,
-        message: "Couldn't reach Cartesia to check that key — check your connection.",
+        message: "Couldn't reach Cartesia to check that key. Check your connection.",
       };
     }
   }

--- a/packages/adapters/src/cartesia-voice.ts
+++ b/packages/adapters/src/cartesia-voice.ts
@@ -14,6 +14,7 @@ import {
   requireOk,
   voiceDeadline,
   voiceHttpError,
+  voiceUnreachable,
 } from "./voice-http.js";
 
 const API = "https://api.cartesia.ai";
@@ -49,7 +50,7 @@ export class CartesiaVoiceProvider implements VoiceProvider {
     } catch {
       return {
         ok: false,
-        message: "Couldn't reach Cartesia to check that key. Check your connection.",
+        message: voiceUnreachable("Cartesia"),
       };
     }
   }

--- a/packages/adapters/src/elevenlabs-voice.ts
+++ b/packages/adapters/src/elevenlabs-voice.ts
@@ -16,6 +16,7 @@ import {
   speechUploadName,
   voiceDeadline,
   voiceHttpError,
+  voiceUnreachable,
 } from "./voice-http.js";
 
 const API = "https://api.elevenlabs.io/v1";
@@ -52,7 +53,7 @@ export class ElevenLabsVoiceProvider implements VoiceProvider {
     } catch {
       return {
         ok: false,
-        message: "Couldn't reach ElevenLabs to check that key. Check your connection.",
+        message: voiceUnreachable("ElevenLabs"),
       };
     }
   }

--- a/packages/adapters/src/elevenlabs-voice.ts
+++ b/packages/adapters/src/elevenlabs-voice.ts
@@ -52,7 +52,7 @@ export class ElevenLabsVoiceProvider implements VoiceProvider {
     } catch {
       return {
         ok: false,
-        message: "Couldn't reach ElevenLabs to check that key — check your connection.",
+        message: "Couldn't reach ElevenLabs to check that key. Check your connection.",
       };
     }
   }

--- a/packages/adapters/src/fish-audio-voice.ts
+++ b/packages/adapters/src/fish-audio-voice.ts
@@ -16,6 +16,7 @@ import {
   speechUploadName,
   voiceDeadline,
   voiceHttpError,
+  voiceUnreachable,
 } from "./voice-http.js";
 
 const API = "https://api.fish.audio";
@@ -58,7 +59,7 @@ export class FishAudioVoiceProvider implements VoiceProvider {
     } catch {
       return {
         ok: false,
-        message: "Couldn't reach Fish Audio to check that key. Check your connection.",
+        message: voiceUnreachable("Fish Audio"),
       };
     }
   }

--- a/packages/adapters/src/fish-audio-voice.ts
+++ b/packages/adapters/src/fish-audio-voice.ts
@@ -58,7 +58,7 @@ export class FishAudioVoiceProvider implements VoiceProvider {
     } catch {
       return {
         ok: false,
-        message: "Couldn't reach Fish Audio to check that key — check your connection.",
+        message: "Couldn't reach Fish Audio to check that key. Check your connection.",
       };
     }
   }

--- a/packages/adapters/src/openai-voice.ts
+++ b/packages/adapters/src/openai-voice.ts
@@ -65,7 +65,7 @@ export class OpenAIVoiceProvider implements VoiceProvider {
     } catch {
       return {
         ok: false,
-        message: "Couldn't reach OpenAI to check that key — check your connection.",
+        message: "Couldn't reach OpenAI to check that key. Check your connection.",
       };
     }
   }

--- a/packages/adapters/src/openai-voice.ts
+++ b/packages/adapters/src/openai-voice.ts
@@ -16,6 +16,7 @@ import {
   speechUploadName,
   voiceDeadline,
   voiceHttpError,
+  voiceUnreachable,
 } from "./voice-http.js";
 
 const API = "https://api.openai.com/v1";
@@ -65,7 +66,7 @@ export class OpenAIVoiceProvider implements VoiceProvider {
     } catch {
       return {
         ok: false,
-        message: "Couldn't reach OpenAI to check that key. Check your connection.",
+        message: voiceUnreachable("OpenAI"),
       };
     }
   }

--- a/packages/adapters/src/voice-http.ts
+++ b/packages/adapters/src/voice-http.ts
@@ -94,6 +94,10 @@ function detail(body: unknown): string {
   return "";
 }
 
+export function voiceUnreachable(provider: string): string {
+  return `Couldn't reach ${provider} to check that key. Check your connection.`;
+}
+
 export function voiceHttpError(
   status: number,
   provider: string,

--- a/packages/adapters/src/voice-http.ts
+++ b/packages/adapters/src/voice-http.ts
@@ -105,7 +105,7 @@ export function voiceHttpError(
     return `${provider} rejected that key. Check the key and that it has speech permissions.`;
   }
   if (status === 429)
-    return theirs || `${provider} is rate-limiting this account — wait a moment and try again.`;
+    return theirs || `${provider} is rate-limiting this account. Wait a moment and try again.`;
   if (status === 402) return theirs || `${provider} says this account is out of credit.`;
   return theirs ? `${what} failed: ${theirs}` : `${what} failed (${status})`;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Weekday copy tidy — string/error copy only; no UI screenshots needed.

- DRY voice key-check unreachable copy via `voiceUnreachable()` next to `voiceHttpError`; drop the em dash in the shared rate-limit string.
- Replace the em dash in the chat-app link confirmation DM (`Linked. Messages here…`) and update the matching test assertion.
- Rewrite the Russian mobile self-host origin string to use a comma instead of an em dash; drop orphan “Applies when you click Add server…” translation cache entries from six locale JSON files.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76d79dd0-c47e-44d2-8179-e2913be8aba7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76d79dd0-c47e-44d2-8179-e2913be8aba7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

