### PR TITLE
fix(web): clearer Lucide Brain icon for Settings Memory nav

### DIFF
--- a/apps/web/src/pages/SettingsOverlay.tsx
+++ b/apps/web/src/pages/SettingsOverlay.tsx
@@ -2,9 +2,9 @@ import { useLingui } from "@lingui/react/macro";
 import type { AvatarStyle, SpaceMemoryConfig } from "@rakazo/contracts";
 import { Button, Dialog, DialogClose, DialogContent, DialogTitle } from "@rakazo/ui-web";
 import {
+  Brain,
   CloudDownload,
   Cpu,
-  Diamond,
   Gauge,
   Monitor,
   Settings,
@@ -91,7 +91,7 @@ export function SettingsOverlay({
   const navItems: NavItem[] = [
     { id: "general", label: t`General`, icon: Settings },
     { id: "models", label: t`Models`, icon: Cpu },
-    { id: "memory", label: t`Memory`, icon: Diamond },
+    { id: "memory", label: t`Memory`, icon: Brain },
     { id: "voice", label: t`Voice`, icon: Volume2 },
     { id: "usage", label: t`Usage`, icon: Gauge },
     ...(showComputer ? [{ id: "computer" as const, label: t`Computer`, icon: Monitor }] : []),

--- a/apps/web/src/pages/SettingsOverlay.tsx
+++ b/apps/web/src/pages/SettingsOverlay.tsx
@@ -1,16 +1,7 @@
 import { useLingui } from "@lingui/react/macro";
 import type { AvatarStyle, SpaceMemoryConfig } from "@rakazo/contracts";
 import { Button, Dialog, DialogClose, DialogContent, DialogTitle } from "@rakazo/ui-web";
-import {
-  Brain,
-  CloudDownload,
-  Cpu,
-  Gauge,
-  Monitor,
-  Settings,
-  Volume2,
-  XIcon,
-} from "lucide-react";
+import { Brain, CloudDownload, Cpu, Gauge, Monitor, Settings, Volume2, XIcon } from "lucide-react";
 import { type ComponentType, useEffect, useRef, useState } from "react";
 import { computersAreUnavailable } from "../components/ComputersUnavailableHint";
 import {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The Settings left-nav Memory row used Lucide `Diamond`, which reads as a gem rather than durable/semantic memory. The rest of the nav already uses literal Lucide glyphs (`Settings`, `Cpu`, `Volume2`, `Gauge`, `CloudDownload`); Memory was the outlier.

## What changed

- Replaced Memory’s `Diamond` with `Brain` in `SettingsOverlay` (same `size-4` / `strokeWidth={1.75}` as siblings).
- Left the other nav icons unchanged; they already read clearly next to `Brain`.

No new user-facing copy.

## How tested

- `pnpm exec biome check apps/web/src/pages/SettingsOverlay.tsx` passes.
- Existing `settings-shell` E2E opens the Settings nav and captures frames that show the icons. CI frames:
  - [settings-shell-general](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34501377540-1/screenshots/images/224-settings-shell-general.png) (nav with Brain on Memory)
  - [settings-shell-memory](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34501377540-1/screenshots/images/225-settings-shell-memory.png) (Memory selected)
  - [gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/842/index.html)

## Notes

- Lucide only; no icon library churn.
- Smallest correct fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fee81c84-43e8-48a3-b477-d083e94825c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fee81c84-43e8-48a3-b477-d083e94825c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the Settings overlay’s Memory section icon from a diamond to a brain symbol, providing a more recognizable visual indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->