### PR TITLE
fix: exclude revoked connections from run tool discovery

### DIFF
--- a/packages/adapters/src/executor-connections.test.ts
+++ b/packages/adapters/src/executor-connections.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { selectRunConnections } from "./executor.js";
+
+describe("run connection selection", () => {
+  it("does not send revoked accounts alongside a reconnected toolkit", () => {
+    const oldAccount = {
+      connectorId: "composio",
+      provider: "youtube",
+      status: "revoked",
+      providerRef: "ca_old",
+    };
+    const currentAccount = { ...oldAccount, status: "connected", providerRef: "ca_current" };
+    expect(selectRunConnections([oldAccount, currentAccount], ["youtube"])).toEqual([
+      currentAccount,
+    ]);
+  });
+
+  it("preserves live connection recovery and connected accounts from other providers", () => {
+    const pending = { connectorId: "composio", provider: "youtube", status: "pending" };
+    const revoked = { ...pending, status: "revoked" };
+    const other = { connectorId: "pipedream", provider: "youtube", status: "connected" };
+    const disconnected = { ...other, status: "error" };
+    expect(selectRunConnections([pending, revoked, other, disconnected], ["youtube"])).toEqual([
+      pending,
+      other,
+    ]);
+  });
+});

--- a/packages/adapters/src/executor-connections.test.ts
+++ b/packages/adapters/src/executor-connections.test.ts
@@ -1,7 +1,56 @@
-import { describe, expect, it } from "vitest";
-import { selectRunConnections } from "./executor.js";
+import type { PrismaClient } from "@rakazo/db";
+import { describe, expect, it, vi } from "vitest";
+import { mergeConnectedPlugins } from "./composio-connector.js";
+import { persistLivePluginConnections, selectRunConnections } from "./executor.js";
 
 describe("run connection selection", () => {
+  it("uses synchronized account statuses in the current run", async () => {
+    const rows = [
+      { id: "gmail", provider: "gmail", status: "error" },
+      { id: "slack", provider: "slack", status: "revoked" },
+      { id: "slack-old", provider: "slack", status: "revoked" },
+      { id: "gmail-duplicate", provider: "gmail", status: "pending" },
+    ].map((row) => ({ ...row, connectorId: "composio", displayName: row.provider }));
+    const prisma = {
+      connection: { updateMany: vi.fn().mockResolvedValue({ count: 2 }) },
+    } as unknown as PrismaClient;
+    const liveSlugs = ["gmail", "slack"];
+
+    await persistLivePluginConnections(
+      prisma,
+      { userId: "user", spaceId: "space" },
+      rows,
+      liveSlugs,
+    );
+
+    expect(rows.map((row) => row.status)).toEqual(["connected", "connected", "revoked", "revoked"]);
+    expect(
+      selectRunConnections(
+        rows,
+        mergeConnectedPlugins(rows, liveSlugs).map((row) => row.provider),
+      ),
+    ).toEqual([rows[0], rows[1]]);
+  });
+
+  it("does not recover a revoked account when persistence fails", async () => {
+    const rows = [
+      {
+        id: "slack",
+        connectorId: "composio",
+        provider: "slack",
+        displayName: "Slack",
+        status: "revoked",
+      },
+    ];
+    const prisma = {
+      connection: { updateMany: vi.fn().mockRejectedValue(new Error("database unavailable")) },
+    } as unknown as PrismaClient;
+    await expect(
+      persistLivePluginConnections(prisma, { userId: "user", spaceId: "space" }, rows, ["slack"]),
+    ).rejects.toThrow("database unavailable");
+    expect(selectRunConnections(rows, ["slack"])).toEqual([]);
+  });
+
   it("does not send revoked accounts alongside a reconnected toolkit", () => {
     const oldAccount = {
       connectorId: "composio",

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -608,7 +608,7 @@ async function loadLivePluginSlugs(
   }
 }
 
-async function persistLivePluginConnections(
+export async function persistLivePluginConnections(
   prisma: PrismaClient,
   owner: { userId: string; spaceId: string },
   rows: PluginConnectionRow[],
@@ -624,6 +624,9 @@ async function persistLivePluginConnections(
       },
       data: { status: "connected" },
     });
+    for (const row of rows) {
+      if (sync.connectIds.includes(row.id)) row.status = "connected";
+    }
   }
   if (sync.revokeIds.length > 0) {
     await prisma.connection.updateMany({
@@ -634,6 +637,9 @@ async function persistLivePluginConnections(
       },
       data: { status: "revoked" },
     });
+    for (const row of rows) {
+      if (sync.revokeIds.includes(row.id)) row.status = "revoked";
+    }
   }
 }
 

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1142,13 +1142,9 @@ export function createRunExecutor(deps: ExecutorDeps) {
           }
         }
         const connectedComposio = mergeConnectedPlugins(composioRows, liveSlugs);
-        const activeKeys = new Set(
-          connectedComposio.map((connection) => `composio:${connection.provider}`),
-        );
-        const connectedPlugins = storedConnections.filter(
-          (connection) =>
-            connection.status === "connected" ||
-            activeKeys.has(`${connection.connectorId}:${connection.provider}`),
+        const connectedPlugins = selectRunConnections(
+          storedConnections,
+          connectedComposio.map((connection) => connection.provider),
         );
         const context = {
           operationId: runId,
@@ -4593,6 +4589,17 @@ async function withModelCredentialLock<T>(key: string, fn: () => Promise<T>): Pr
     release();
     if (modelCredentialLocks.get(key) === current) modelCredentialLocks.delete(key);
   }
+}
+
+export function selectRunConnections<
+  T extends { connectorId: string; provider: string; status: string },
+>(rows: T[], connectedComposioProviders: string[]): T[] {
+  const activeKeys = new Set(connectedComposioProviders.map((provider) => `composio:${provider}`));
+  return rows.filter(
+    (row) =>
+      row.status !== "revoked" &&
+      (row.status === "connected" || activeKeys.has(`${row.connectorId}:${row.provider}`)),
+  );
 }
 
 export async function loadCurrentTurnImages(


### PR DESCRIPTION
Reconnecting a Composio toolkit can leave revoked connection records alongside the active account. Run setup currently includes every record for an active toolkit, so stale connected-account IDs reach Composio and cause `ToolRouterV2_InvalidConnectedAccountIds`. Tool discovery then fails for the entire Composio provider even though the integration appears connected.

Exclude revoked records when selecting run connections. Apply successfully persisted live-sync statuses to the in-memory rows so a recovered account is available in the same run and newly revoked duplicates are excluded. Preserve connected accounts from other providers.

Based on [@makhonyiu](https://github.com/makhonyiu)'s work in #847 (closed by the author). Thanks!

Validation: all 73 executor and Composio tests pass, adapter TypeScript checking passes, and Biome checks pass. Coverage includes revoked duplicates, same-run recovery, and failed persistence.