### PR TITLE
fix(mobile): strip Account explainers and show integration logos

### DIFF
--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -138,6 +138,7 @@ jobs:
           script: bash .github/scripts/capture-mobile-android-screenshots.sh
 
       - name: Publish screenshot gallery
+        if: always()
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}

--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -115,31 +115,34 @@ tags:
 - extendedWaitUntil:
     visible: "The fixture workspace is ready."
     timeout: 10000
-- assertNotVisible: "Add thumbs-up"
-- assertNotVisible: "Remove thumbs-up"
 - assertNotVisible: "Reply"
+- assertNotVisible: "React"
+- assertNotVisible: "More"
 - takeScreenshot: "15-thread"
 - longPressOn: "The fixture workspace is ready."
-- assertVisible: "Add thumbs-up"
 - assertVisible: "Reply"
+- assertVisible: "React"
+- assertVisible: "More"
 - takeScreenshot: "15b-message-actions"
 - tapOn: "More"
 - assertVisible: "Speak message"
 - back
 - longPressOn: "The fixture workspace is ready."
-- tapOn: "Add thumbs-up"
+- tapOn: "React"
+- tapOn: "👍"
 - extendedWaitUntil:
-    visible: "Remove thumbs-up"
+    visible: "👍"
     timeout: 10000
 - assertNotVisible: "Reply"
 - takeScreenshot: "15c-message-reaction"
-- tapOn: "Remove thumbs-up"
-- extendedWaitUntil:
-    notVisible: "Remove thumbs-up"
-    timeout: 10000
 - longPressOn: "Summarize the fixture launch checklist."
-- assertVisible: "Add thumbs-up"
+- assertVisible: "Reply"
+- assertVisible: "React"
+- assertVisible: "More"
+- tapOn: "More"
 - assertNotVisible: "Speak message"
+- back
+- longPressOn: "Summarize the fixture launch checklist."
 - tapOn: "Reply"
 - assertVisible: "Replying to"
 - tapOn: "Cancel reply"
@@ -168,19 +171,20 @@ tags:
 - extendedWaitUntil:
     visible: "The fixture launch plan is ready."
     timeout: 10000
-- assertNotVisible: "Add thumbs-up"
 - assertNotVisible: "Reply"
+- assertNotVisible: "React"
+- assertNotVisible: "More"
 - takeScreenshot: "19-group-thread"
 - longPressOn: "The fixture launch plan is ready."
-- assertVisible: "Add thumbs-up"
-- tapOn: "Add thumbs-up"
+- assertVisible: "Reply"
+- assertVisible: "React"
+- assertVisible: "More"
+- tapOn: "React"
+- tapOn: "👍"
 - extendedWaitUntil:
-    visible: "Remove thumbs-up"
+    visible: "👍"
     timeout: 10000
-- tapOn: "Remove thumbs-up"
-- extendedWaitUntil:
-    notVisible: "Remove thumbs-up"
-    timeout: 10000
+- assertNotVisible: "Reply"
 
 - openLink: "rakazo:///group-settings?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}"
 - extendedWaitUntil:

--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -127,22 +127,13 @@ tags:
 - tapOn: "More"
 - assertVisible: "Speak message"
 - back
-- longPressOn: "The fixture workspace is ready."
-- tapOn: "React"
-- tapOn: "👍"
-- extendedWaitUntil:
-    visible: "👍"
-    timeout: 10000
-- assertNotVisible: "Reply"
-- takeScreenshot: "15c-message-reaction"
+# User messages omit Speak, so Android fits Reply/React/Copy on one page (no More).
 - longPressOn: "Summarize the fixture launch checklist."
 - assertVisible: "Reply"
 - assertVisible: "React"
-- assertVisible: "More"
-- tapOn: "More"
+- assertVisible: "Copy"
+- assertNotVisible: "More"
 - assertNotVisible: "Speak message"
-- back
-- longPressOn: "Summarize the fixture launch checklist."
 - tapOn: "Reply"
 - assertVisible: "Replying to"
 - tapOn: "Cancel reply"
@@ -179,12 +170,7 @@ tags:
 - assertVisible: "Reply"
 - assertVisible: "React"
 - assertVisible: "More"
-- tapOn: "React"
-- tapOn: "👍"
-- extendedWaitUntil:
-    visible: "👍"
-    timeout: 10000
-- assertNotVisible: "Reply"
+- back
 
 - openLink: "rakazo:///group-settings?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}"
 - extendedWaitUntil:
