### PR TITLE
fix: exclude revoked connections from run tool discovery

### DIFF
--- a/packages/adapters/src/executor-connections.test.ts
+++ b/packages/adapters/src/executor-connections.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { selectRunConnections } from "./executor.js";
+
+describe("run connection selection", () => {
+  it("does not send revoked accounts alongside a reconnected toolkit", () => {
+    const oldAccount = {
+      connectorId: "composio",
+      provider: "youtube",
+      status: "revoked",
+      providerRef: "ca_old",
+    };
+    const currentAccount = { ...oldAccount, status: "connected", providerRef: "ca_current" };
+    expect(selectRunConnections([oldAccount, currentAccount], ["youtube"])).toEqual([
+      currentAccount,
+    ]);
+  });
+
+  it("preserves live connection recovery and connected accounts from other providers", () => {
+    const pending = { connectorId: "composio", provider: "youtube", status: "pending" };
+    const revoked = { ...pending, status: "revoked" };
+    const other = { connectorId: "pipedream", provider: "youtube", status: "connected" };
+    const disconnected = { ...other, status: "error" };
+    expect(selectRunConnections([pending, revoked, other, disconnected], ["youtube"])).toEqual([
+      pending,
+      other,
+    ]);
+  });
+});

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1142,13 +1142,9 @@ export function createRunExecutor(deps: ExecutorDeps) {
           }
         }
         const connectedComposio = mergeConnectedPlugins(composioRows, liveSlugs);
-        const activeKeys = new Set(
-          connectedComposio.map((connection) => `composio:${connection.provider}`),
-        );
-        const connectedPlugins = storedConnections.filter(
-          (connection) =>
-            connection.status === "connected" ||
-            activeKeys.has(`${connection.connectorId}:${connection.provider}`),
+        const connectedPlugins = selectRunConnections(
+          storedConnections,
+          connectedComposio.map((connection) => connection.provider),
         );
         const context = {
           operationId: runId,
@@ -4593,6 +4589,17 @@ async function withModelCredentialLock<T>(key: string, fn: () => Promise<T>): Pr
     release();
     if (modelCredentialLocks.get(key) === current) modelCredentialLocks.delete(key);
   }
+}
+
+export function selectRunConnections<
+  T extends { connectorId: string; provider: string; status: string },
+>(rows: T[], connectedComposioProviders: string[]): T[] {
+  const activeKeys = new Set(connectedComposioProviders.map((provider) => `composio:${provider}`));
+  return rows.filter(
+    (row) =>
+      row.status !== "revoked" &&
+      (row.status === "connected" || activeKeys.has(`${row.connectorId}:${row.provider}`)),
+  );
 }
 
 export async function loadCurrentTurnImages(


### PR DESCRIPTION
Reconnecting a Composio toolkit can leave revoked connection records alongside the active account. Run setup currently includes every record for an active toolkit, so stale connected-account IDs reach Composio and cause `ToolRouterV2_InvalidConnectedAccountIds`. Tool discovery then fails for the entire Composio provider even though the integration appears connected.

Exclude revoked records when selecting run connections. Preserve existing live-connection recovery and connected accounts from other providers, with regression coverage for both behaviors.

Validation: all 71 executor and Composio tests pass, adapter TypeScript checking passes, and Biome checks pass. The regression tests failed before the filter change. A read-only end-to-end YouTube lookup also succeeded after applying the fix to an affected deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection selection to exclude revoked and errored connections when a valid replacement is available.
  - Preserved pending connections needed for live recovery.
  - Retained connected accounts from other connectors and active provider connections.
- **Tests**
  - Added coverage for connection filtering and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->