### PR TITLE
fix(adapters): normalize OpenAI tool parameters for local servers

### DIFF
--- a/packages/adapters/src/openai-tool-parameters.test.ts
+++ b/packages/adapters/src/openai-tool-parameters.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { builtinAgentTools } from "./builtin-tools.js";
+import {
+  normalizeOpenAiToolParameters,
+  openAiToolParametersNeedNormalization,
+} from "./openai-tool-parameters.js";
+import { parametersFor } from "./pi-runtime.js";
+
+describe("normalizeOpenAiToolParameters", () => {
+  it("fills properties for a zero-argument object schema", () => {
+    expect(normalizeOpenAiToolParameters({ type: "object" })).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
+  it("keeps an empty properties map and does not invent parameters", () => {
+    expect(normalizeOpenAiToolParameters({ type: "object", properties: {} })).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
+  it("forces type object when a union discriminator is missing", () => {
+    const normalized = normalizeOpenAiToolParameters({
+      anyOf: [
+        { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+        { type: "object", properties: { b: { type: "string" } }, required: ["b"] },
+      ],
+    });
+    expect(normalized.type).toBe("object");
+    expect(normalized.properties).toEqual({});
+    expect(normalized.anyOf).toHaveLength(2);
+  });
+
+  it("preserves required, additionalProperties, and existing properties", () => {
+    expect(
+      normalizeOpenAiToolParameters({
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+        additionalProperties: false,
+      }),
+    ).toEqual({
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+      additionalProperties: false,
+    });
+  });
+
+  it("replaces a non-object type with object without inventing fields", () => {
+    expect(normalizeOpenAiToolParameters({ type: "string" })).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
+  it("treats nullish or non-object input as an empty object schema", () => {
+    expect(normalizeOpenAiToolParameters(undefined)).toEqual({
+      type: "object",
+      properties: {},
+    });
+    expect(normalizeOpenAiToolParameters(null)).toEqual({
+      type: "object",
+      properties: {},
+    });
+    expect(normalizeOpenAiToolParameters([])).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+});
+
+describe("openAiToolParametersNeedNormalization", () => {
+  it("returns false for a complete object schema", () => {
+    expect(openAiToolParametersNeedNormalization({ type: "object", properties: {} })).toBe(false);
+  });
+
+  it("returns true when type or properties are missing or malformed", () => {
+    expect(openAiToolParametersNeedNormalization({ type: "object" })).toBe(true);
+    expect(openAiToolParametersNeedNormalization({ anyOf: [] })).toBe(true);
+    expect(openAiToolParametersNeedNormalization({ type: "object", properties: [] })).toBe(true);
+    expect(openAiToolParametersNeedNormalization({ type: "string", properties: {} })).toBe(true);
+  });
+});
+
+describe("parametersFor OpenAI wire fidelity", () => {
+  it("serializes zero-argument tools with type object and empty properties", () => {
+    const tool = builtinAgentTools.find((entry) => entry.name === "list_secrets");
+    if (!tool) throw new Error("missing list_secrets");
+    const wire = JSON.parse(JSON.stringify(parametersFor(tool))) as {
+      type?: unknown;
+      properties?: unknown;
+    };
+    expect(wire.type).toBe("object");
+    expect(wire.properties).toEqual({});
+  });
+
+  it("serializes request_secret union with type object and empty properties", () => {
+    const tool = builtinAgentTools.find((entry) => entry.name === "request_secret");
+    if (!tool) throw new Error("missing request_secret");
+    const wire = JSON.parse(JSON.stringify(parametersFor(tool))) as {
+      type?: unknown;
+      properties?: unknown;
+      anyOf?: unknown[];
+      oneOf?: unknown[];
+    };
+    expect(wire.type).toBe("object");
+    expect(wire.properties).toEqual({});
+    expect((wire.anyOf ?? wire.oneOf ?? []).length).toBe(2);
+  });
+});

--- a/packages/adapters/src/openai-tool-parameters.ts
+++ b/packages/adapters/src/openai-tool-parameters.ts
@@ -1,0 +1,34 @@
+/**
+ * OpenAI chat-completions `tools[].function.parameters` must be a JSON Schema
+ * object. Hosted proxies (OpenRouter) are lenient; local OpenAI-compatible
+ * servers (LM Studio, etc.) reject missing `type: "object"` and often reject
+ * zero-argument schemas that omit `properties`.
+ *
+ * Normalize at the adapter boundary so every openai-completions path benefits.
+ * Does not invent parameter names — only ensures the required envelope.
+ */
+export function normalizeOpenAiToolParameters(parameters: unknown): Record<string, unknown> {
+  const schema =
+    parameters && typeof parameters === "object" && !Array.isArray(parameters)
+      ? { ...(parameters as Record<string, unknown>) }
+      : {};
+  const properties =
+    schema.properties != null &&
+    typeof schema.properties === "object" &&
+    !Array.isArray(schema.properties)
+      ? schema.properties
+      : {};
+  return { ...schema, type: "object", properties };
+}
+
+/** True when a schema would fail stricter OpenAI-compatible tool validators. */
+export function openAiToolParametersNeedNormalization(parameters: unknown): boolean {
+  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) return true;
+  const schema = parameters as Record<string, unknown>;
+  if (schema.type !== "object") return true;
+  return (
+    schema.properties == null ||
+    typeof schema.properties !== "object" ||
+    Array.isArray(schema.properties)
+  );
+}

--- a/packages/adapters/src/pi-runtime-secret-schema.test.ts
+++ b/packages/adapters/src/pi-runtime-secret-schema.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import { builtinAgentTools } from "./builtin-tools.js";
 import { parseConnectorToolArgs } from "./lazy-tool-catalog.js";
-import { jsonField, jsonSchemaParameters, prepareRequestSecretArguments } from "./pi-runtime.js";
+import {
+  jsonField,
+  jsonSchemaParameters,
+  parametersFor,
+  prepareRequestSecretArguments,
+} from "./pi-runtime.js";
 
 /**
  * `pi-runtime` used to re-declare `request_secret`'s parameters by hand, and the
@@ -124,6 +129,21 @@ describe("request_secret parameters", () => {
     for (const variant of variants) {
       expect(variant.additionalProperties).toBe(false);
     }
+  });
+
+  it("exposes OpenAI-compatible parameters.type object for local servers", () => {
+    // LM Studio and similar validators reject tools[].function.parameters without
+    // type === "object" (and often without properties). request_secret is the
+    // builtin that previously serialized as a bare anyOf union.
+    const wire = JSON.parse(JSON.stringify(parametersFor(toolNamed("request_secret")))) as {
+      type?: unknown;
+      properties?: unknown;
+      anyOf?: unknown[];
+      oneOf?: unknown[];
+    };
+    expect(wire.type).toBe("object");
+    expect(wire.properties).toEqual({});
+    expect((wire.anyOf ?? wire.oneOf ?? []).length).toBe(2);
   });
 });
 

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -29,6 +29,10 @@ import { getLogger } from "@rakazo/logging";
 import { isToolPauseResult } from "./approval-effect.js";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
 import { DEFAULT_OPENROUTER_MODEL_ID } from "./deployment-model.js";
+import {
+  normalizeOpenAiToolParameters,
+  openAiToolParametersNeedNormalization,
+} from "./openai-tool-parameters.js";
 import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js";
 import { registerLocalProvider } from "./pi-local-provider.js";
 import {
@@ -1116,8 +1120,15 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
   }
 }
 
-function parametersFor(tool: ConnectorTool) {
-  return builtinParameters(tool) ?? safeJsonSchemaParameters(tool);
+/** Build AgentTool.parameters for a connector tool, including OpenAI wire fidelity. */
+export function parametersFor(tool: ConnectorTool) {
+  const schema = builtinParameters(tool) ?? safeJsonSchemaParameters(tool);
+  // Type.Union (top-level oneOf/anyOf) serializes without type/properties.
+  // Re-wrap only when needed so Type.Object schemas keep TypeBox Kind metadata.
+  if (!openAiToolParametersNeedNormalization(schema)) return schema;
+  return Type.Unsafe(
+    normalizeOpenAiToolParameters(JSON.parse(JSON.stringify(schema))),
+  ) as ReturnType<typeof Type.Object>;
 }
 
 /** A remote MCP server controls its own schemas, so a shape TypeBox cannot express must

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1128,7 +1128,7 @@ export function parametersFor(tool: ConnectorTool) {
   if (!openAiToolParametersNeedNormalization(schema)) return schema;
   return Type.Unsafe(
     normalizeOpenAiToolParameters(JSON.parse(JSON.stringify(schema))),
-  ) as ReturnType<typeof Type.Object>;
+  ) as unknown as ReturnType<typeof Type.Object>;
 }
 
 /** A remote MCP server controls its own schemas, so a shape TypeBox cannot express must


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Self-hosted bots pointed at a local OpenAI-compatible server (e.g. LM Studio via `RAKAZO_LOCAL_MODELS_URL`) fail chat with HTTP 400: stricter validators reject `tools[].function.parameters` when `type` is not exactly `"object"`, and often reject zero-argument schemas that omit `properties`. The same model works via OpenRouter, so this is outbound tool JSON Schema fidelity, not the model.

The builtin that triggered the reported `tools[15]` failure is `request_secret`, whose top-level `oneOf` became a TypeBox union that serialized as a bare `anyOf` without `type`/`properties`.

## What changed

- Added a small shared normalizer (`normalizeOpenAiToolParameters`) that forces `type: "object"` and ensures a `properties` object (`{}` when there are no args), without inventing parameter names.
- Applied it in `parametersFor` at the adapter/request boundary so every openai-completions path (local, OpenAI-compatible, hosted) benefits — not an LM Studio-only hack.
- Unit tests cover zero-arg tools, missing/malformed `type`, and `request_secret`'s union wire shape.

## How tested

- Focused vitest run for the normalizer, secret-schema, and tool-schema tests (29 passed)
- Biome check on the touched files passed
- CI checks on this PR are green

No UI changes; no screenshots.

Fixes #851
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c0ed87c-8810-4201-a72f-47646fc336b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c0ed87c-8810-4201-a72f-47646fc336b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