@@ -239,3 +225,14 @@ tags:
 - openLink: "rakazo:///thread?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"
 - assertVisible: "The fixture workspace is ready."
 - takeScreenshot: "29-thread-light-restored"
+
+# Capture the reaction after theme comparisons. Reactions are append-only, so adding
+# 👍 earlier would leak into dark/light thread frames with no remove control.
+- longPressOn: "The fixture workspace is ready."
+- tapOn: "React"
+- tapOn: "👍"
+- extendedWaitUntil:
+    visible: "👍"
+    timeout: 10000
+- assertNotVisible: "Reply"
+- takeScreenshot: "15c-message-reaction"

--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -149,7 +149,8 @@ tags:
 - assertVisible: "Advanced"
 - tapOn: "Advanced"
 - assertVisible: "Model"
-- assertVisible: "Space default"
+# Label includes the resolved space model, e.g. "Space default (OpenAI: …)".
+- assertVisible: "Space default.*"
 - takeScreenshot: "17-bot-settings"
 
 - openLink: "rakazo:///computer?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -44,13 +44,19 @@ import {
   openPromotedNotificationSettings,
   setLiveNotificationSettings,
 } from "../lib/live-notifications";
-import { native, useThemedStyles } from "../lib/native";
+import { presentMessageActionSheet } from "../lib/message-action-sheet";
+import { native, useResolvedAppearance, useThemedStyles } from "../lib/native";
 import { registerPushToken } from "../lib/push";
-import { UI_LOCALE_LABELS, UI_LOCALES, type UiLocale } from "../lib/ui-locale";
+import {
+  ACCOUNT_UI_LOCALES,
+  UI_LOCALE_LABELS,
+  type AccountUiLocale,
+} from "../lib/ui-locale";
 
 /** Render account settings, including the entry point for voice configuration. */
 export default function Account() {
   const { t, locale } = useI18n();
+  const colorScheme = useResolvedAppearance();
   const router = useRouter();
   const { focus } = useLocalSearchParams<{ focus?: string }>();
   const [me, setMe] = useState<MobileMe | null>(null);
@@ -195,6 +201,31 @@ export default function Account() {
     );
   }
 
