### PR TITLE
fix(web): retry transient noVNC asset proxy failures

### DIFF
--- a/apps/web/e2e/screen-proxy-isolation.spec.ts
+++ b/apps/web/e2e/screen-proxy-isolation.spec.ts
@@ -57,6 +57,7 @@ for (const mode of ["development", "preview"] as const) {
     let stop: () => Promise<void>;
 
     let authorized = true;
+    let assetAttempts = 0;
     test.beforeAll(async () => {
       const root = await mkdtemp(path.join(tmpdir(), "rakazo-screen-test-"));
       await mkdir(path.join(root, "dist"));
@@ -68,6 +69,10 @@ for (const mode of ["development", "preview"] as const) {
         );
         res.setHeader("Set-Cookie", "app-session=attacker; Path=/");
         if (req.url === "/core/rfb.js") {
+          if (assetAttempts++ === 0) {
+            res.destroy();
+            return;
+          }
           res.setHeader("Content-Type", "text/javascript");
           res.end('export const loaded = "module loaded";');
         } else {
@@ -164,6 +169,7 @@ for (const mode of ["development", "preview"] as const) {
       await page.goto(`${origin}/app`);
       const response = await page.goto(screenUrl);
       await expect(page.locator("body")).toContainText('"socket":"ok"');
+      expect(assetAttempts).toBeGreaterThanOrEqual(2);
       const result = JSON.parse(await page.locator("body").innerText());
       expect(result).toMatchObject({
         asset: "module loaded",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -95,8 +95,8 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string,
         },
         (incoming) => {
           if (retryable && (incoming.statusCode ?? 502) >= 500 && retries < 3 && !res.destroyed) {
-            incoming.resume();
             retries += 1;
+            incoming.destroy();
             setTimeout(requestUpstream, 50 * retries);
             return;
           }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,5 +1,5 @@
 import { timingSafeEqual } from "node:crypto";
-import type { ClientRequest } from "node:http";
+import type { ClientRequest, IncomingMessage } from "node:http";
 import http from "node:http";
 import https from "node:https";
 import net from "node:net";
@@ -80,9 +80,29 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string,
     const transport = target.protocol === "https:" ? https : http;
     let upstream: ClientRequest | undefined;
     let retries = 0;
+    let retryPending = false;
     let stopChecking: () => void = () => undefined;
     const retryable = req.method === "GET";
-    const requestUpstream = () => {
+    const scheduleRetry = (incoming?: IncomingMessage) => {
+      if (!retryable || retryPending || retries >= 3 || res.destroyed) return false;
+      retryPending = true;
+      retries += 1;
+      const delayMs = 50 * retries;
+      const retry = () => {
+        setTimeout(() => {
+          retryPending = false;
+          if (!res.destroyed) requestUpstream();
+        }, delayMs);
+      };
+      if (incoming && !incoming.destroyed) {
+        incoming.once("close", retry);
+        incoming.destroy();
+      } else {
+        retry();
+      }
+      return true;
+    };
+    function requestUpstream() {
       if (res.destroyed) return;
       upstream = transport.request(
         {
@@ -94,10 +114,7 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string,
           ...(target.protocol === "https:" ? { servername: target.hostname } : {}),
         },
         (incoming) => {
-          if (retryable && (incoming.statusCode ?? 502) >= 500 && retries < 3 && !res.destroyed) {
-            retries += 1;
-            incoming.destroy();
-            setTimeout(requestUpstream, 50 * retries);
+          if ((incoming.statusCode ?? 502) >= 500 && scheduleRetry(incoming)) {
             return;
           }
           res.writeHead(
@@ -108,9 +125,7 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string,
         },
       );
       upstream.on("error", () => {
-        if (retryable && !res.headersSent && retries < 3 && !res.destroyed) {
-          retries += 1;
-          setTimeout(requestUpstream, 50 * retries);
+        if (retryable && !res.headersSent && !res.destroyed && (retryPending || scheduleRetry())) {
           return;
         }
         stopChecking();
@@ -123,7 +138,7 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string,
       });
       if (req.method === "GET" || req.readableEnded) upstream.end();
       else req.pipe(upstream);
-    };
+    }
     stopChecking = watchScreenAuthorization(
       async () => Boolean(await resolveNovncTarget(req.url, secret, api)),
       () => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,5 @@
 import { timingSafeEqual } from "node:crypto";
+import type { ClientRequest } from "node:http";
 import http from "node:http";
 import https from "node:https";
 import net from "node:net";
@@ -77,41 +78,64 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string,
       host: `${target.hostname}:${target.port}`,
     };
     const transport = target.protocol === "https:" ? https : http;
-    const upstream = transport.request(
-      {
-        hostname: target.hostname,
-        port: target.port,
-        path: target.path,
-        method: req.method,
-        headers,
-        ...(target.protocol === "https:" ? { servername: target.hostname } : {}),
-      },
-      (incoming) => {
-        res.writeHead(incoming.statusCode ?? 502, safeScreenProxyResponseHeaders(incoming.headers));
-        incoming.pipe(res);
-      },
-    );
-    const stopChecking = watchScreenAuthorization(
+    let upstream: ClientRequest | undefined;
+    let retries = 0;
+    let stopChecking: () => void = () => undefined;
+    const retryable = req.method === "GET";
+    const requestUpstream = () => {
+      if (res.destroyed) return;
+      upstream = transport.request(
+        {
+          hostname: target.hostname,
+          port: target.port,
+          path: target.path,
+          method: req.method,
+          headers,
+          ...(target.protocol === "https:" ? { servername: target.hostname } : {}),
+        },
+        (incoming) => {
+          if (retryable && (incoming.statusCode ?? 502) >= 500 && retries < 3 && !res.destroyed) {
+            incoming.resume();
+            retries += 1;
+            setTimeout(requestUpstream, 50 * retries);
+            return;
+          }
+          res.writeHead(
+            incoming.statusCode ?? 502,
+            safeScreenProxyResponseHeaders(incoming.headers),
+          );
+          incoming.pipe(res);
+        },
+      );
+      upstream.on("error", () => {
+        if (retryable && !res.headersSent && retries < 3 && !res.destroyed) {
+          retries += 1;
+          setTimeout(requestUpstream, 50 * retries);
+          return;
+        }
+        stopChecking();
+        if (res.headersSent) {
+          res.destroy();
+          return;
+        }
+        res.statusCode = 502;
+        res.end("Screen unavailable");
+      });
+      if (req.method === "GET" || req.readableEnded) upstream.end();
+      else req.pipe(upstream);
+    };
+    stopChecking = watchScreenAuthorization(
       async () => Boolean(await resolveNovncTarget(req.url, secret, api)),
       () => {
-        upstream.destroy();
+        upstream?.destroy();
         res.destroy();
       },
     );
     res.once("close", () => {
       stopChecking();
-      upstream.destroy();
+      upstream?.destroy();
     });
-    upstream.on("error", () => {
-      stopChecking();
-      if (res.headersSent) {
-        res.destroy();
-        return;
-      }
-      res.statusCode = 502;
-      res.end("Screen unavailable");
-    });
-    req.pipe(upstream);
+    requestUpstream();
   });
 
   server.httpServer?.on("upgrade", async (req, socket, head) => {


### PR DESCRIPTION
## Why

The noVNC static asset proxy could return transient 502 responses while the upstream screen transport was briefly unavailable. Because each module load failed immediately, the embedded remote desktop could remain black even though the underlying RFB screen was healthy.

## What changed

- Retry GET requests for noVNC assets up to three times with a short backoff when the upstream connection fails or returns a 5xx response.
- Keep non-GET requests and authorization failures fail-closed.
- Extend the screen-proxy isolation E2E fixture to drop the first asset request and verify recovery in both development and preview modes.

## Testing

- `pnpm check`
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web test` (211 tests)
- `pnpm --filter @rakazo/web exec playwright test --config playwright.screen-proxy.config.ts` (8 passed)
- `pnpm lint` (passes; existing unrelated warnings remain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the noVNC HTTP proxy’s resilience when upstream GET requests fail or return server errors.
  - Failed asset requests are now retried automatically, helping interrupted connections recover without requiring users to reload.

- **Tests**
  - Added coverage verifying that interrupted asset requests are retried and successfully fetched on a subsequent attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->