### PR TITLE
fix(adapters): preserve nullable connector tool parameters

### DIFF
--- a/packages/adapters/src/pi-runtime-tool-schema.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-schema.test.ts
@@ -1,7 +1,84 @@
 import { describe, expect, it } from "vitest";
-import { jsonSchemaParameters } from "./pi-runtime.js";
+import { parseConnectorToolArgs } from "./lazy-tool-catalog.js";
+import { jsonSchemaParameters, parametersFor } from "./pi-runtime.js";
 
 describe("jsonSchemaParameters", () => {
+  it("keeps model-facing nullable parameters compatible with connector validation", () => {
+    const tool = {
+      name: "catalog_lookup",
+      description: "Look up catalog entries",
+      inputSchema: {
+        type: "object",
+        properties: { enabled: { type: ["boolean", "null"] } },
+        required: ["enabled"],
+      },
+    };
+    const wire = JSON.parse(JSON.stringify(parametersFor(tool)));
+    for (const enabled of [true, false, null]) {
+      expect(parseConnectorToolArgs(wire, { enabled })).toEqual(
+        parseConnectorToolArgs(tool.inputSchema, { enabled }),
+      );
+    }
+    expect(() => parseConnectorToolArgs(wire, { enabled: "false" })).toThrow();
+    expect(() => parseConnectorToolArgs(wire, {})).toThrow();
+  });
+
+  it("preserves nullable object fields instead of advertising strings", () => {
+    const schema = jsonSchemaParameters({
+      type: "object",
+      properties: {
+        filter: {
+          type: ["object", "null"],
+          properties: { enabled: { type: "boolean" } },
+          required: ["enabled"],
+          additionalProperties: false,
+        },
+      },
+      required: ["filter"],
+    });
+    expect(JSON.parse(JSON.stringify(schema))).toEqual({
+      type: "object",
+      required: ["filter"],
+      properties: {
+        filter: {
+          anyOf: [
+            {
+              type: "object",
+              properties: { enabled: { type: "boolean" } },
+              required: ["enabled"],
+              additionalProperties: false,
+            },
+            { type: "null" },
+          ],
+        },
+      },
+    });
+  });
+
+  it("preserves null branches in anyOf", () => {
+    const schema = jsonSchemaParameters({
+      type: "object",
+      properties: { cursor: { anyOf: [{ type: "string" }, { type: "null" }] } },
+    });
+    expect(JSON.parse(JSON.stringify(schema)).properties.cursor).toEqual({
+      anyOf: [{ type: "string" }, { type: "null" }],
+    });
+  });
+
+  it("preserves nullable array items and array constraints", () => {
+    const schema = jsonSchemaParameters({
+      type: "object",
+      properties: {
+        values: { type: "array", items: { type: ["boolean", "null"] }, minItems: 1 },
+      },
+    });
+    expect(JSON.parse(JSON.stringify(schema)).properties.values).toEqual({
+      type: "array",
+      minItems: 1,
+      items: { anyOf: [{ type: "boolean" }, { type: "null" }] },
+    });
+  });
+
   it("keeps primitive enums as literal unions", () => {
     const schema = jsonSchemaParameters({
       type: "object",

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1363,7 +1363,11 @@ export function jsonField(spec: unknown): ReturnType<typeof Type.String> {
   if (variants && variants.length > 0) {
     return Type.Union(variants.map((variant) => jsonField(variant))) as never;
   }
+  if (Array.isArray(definition.type) && definition.type.length > 0) {
+    return Type.Union(definition.type.map((type) => jsonField({ ...definition, type }))) as never;
+  }
   const type = "type" in definition ? String(definition.type) : "string";
+  if (type === "null") return Type.Null() as never;
   if (type === "number" || type === "integer") return Type.Number() as never;
   if (type === "boolean") return Type.Boolean() as never;
   if (type === "array") {


### PR DESCRIPTION
## Why

Connector tools can describe nullable filters, cursors, and array elements with JSON Schema type arrays or explicit null branches. The runtime currently turns `type: ["object", "null"]` into a string schema, losing the object's fields, and turns `type: "null"` into a string as well. The model is then asked to send values that disagree with the connector's original argument validator.

This complements the top-level object envelope fix in #853: nested nullable fields still need to retain their actual types.

## What changed

- Translate JSON Schema type arrays into TypeBox unions using the existing field conversion.
- Preserve explicit null fields with `Type.Null()`.
- Cover nullable object fields, null union branches, nullable array elements, and the model-facing `parametersFor` boundary against connector argument validation.

No provider-specific switches, UI changes, or changes to connector execution policy.

## Testing

- Three wire-schema regressions fail on the original implementation and pass with the fix.
- Additional boundary regression verifies boolean/null values remain valid while strings and missing required values are rejected.
- Focused schema suites: 33 tests passed, including the additional boundary regression.
- Full adapters suite on the final commit: 1,667 passed, 25 skipped.
- Core suite: 458 passed.
- Adapters TypeScript check, targeted Biome check, and diff whitespace check passed.

No live model or external MCP server was used; the reproduction is deterministic and offline.