+  function applyLocale(code: AccountUiLocale) {
+    if (code === locale || localeSaving) return;
+    setLocaleSaving(true);
+    setLocaleError(null);
+    void setUiLocale(code)
+      .catch(() => {
+        setLocaleError(t("Could not change language"));
+      })
+      .finally(() => setLocaleSaving(false));
+  }
+
+  function openLanguagePicker() {
+    if (localeSaving) return;
+    presentMessageActionSheet({
+      title: t("Language"),
+      actions: ACCOUNT_UI_LOCALES.map((code) => ({
+        text: UI_LOCALE_LABELS[code],
+        onPress: () => applyLocale(code),
+      })),
+      colorScheme,
+      cancel: t("Cancel"),
+      more: t("More"),
+    });
+  }
+
   async function handleDeletion() {
     setPending(true);
     setError(null);
@@ -294,41 +325,26 @@ export default function Account() {
           {avatarError ? <Text style={styles.error}>{avatarError}</Text> : null}
         </View>
 
-        <View accessibilityLabel={t("Language")} style={styles.avatarSection}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t("Language")}
+          accessibilityValue={{ text: UI_LOCALE_LABELS[locale] }}
+          accessibilityState={{ disabled: localeSaving }}
+          disabled={localeSaving}
+          onPress={openLanguagePicker}
+          style={({ pressed }) => [
+            styles.settingsButton,
+            pressed && styles.pressed,
+            localeSaving && { opacity: 0.6 },
+          ]}
+        >
           <Text style={styles.settingsTitle}>{t("Language")}</Text>
-          <View style={styles.localeOptions}>
-            {UI_LOCALES.map((code) => {
-              const selected = locale === code;
-              return (
-                <Pressable
-                  key={code}
-                  accessibilityRole="button"
-                  accessibilityState={{ selected, disabled: localeSaving }}
-                  disabled={localeSaving}
-                  onPress={() => {
-                    if (code === locale || localeSaving) return;
-                    setLocaleSaving(true);
-                    setLocaleError(null);
-                    void setUiLocale(code as UiLocale)
-                      .catch(() => {
-                        setLocaleError(t("Could not change language"));
-                      })
-                      .finally(() => setLocaleSaving(false));
-                  }}
-                  style={({ pressed }) => [
-                    styles.localeOption,
-                    selected && styles.avatarOptionSelected,
-                    pressed && styles.pressed,
-                    localeSaving && { opacity: 0.6 },
-                  ]}
-                >
-                  <Text style={styles.avatarLabel}>{UI_LOCALE_LABELS[code]}</Text>
-                </Pressable>
-              );
-            })}
+          <View style={styles.settingsTrailing}>
+            <Text style={styles.settingsValue}>{UI_LOCALE_LABELS[locale]}</Text>
+            <Text style={styles.chevron}>›</Text>
           </View>
-          {localeError ? <Text style={styles.error}>{localeError}</Text> : null}
-        </View>
+        </Pressable>
+        {localeError ? <Text style={styles.error}>{localeError}</Text> : null}
 
         {Platform.OS === "android" ? (
           <View accessibilityLabel={t("Notifications")} style={styles.profile}>
@@ -660,17 +676,6 @@ function createAccountStyles() {
       fontSize: 14,
       fontWeight: "600",
     },
-    localeOptions: {
-      gap: 8,
-    },
-    localeOption: {
-      minHeight: 44,
-      borderRadius: 12,
-      borderWidth: StyleSheet.hairlineWidth,
-      borderColor: native.tertiaryLabel,
-      paddingHorizontal: 14,
-      justifyContent: "center",
-    },
     avatarOptions: {
       flexDirection: "row",
       gap: 12,
@@ -698,6 +703,16 @@ function createAccountStyles() {
       color: native.label,
       fontSize: 17,
       fontWeight: "600",
+    },
+    settingsTrailing: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      minWidth: 0,
+    },
+    settingsValue: {
+      color: native.secondaryLabel,
+      fontSize: 15,
     },
     settingsExplanation: {
       color: native.secondaryLabel,

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -47,11 +47,7 @@ import {
 import { presentMessageActionSheet } from "../lib/message-action-sheet";
 import { native, useResolvedAppearance, useThemedStyles } from "../lib/native";
 import { registerPushToken } from "../lib/push";
-import {
-  ACCOUNT_UI_LOCALES,
-  UI_LOCALE_LABELS,
-  type AccountUiLocale,
-} from "../lib/ui-locale";
+import { ACCOUNT_UI_LOCALES, type AccountUiLocale, UI_LOCALE_LABELS } from "../lib/ui-locale";
 
 /** Render account settings, including the entry point for voice configuration. */
 export default function Account() {

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -47,7 +47,8 @@ import {
 import { presentMessageActionSheet } from "../lib/message-action-sheet";
 import { native, useResolvedAppearance, useThemedStyles } from "../lib/native";
 import { registerPushToken } from "../lib/push";
-import { ACCOUNT_UI_LOCALES, type AccountUiLocale, UI_LOCALE_LABELS } from "../lib/ui-locale";
+import type { AccountUiLocale } from "../lib/ui-locale";
+import { ACCOUNT_UI_LOCALES, UI_LOCALE_LABELS } from "../lib/ui-locale";
 
 /** Render account settings, including the entry point for voice configuration. */
 export default function Account() {

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -111,7 +111,6 @@ export default function Account() {
           })}
         </Text>
       ) : null}
-      <Text style={styles.settingsExplanation}>{t("Model spend uses your provider keys.")}</Text>
     </View>
   );
 
@@ -709,11 +708,6 @@ function createAccountStyles() {
     settingsValue: {
       color: native.secondaryLabel,
       fontSize: 15,
-    },
-    settingsExplanation: {
-      color: native.secondaryLabel,
-      fontSize: 13,
-      marginTop: 3,
     },
     chevron: {
       color: native.secondaryLabel,

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -393,12 +393,7 @@ export default function Account() {
           onPress={() => router.push("/models")}
           style={({ pressed }) => [styles.settingsButton, pressed && styles.pressed]}
         >
-          <View>
-            <Text style={styles.settingsTitle}>{t("Models")}</Text>
-            <Text style={styles.settingsExplanation}>
-              {t("Choose your provider and active model")}
-            </Text>
-          </View>
+          <Text style={styles.settingsTitle}>{t("Models")}</Text>
           <Text style={styles.chevron}>›</Text>
         </Pressable>
 
@@ -408,12 +403,7 @@ export default function Account() {
           onPress={() => router.push("/voice")}
           style={({ pressed }) => [styles.settingsButton, pressed && styles.pressed]}
         >
-          <View>
-            <Text style={styles.settingsTitle}>{t("Voice")}</Text>
-            <Text style={styles.settingsExplanation}>
-              {t("Speak replies aloud with ElevenLabs, OpenAI, Cartesia, or Fish Audio")}
-            </Text>
-          </View>
+          <Text style={styles.settingsTitle}>{t("Voice")}</Text>
           <Text style={styles.chevron}>›</Text>
         </Pressable>
 
@@ -423,10 +413,7 @@ export default function Account() {
           onPress={() => router.push("/integrations")}
           style={({ pressed }) => [styles.settingsButton, pressed && styles.pressed]}
         >
-          <View>
-            <Text style={styles.settingsTitle}>{t("Integrations")}</Text>
-            <Text style={styles.settingsExplanation}>{t("Connect apps.")}</Text>
-          </View>
+          <Text style={styles.settingsTitle}>{t("Integrations")}</Text>
           <Text style={styles.chevron}>›</Text>
         </Pressable>
 
@@ -490,11 +477,6 @@ export default function Account() {
 
         <View style={styles.dangerZone}>
           <Text style={styles.dangerTitle}>{t("Delete account")}</Text>
-          <Text style={styles.explanation}>
-            {t(
-              "Enter your current password, then confirm permanent deletion of your account and all associated data.",
-            )}
-          </Text>
           <TextInput
             accessibilityLabel={t("Current password")}
             autoCapitalize="none"
@@ -748,12 +730,6 @@ function createAccountStyles() {
       color: tokens.destructive,
       fontSize: 17,
       fontWeight: "600",
-    },
-    explanation: {
-      color: native.secondaryLabel,
-      fontSize: 14,
-      lineHeight: 20,
-      marginTop: 8,
     },
     password: {
       height: 48,

--- a/apps/mobile/app/change-password.tsx
+++ b/apps/mobile/app/change-password.tsx
@@ -70,11 +70,30 @@ export default function ChangePassword() {
     <SafeAreaView edges={["bottom"]} style={styles.screen}>
       <Stack.Screen
         options={{
+          headerBackVisible: false,
+          // Android / older iOS: plain text Cancel like New bot / New space.
           headerLeft: () => (
-            <Pressable accessibilityRole="button" onPress={close} style={styles.cancel}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("Cancel")}
+              hitSlop={8}
+              onPress={close}
+              style={styles.cancel}
+            >
               <Text style={styles.cancelLabel}>{t("Cancel")}</Text>
             </Pressable>
           ),
+          // iOS formSheet wraps custom headerLeft in a filled bar button; use a
+          // native plain item and hide the shared liquid-glass background.
+          unstable_headerLeftItems: () => [
+            {
+              type: "button",
+              label: t("Cancel"),
+              variant: "plain",
+              hidesSharedBackground: true,
+              onPress: close,
+            },
+          ],
         }}
       />
       <KeyboardAvoidingView
@@ -150,7 +169,12 @@ function createStyles() {
   return StyleSheet.create({
     screen: { flex: 1, backgroundColor: native.page },
     content: { padding: 20, gap: 12 },
-    cancel: { minHeight: 44, justifyContent: "center", paddingEnd: 16 },
+    cancel: {
+      backgroundColor: "transparent",
+      paddingEnd: 20,
+      paddingVertical: 8,
+      justifyContent: "center",
+    },
     cancelLabel: { color: native.label, fontSize: 17 },
     input: {
       minHeight: 48,

--- a/apps/mobile/app/integrations.tsx
+++ b/apps/mobile/app/integrations.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  Image,
   Linking,
   Pressable,
   ScrollView,
@@ -30,8 +31,47 @@ import { native, useThemedStyles } from "../lib/native";
 type SourceKind = "treg" | "executor" | "mcp" | "api" | "graphql";
 type ConnectionTool = { name: string; description: string };
 
+const LOGO_SIZE = 32;
+
 function itemKey(item: Pick<ConnectionCatalogItem, "connectorId" | "slug">) {
   return `${item.connectorId}:${item.slug}`;
+}
+
+function ConnectorLogo({
+  logo,
+  label,
+  styles,
+}: {
+  logo?: string | null;
+  label: string;
+  styles: ReturnType<typeof createIntegrationsStyles>;
+}) {
+  const [failed, setFailed] = useState(false);
+  useEffect(() => {
+    setFailed(false);
+  }, [logo]);
+  const initial = (label.trim()[0] || "?").toUpperCase();
+  if (!logo || failed) {
+    return (
+      <View
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+        style={styles.logoFallback}
+      >
+        <Text style={styles.logoInitial}>{initial}</Text>
+      </View>
+    );
+  }
+  return (
+    <Image
+      accessibilityIgnoresInvertColors
+      accessible={false}
+      onError={() => setFailed(true)}
+      resizeMode="contain"
+      source={{ uri: logo }}
+      style={styles.logo}
+    />
+  );
 }
 
 export default function Integrations() {
@@ -393,6 +433,7 @@ export default function Integrations() {
     const connected = itemConnected(item);
     const body = (
       <>
+        <ConnectorLogo logo={item.logo} label={label} styles={styles} />
         <View style={styles.grow}>
           <Text numberOfLines={1} style={styles.title}>
             {label}
@@ -440,6 +481,7 @@ export default function Integrations() {
             >
               <Text style={styles.link}>{t("Back")}</Text>
             </Pressable>
+            <ConnectorLogo logo={item.logo} label={item.name} styles={styles} />
             <Text numberOfLines={1} style={styles.detailTitle}>
               {item.name}
             </Text>
@@ -575,6 +617,7 @@ export default function Integrations() {
                             disabled ? { opacity: 0.7 } : null,
                           ]}
                         >
+                          <ConnectorLogo label={tile.label} styles={styles} />
                           <View style={styles.grow}>
                             <Text numberOfLines={1} style={styles.title}>
                               {tile.label}
@@ -813,6 +856,25 @@ function createIntegrationsStyles() {
       flexDirection: "row",
       alignItems: "center",
       gap: 10,
+    },
+    logo: {
+      width: LOGO_SIZE,
+      height: LOGO_SIZE,
+      borderRadius: 10,
+      backgroundColor: native.fillPressed,
+    },
+    logoFallback: {
+      width: LOGO_SIZE,
+      height: LOGO_SIZE,
+      borderRadius: 10,
+      backgroundColor: native.fillPressed,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    logoInitial: {
+      color: native.label,
+      fontSize: 14,
+      fontWeight: "600",
     },
     grow: { flex: 1, gap: 3, minWidth: 0 },
     title: { color: native.label, fontSize: 15, fontWeight: "600" },

--- a/apps/mobile/lib/locales/ru.ts
+++ b/apps/mobile/lib/locales/ru.ts
@@ -324,8 +324,6 @@ export const RU_MESSAGES: Record<string, string> = {
   "Message {name}": "Написать {name}",
   Model: "Модель",
   "Model id": "Идентификатор модели",
-  "Model spend uses your provider keys.":
-    "Расходы на модель оплачиваются вашими ключами провайдера.",
   "Model updated.": "Модель обновлена.",
   Models: "Модели",
   "Move to": "Переместить в",

--- a/apps/mobile/lib/locales/ru.ts
+++ b/apps/mobile/lib/locales/ru.ts
@@ -42,8 +42,6 @@ export const RU_MESSAGES: Record<string, string> = {
   "Set up Executor on your server in the web app.":
     "Настройте Executor на сервере в веб-приложении.",
   "Space default": "Пространство по умолчанию",
-  "Speak replies aloud with ElevenLabs, OpenAI, Cartesia, or Fish Audio":
-    "Озвучивать ответы с помощью ElevenLabs, OpenAI, Cartesia или Fish Audio",
   "Stop all workers and confirm that provider operations have stopped before releasing this computer.":
     "Остановите всех воркеров и убедитесь, что операции провайдера остановлены, прежде чем освобождать этот компьютер.",
   "Stored securely. Never shown here.": "Хранится безопасно. Здесь не отображается.",
@@ -136,7 +134,6 @@ export const RU_MESSAGES: Record<string, string> = {
   Checking: "Проверка",
   "Checking…": "Проверка…",
   "Check your email": "Проверьте свою электронную почту",
-  "Choose your provider and active model": "Выберите своего провайдера и активную модель",
   Clear: "Очистить",
   "Clear conversation": "Очистить диалог",
   "Clear conversation?": "Очистить диалог?",
@@ -158,7 +155,6 @@ export const RU_MESSAGES: Record<string, string> = {
   Connect: "Подключить",
   "Connect a voice provider first.": "Сначала подключите провайдера голосовой связи.",
   "Connect API key": "Подключить API-ключ",
-  "Connect apps.": "Подключить приложения.",
   "Connect Executor": "Подключить Executor",
   "Connect Treg": "Подключить Treg",
   "Connect this provider to use it as your personal model.":
@@ -267,8 +263,6 @@ export const RU_MESSAGES: Record<string, string> = {
   "OTA · {id} · {date}": "OTA · {id} · {date}",
   "Enter a server URL": "Введите URL-адрес сервера",
   "Enter this code in your browser:": "Введите этот код в браузере:",
-  "Enter your current password, then confirm permanent deletion of your account and all associated data.":
-    "Введите свой текущий пароль, а затем подтвердите окончательное удаление вашей учетной записи и всех связанных с ней данных.",
   "Executor token": "Токен Executor",
   Failed: "Ошибка",
   "Failed to refresh": "Не удалось обновить",
@@ -456,8 +450,6 @@ export const RU_MESSAGES: Record<string, string> = {
   "Speak message": "Озвучить сообщение",
   Speak: "Озвучить",
   "Speak only": "Только озвучить",
-  "Speak replies aloud with ElevenLabs, OpenAI, or Cartesia":
-    "Озвучивайте ответы с помощью ElevenLabs, OpenAI или Cartesia",
   Starting: "Запуск",
   "Starting…": "Запуск…",
   Stop: "Остановить",

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -308,7 +308,6 @@ export const ZH_MESSAGES: Record<string, string> = {
   "Message {name}": "给 {name} 发消息",
   Model: "模型",
   "Model id": "模型 ID",
-  "Model spend uses your provider keys.": "模型费用使用你自己的提供商密钥结算。",
   "Model updated.": "模型已更新。",
   Models: "模型",
   "Move to": "移动到",

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -122,7 +122,6 @@ export const ZH_MESSAGES: Record<string, string> = {
   Checking: "检查中",
   "Checking…": "正在检查…",
   "Check your email": "请查看邮箱",
-  "Choose your provider and active model": "选择提供商和当前模型",
   Clear: "清除",
   "Clear conversation": "清除对话",
   "Clear conversation?": "要清除对话吗？",
@@ -143,7 +142,6 @@ export const ZH_MESSAGES: Record<string, string> = {
   Connect: "连接",
   "Connect a voice provider first.": "请先连接语音提供商。",
   "Connect API key": "连接 API 密钥",
-  "Connect apps.": "连接应用。",
   "Connect Executor": "连接 Executor",
   "Connect Treg": "连接 Treg",
   "Connect this provider to use it as your personal model.": "连接此提供商，将其用作你的个人模型。",
@@ -250,8 +248,6 @@ export const ZH_MESSAGES: Record<string, string> = {
   "OTA · {id} · {date}": "OTA · {id} · {date}",
   "Enter a server URL": "请输入服务器地址",
   "Enter this code in your browser:": "请在浏览器中输入此代码：",
-  "Enter your current password, then confirm permanent deletion of your account and all associated data.":
-    "输入当前密码，然后确认永久删除账户及所有相关数据。",
   "Executor token": "Executor 令牌",
   Failed: "失败",
   "Failed to refresh": "刷新失败",
@@ -436,8 +432,6 @@ export const ZH_MESSAGES: Record<string, string> = {
   "Speak message": "朗读消息",
   Speak: "朗读",
   "Speak only": "仅朗读",
-  "Speak replies aloud with ElevenLabs, OpenAI, Cartesia, or Fish Audio":
-    "使用 ElevenLabs、OpenAI、Cartesia 或 Fish Audio 朗读回复",
   Starting: "正在启动",
   "Starting…": "正在启动…",
   Stop: "停止",

--- a/apps/mobile/lib/ui-locale.test.ts
+++ b/apps/mobile/lib/ui-locale.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  ACCOUNT_UI_LOCALES,
   htmlLangForLocale,
   isUiLocale,
   normalizeUiLocale,
@@ -18,6 +19,13 @@ describe("UI_LOCALES", () => {
     expect(isUiLocale("hi")).toBe(false);
     expect(isUiLocale("pt-BR")).toBe(false);
     expect(isUiLocale("ru")).toBe(true);
+  });
+});
+
+describe("ACCOUNT_UI_LOCALES", () => {
+  it("limits the Account picker to English and Simplified Chinese", () => {
+    expect([...ACCOUNT_UI_LOCALES]).toEqual(["en", "zh-CN"]);
+    expect(ACCOUNT_UI_LOCALES).not.toContain("ru");
   });
 });
 

--- a/apps/mobile/lib/ui-locale.ts
+++ b/apps/mobile/lib/ui-locale.ts
@@ -2,6 +2,11 @@ export const UI_LOCALES = ["en", "zh-CN", "ru"] as const;
 
 export type UiLocale = (typeof UI_LOCALES)[number];
 
+/** Locales offered on the mobile Account language picker. */
+export const ACCOUNT_UI_LOCALES = ["en", "zh-CN"] as const satisfies readonly UiLocale[];
+
+export type AccountUiLocale = (typeof ACCOUNT_UI_LOCALES)[number];
+
 export const UI_LOCALE_STORAGE_KEY = "rakazo.uiLocale";
 
 export const UI_LOCALE_LABELS: Record<UiLocale, string> = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Mobile Account settings carried long explainer copy that repeats what destinations and confirm alerts already make clear. Integrations catalog tiles only showed names. The language control listed every catalog locale, including Russian. Change password’s Cancel sat in a filled iOS pill. Usage still had a spend subtitle under the same explainer pattern.

## What changed

1. **Account explainers** (`apps/mobile/app/account.tsx`)
   - Models, Voice, and Integrations are title + chevron only.
   - Delete account keeps title, password field, and button; drops the long paragraph.
   - Usage keeps runs/tokens; drops `Model spend uses your provider keys.` and unused `settingsExplanation`.
   - Notification switch details (e.g. “While agents are working”) stay.
   - Language locale type uses a top-level `import type { AccountUiLocale }`.

2. **Integrations logos** (`apps/mobile/app/integrations.tsx`)
   - Catalog, featured, and detail use `item.logo` from `ConnectionCatalogItem`, with a letter fallback.

3. **Account language select**
   - Settings row + `presentMessageActionSheet` with English and 简体中文 only (`ACCOUNT_UI_LOCALES`).

4. **Change password Cancel**
   - Plain header action via `unstable_headerLeftItems` (`variant: "plain"`, `hidesSharedBackground: true`) on iOS; transparent text Pressable on Android.

5. **Maestro screenshots**
   - User-message sheets assert `Copy` (not `More`); Speak-less sheets fit on one Android Alert page.
   - Reaction capture runs after dark/light thread frames so append-only 👍 cannot contaminate theme comparisons.
   - Gallery publish still runs when a late assert fails.

## Test plan

- [ ] Account: Models / Voice / Integrations title-only; Usage has no spend blurb; Delete has no paragraph; password still required.
- [ ] Integrations: logos when provided; initial fallback; detail header logo.
- [ ] Language: English / 简体中文 only; applies locale.
- [ ] Change password: Cancel is plain text; dismisses sheet.
- [ ] Maestro Android screenshots: user-message long-press shows Reply/React/Copy; theme thread frames have no 👍; `15c` still captured.

## Copy removed

- `Choose your provider and active model`
- `Speak replies aloud with ElevenLabs, OpenAI, Cartesia, or Fish Audio`
- `Connect apps.`
- `Enter your current password, then confirm permanent deletion of your account and all associated data.`
- `Model spend uses your provider keys.`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2338a7c-4dce-4111-932f-65f593e337d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2338a7c-4dce-4111-932f-65f593e337d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added connector logos to integration listings and detail views, with initial-based fallbacks when unavailable.
  - Updated Account language selection to use a native action sheet showing the current language.
  - Limited Account language options to English and Simplified Chinese.
  - Improved iOS change-password cancellation controls and accessibility.

- **Bug Fixes**
  - Screenshot galleries now publish even when earlier workflow steps fail.
  - Updated mobile screenshot checks for the current reaction menu and behavior.

- **Style**
  - Simplified several Account settings descriptions and presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->