### PR TITLE
feat(mobile): show store version and OTA identity on account

### DIFF
--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -26,6 +26,7 @@ import {
   selectedSpaceId,
   signOut,
 } from "../lib/api";
+import { formatUpdateLabel, getAppVersionInfo } from "../lib/app-version";
 import {
   getCachedAppearancePreference,
   mobileTokens,
@@ -75,6 +76,9 @@ export default function Account() {
   const { avatarStyle, updateAvatarStyle } = useAvatarStyle();
   const appearance = getCachedAppearancePreference();
   const styles = useThemedStyles(createAccountStyles);
+  const versionInfo = getAppVersionInfo();
+  const updateLabel = formatUpdateLabel(versionInfo.update, t);
+  const versionAccessibility = [versionInfo.nativeLabel, updateLabel].filter(Boolean).join(". ");
 
   useEffect(() => {
     void rpc<MobileMe>("me")
@@ -471,6 +475,19 @@ export default function Account() {
           </View>
         ) : null}
 
+        {versionInfo.nativeLabel || updateLabel ? (
+          <View
+            accessibilityLabel={versionAccessibility}
+            accessibilityRole="summary"
+            style={styles.versionFooter}
+          >
+            {versionInfo.nativeLabel ? (
+              <Text style={styles.versionLine}>{versionInfo.nativeLabel}</Text>
+            ) : null}
+            {updateLabel ? <Text style={styles.versionLine}>{updateLabel}</Text> : null}
+          </View>
+        ) : null}
+
         <View style={styles.dangerZone}>
           <Text style={styles.dangerTitle}>{t("Delete account")}</Text>
           <Text style={styles.explanation}>
@@ -709,6 +726,16 @@ function createAccountStyles() {
       color: native.secondaryLabel,
       fontSize: 28,
       fontWeight: "300",
+    },
+    versionFooter: {
+      marginTop: 4,
+      alignItems: "center",
+      gap: 2,
+    },
+    versionLine: {
+      color: native.tertiaryLabel,
+      fontSize: 12,
+      textAlign: "center",
     },
     dangerZone: {
       marginTop: 12,

--- a/apps/mobile/lib/app-version.test.ts
+++ b/apps/mobile/lib/app-version.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const application = vi.hoisted(() => ({
+  nativeApplicationVersion: null as string | null,
+  nativeBuildVersion: null as string | null,
+}));
+
+const updates = vi.hoisted(() => ({
+  isEnabled: false,
+  isEmbeddedLaunch: true,
+  updateId: null as string | null,
+  channel: null as string | null,
+  createdAt: null as Date | null,
+}));
+
+const constants = vi.hoisted(() => ({
+  expoConfig: { version: "1.0.3" } as { version?: string } | null,
+  platform: {
+    ios: { buildNumber: "1" },
+    android: { versionCode: 10 },
+  } as {
+    ios?: { buildNumber: string | null };
+    android?: { versionCode: number };
+  },
+}));
+
+vi.mock("expo-application", () => application);
+vi.mock("expo-updates", () => updates);
+vi.mock("expo-constants", () => ({ default: constants }));
+vi.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+
+afterEach(() => {
+  application.nativeApplicationVersion = null;
+  application.nativeBuildVersion = null;
+  updates.isEnabled = false;
+  updates.isEmbeddedLaunch = true;
+  updates.updateId = null;
+  updates.channel = null;
+  updates.createdAt = null;
+  constants.expoConfig = { version: "1.0.3" };
+  constants.platform = {
+    ios: { buildNumber: "1" },
+    android: { versionCode: 10 },
+  };
+  vi.resetModules();
+});
+
+describe("app version footer helpers", () => {
+  it("formats native version with and without build", async () => {
+    const { formatNativeVersionLabel, shortUpdateId } = await import("./app-version");
+    expect(formatNativeVersionLabel("1.0.3", "10")).toBe("1.0.3 (10)");
+    expect(formatNativeVersionLabel("1.0.3", null)).toBe("1.0.3");
+    expect(formatNativeVersionLabel(null, "10")).toBe("10");
+    expect(formatNativeVersionLabel("  ", "  ")).toBeNull();
+    expect(shortUpdateId("A1B2C3D4-E5F6-7890-ABCD-EF1234567890")).toBe("a1b2c3d4");
+  });
+
+  it("prefers expo-application values and labels embedded updates", async () => {
+    application.nativeApplicationVersion = "1.0.3";
+    application.nativeBuildVersion = "12";
+    updates.isEnabled = true;
+    updates.isEmbeddedLaunch = true;
+    const { formatUpdateLabel, getAppVersionInfo } = await import("./app-version");
+    const info = getAppVersionInfo();
+    expect(info.nativeLabel).toBe("1.0.3 (12)");
+    expect(info.update).toEqual({ kind: "embedded" });
+    expect(formatUpdateLabel(info.update, (message) => message)).toBe("Embedded");
+  });
+
+  it("falls back to Constants when Application is empty", async () => {
+    const { getAppVersionInfo } = await import("./app-version");
+    expect(getAppVersionInfo().nativeLabel).toBe("1.0.3 (1)");
+  });
+
+  it("summarizes an OTA update with channel and date", async () => {
+    application.nativeApplicationVersion = "1.0.3";
+    application.nativeBuildVersion = "12";
+    updates.isEnabled = true;
+    updates.isEmbeddedLaunch = false;
+    updates.updateId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    updates.channel = "production";
+    updates.createdAt = new Date("2026-09-10T12:00:00.000Z");
+    const { formatUpdateLabel, getAppVersionInfo } = await import("./app-version");
+    const info = getAppVersionInfo();
+    expect(info.update).toEqual({
+      kind: "ota",
+      id: "a1b2c3d4",
+      channel: "production",
+      createdAt: "2026-09-10",
+    });
+    expect(
+      formatUpdateLabel(info.update, (message, values) => {
+        if (!values) return message;
+        return message.replace(/\{([A-Za-z0-9_]+)\}/g, (match, key: string) =>
+          Object.hasOwn(values, key) ? String(values[key]) : match,
+        );
+      }),
+    ).toBe("production · a1b2c3d4 · 2026-09-10");
+  });
+
+  it("treats disabled updates as embedded", async () => {
+    updates.isEnabled = false;
+    updates.isEmbeddedLaunch = false;
+    updates.updateId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    const { getAppVersionInfo } = await import("./app-version");
+    expect(getAppVersionInfo().update).toEqual({ kind: "embedded" });
+  });
+});

--- a/apps/mobile/lib/app-version.ts
+++ b/apps/mobile/lib/app-version.ts
@@ -1,0 +1,108 @@
+import * as Application from "expo-application";
+import Constants from "expo-constants";
+import * as Updates from "expo-updates";
+import { Platform } from "react-native";
+
+export type AppUpdateIdentity =
+  | { kind: "embedded" }
+  | {
+      kind: "ota";
+      /** Short hex fragment of the running update id. */
+      id: string;
+      channel: string | null;
+      /** ISO date (YYYY-MM-DD) when the update was created, if known. */
+      createdAt: string | null;
+    };
+
+export type AppVersionInfo = {
+  /** Store / native binary version, e.g. `1.0.3 (10)`. */
+  nativeLabel: string | null;
+  update: AppUpdateIdentity;
+};
+
+type Translate = (message: string, values?: Record<string, string | number>) => string;
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function fallbackNativeVersion(): { version: string | null; build: string | null } {
+  const version = readString(Constants.expoConfig?.version);
+  if (Platform.OS === "ios") {
+    return { version, build: readString(Constants.platform?.ios?.buildNumber) };
+  }
+  if (Platform.OS === "android") {
+    const code = Constants.platform?.android?.versionCode;
+    return { version, build: code != null ? String(code) : null };
+  }
+  return { version, build: null };
+}
+
+/** Format store version + build as `1.0.3 (10)`, or either part alone. */
+export function formatNativeVersionLabel(
+  applicationVersion: string | null | undefined,
+  buildVersion: string | null | undefined,
+): string | null {
+  const version = readString(applicationVersion);
+  const build = readString(buildVersion);
+  if (version && build) return `${version} (${build})`;
+  return version ?? build;
+}
+
+/** Shorten a UUID update id for footer display. */
+export function shortUpdateId(updateId: string): string {
+  const compact = updateId.replace(/-/g, "").toLowerCase();
+  return compact.slice(0, 8) || updateId.slice(0, 8);
+}
+
+function formatCreatedAt(value: unknown): string | null {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) return null;
+  return value.toISOString().slice(0, 10);
+}
+
+function resolveUpdateIdentity(): AppUpdateIdentity {
+  try {
+    if (!Updates.isEnabled || Updates.isEmbeddedLaunch) return { kind: "embedded" };
+    const rawId = readString(Updates.updateId);
+    if (!rawId) return { kind: "embedded" };
+    return {
+      kind: "ota",
+      id: shortUpdateId(rawId),
+      channel: readString(Updates.channel),
+      createdAt: formatCreatedAt(Updates.createdAt),
+    };
+  } catch {
+    // Expo Go, web, and some simulators expose a stub that still throws on access.
+    return { kind: "embedded" };
+  }
+}
+
+/** Human update line for the account footer (English source strings for i18n). */
+export function formatUpdateLabel(update: AppUpdateIdentity, t: Translate): string {
+  if (update.kind === "embedded") return t("Embedded");
+  const { id, channel, createdAt } = update;
+  if (channel && createdAt) return t("{channel} · {id} · {date}", { channel, id, date: createdAt });
+  if (channel) return t("{channel} · {id}", { channel, id });
+  if (createdAt) return t("OTA · {id} · {date}", { id, date: createdAt });
+  return t("OTA · {id}", { id });
+}
+
+/** Read native store version and OTA identity for the account footer. */
+export function getAppVersionInfo(): AppVersionInfo {
+  let applicationVersion: string | null = null;
+  let buildVersion: string | null = null;
+  try {
+    applicationVersion = readString(Application.nativeApplicationVersion);
+    buildVersion = readString(Application.nativeBuildVersion);
+  } catch {
+    // Hosts without the native module still get the expo config fallback below.
+  }
+  const fallback = fallbackNativeVersion();
+  return {
+    nativeLabel: formatNativeVersionLabel(
+      applicationVersion ?? fallback.version,
+      buildVersion ?? fallback.build,
+    ),
+    update: resolveUpdateIdentity(),
+  };
+}

--- a/apps/mobile/lib/locales/ru.ts
+++ b/apps/mobile/lib/locales/ru.ts
@@ -260,6 +260,11 @@ export const RU_MESSAGES: Record<string, string> = {
   "Don’t have an account?": "Нет аккаунта?",
   Done: "Готово",
   Email: "Электронная почта",
+  Embedded: "Встроенная",
+  "{channel} · {id}": "{channel} · {id}",
+  "{channel} · {id} · {date}": "{channel} · {id} · {date}",
+  "OTA · {id}": "OTA · {id}",
+  "OTA · {id} · {date}": "OTA · {id} · {date}",
   "Enter a server URL": "Введите URL-адрес сервера",
   "Enter this code in your browser:": "Введите этот код в браузере:",
   "Enter your current password, then confirm permanent deletion of your account and all associated data.":

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -243,6 +243,11 @@ export const ZH_MESSAGES: Record<string, string> = {
   "Don’t have an account?": "还没有账户？",
   Done: "完成",
   Email: "邮箱",
+  Embedded: "内置",
+  "{channel} · {id}": "{channel} · {id}",
+  "{channel} · {id} · {date}": "{channel} · {id} · {date}",
+  "OTA · {id}": "OTA · {id}",
+  "OTA · {id} · {date}": "OTA · {id} · {date}",
   "Enter a server URL": "请输入服务器地址",
   "Enter this code in your browser:": "请在浏览器中输入此代码：",
   "Enter your current password, then confirm permanent deletion of your account and all associated data.":

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,6 +25,7 @@
     "@react-native-vector-icons/ionicons": "13.1.4",
     "@react-native-vector-icons/material-design-icons": "13.1.4",
     "expo": "57.0.21",
+    "expo-application": "57.0.2",
     "expo-audio": "57.0.4",
     "expo-clipboard": "57.0.1",
     "expo-constants": "57.0.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,7 @@ importers:
         specifier: 57.0.21
         version: 57.0.21(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-router@57.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-application:
-        specifier: ~57.0.2
+        specifier: 57.0.2
         version: 57.0.2(expo@57.0.21)
       expo-audio:
         specifier: 57.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       expo:
         specifier: 57.0.21
         version: 57.0.21(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-router@57.0.20)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-application:
+        specifier: ~57.0.2
+        version: 57.0.2(expo@57.0.21)
       expo-audio:
         specifier: 57.0.4
         version: 57.0.4(expo-asset@57.0.16(expo@57.0.21)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(expo@57.0.21)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

On a phone it is hard to tell whether the installed binary and OTA bundle match the latest release. Account settings had no build identity, so checking meant leaving the app.

## What

Adds a quiet two-line footer at the bottom of the mobile account screen (above Delete account):

1. Native / store version from `expo-application` (`nativeApplicationVersion` + `nativeBuildVersion`), falling back to `expo-constants` when needed — e.g. `1.0.3 (10)`.
2. Update identity from `expo-updates`: `Embedded` for store/embedded launches, otherwise a short label such as `production · a1b2c3d4 · 2026-09-10` or `OTA · a1b2c3d4`.

Helper: `apps/mobile/lib/app-version.ts`. Unavailable Updates/Application hosts degrade to native version + `Embedded` without crashing.

### User-facing copy

| String | Why it is necessary | Why not remove / progressive-only |
| --- | --- | --- |
| `1.0.3 (10)` (raw native label) | Identifies the store binary | Without it, OTA alone cannot confirm the binary |
| `Embedded` | Marks store/embedded launch vs downloaded OTA | Progressive disclosure would hide the only signal that distinguishes the two |
| `{channel} · {id}` / `{channel} · {id} · {date}` | Short OTA identity | Needed when an update is active; channel/id/date are the checkable bits |
| `OTA · {id}` / `OTA · {id} · {date}` | Same when channel is unset | Same as above for builds without a channel |

No explainer blurbs. Monochrome tertiary label styling via existing appearance tokens.

## How tested

- `pnpm --filter @rakazo/mobile test` (includes new `app-version` unit tests and i18n coverage)
- `pnpm --filter @rakazo/mobile exec tsc --noEmit -p tsconfig.json`
- Manual: open Account on a device or simulator, scroll past Sign out; footer should sit above Delete account. Dev/simulator typically shows config version + `Embedded`; a production OTA build should show channel/id/date instead.

Native-only mobile UI; CI cannot capture a device screenshot for this footer.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-592d7e97-eb23-48c1-8407-bc476a4b0a2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-592d7e97-eb23-48c1-8407-bc476a4b0a2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an accessible version summary to the account screen.
  - Displays the installed app version and build information.
  - Shows whether the app is running an embedded version or an over-the-air update, including update details when available.
- **Localization**
  - Added translated version and update status labels for Russian and Chinese.
- **Tests**
  - Added coverage for version formatting and update status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->