### PR TITLE
fix(k8s): allow CGNAT screen proxy and publish computer VNC on 0.0.0.0

### DIFF
--- a/apps/api/src/computer-status.ts
+++ b/apps/api/src/computer-status.ts
@@ -72,8 +72,9 @@ export function toComputerStatus(
           computer?.state === "error"
         ? computer.state
         : "stopped";
-  const screen = computerScreenSize(computer?.kind);
-  const kind = (computer?.kind ?? "fake") as ComputerStatus["kind"];
+  const rawKind = computer?.kind === "none" ? "fake" : computer?.kind;
+  const screen = computerScreenSize(rawKind);
+  const kind = (rawKind ?? "fake") as ComputerStatus["kind"];
   return {
     botId,
     mode: computer?.scope === "dedicated" ? "dedicated" : "team",

--- a/infra/k8s/31-supervisor.yaml
+++ b/infra/k8s/31-supervisor.yaml
@@ -1,0 +1,141 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: supervisor
+  namespace: rakazo
+  labels:
+    app.kubernetes.io/name: rakazo
+    app.kubernetes.io/component: supervisor
+spec:
+  selector:
+    app.kubernetes.io/name: rakazo
+    app.kubernetes.io/component: supervisor
+  ports:
+    - name: http
+      port: 7091
+      targetPort: 7091
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: supervisor
+  namespace: rakazo
+  labels:
+    app.kubernetes.io/name: rakazo
+    app.kubernetes.io/component: supervisor
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rakazo
+      app.kubernetes.io/component: supervisor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rakazo
+        app.kubernetes.io/component: supervisor
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        fsGroup: 1000
+      volumes:
+        - name: docker-sock
+          emptyDir: {}
+        - name: docker-graph
+          emptyDir: {}
+        - name: appdata
+          persistentVolumeClaim:
+            claimName: app-data
+      initContainers:
+        - name: chown-data
+          image: busybox:1.36
+          command: ["sh", "-c", "chown 1000:1000 /data; chmod 755 /data"]
+          volumeMounts:
+            - name: appdata
+              mountPath: /data
+      containers:
+        - name: dind
+          image: docker:27-dind
+          imagePullPolicy: IfNotPresent
+          args:
+            - --storage-driver=overlay2
+            - --host=unix:///var/run/docker.sock
+            - --host=tcp://0.0.0.0:2375
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: docker-sock
+              mountPath: /var/run
+            - name: docker-graph
+              mountPath: /var/lib/docker
+            - name: appdata
+              mountPath: /data
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "docker info >/dev/null 2>&1 || ls /var/run/docker.sock >/dev/null"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+
+        - name: supervisor
+          image: ghcr.io/elie222/rakazo/app:edge
+          imagePullPolicy: Always
+          command: ["bash", "-lc", "pnpm --filter @rakazo/sandbox-supervisor start"]
+          ports:
+            - containerPort: 7091
+              name: http
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: SUPERVISOR_HOST
+              value: "0.0.0.0"
+            - name: SUPERVISOR_PORT
+              value: "7091"
+            - name: DATA_DIR
+              value: "/data"
+            - name: DOCKER_HOST
+              value: "tcp://127.0.0.1:2375"
+            - name: RAKAZO_COMPUTER_IMAGE
+              value: "ghcr.io/elie222/rakazo/computer:edge"
+            - name: SANDBOX_SUPERVISOR_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: rakazo-secrets
+                  key: SANDBOX_SUPERVISOR_TOKEN
+            - name: SANDBOX_SCREEN_NETWORK
+              value: "published"
+          volumeMounts:
+            - name: appdata
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 7091
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 7091
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1536Mi

--- a/infra/k8s/31-supervisor.yaml
+++ b/infra/k8s/31-supervisor.yaml
@@ -62,7 +62,7 @@ spec:
           args:
             - --storage-driver=overlay2
             - --host=unix:///var/run/docker.sock
-            - --host=tcp://0.0.0.0:2375
+            - --host=tcp://127.0.0.1:2375
           env:
             - name: DOCKER_TLS_CERTDIR
               value: ""
@@ -92,22 +92,7 @@ spec:
         - name: supervisor
           image: ghcr.io/elie222/rakazo/app:edge
           imagePullPolicy: Always
-          securityContext:
-            runAsUser: 0
-          command:
-            - bash
-            - -lc
-            - |
-              set -e
-              f=/app/infra/sandboxes/supervisor/src/computer-spec.ts
-              if grep -q 'HostIp: "127.0.0.1"' "$f"; then
-                t=$(mktemp)
-                perl -0777 -pe 's/HostIp: "127\.0\.0\.1"/HostIp: "0.0.0.0"/g; s/binding\.HostIp !== "127\.0\.0\.1"/binding.HostIp !== "127.0.0.1" \&\& binding.HostIp !== "0.0.0.0" \&\& binding.HostIp !== ""/g; s/binding\.HostIp === "127\.0\.0\.1"/(binding.HostIp === "127.0.0.1" || binding.HostIp === "0.0.0.0" || binding.HostIp === "")/g' "$f" > "$t"
-                cat "$t" > "$f"
-                rm -f "$t"
-                echo "[supervisor-hotfix] patched $f HostIp 127.0.0.1 -> 0.0.0.0"
-              fi
-              exec runuser -u node -- pnpm --filter @rakazo/sandbox-supervisor start
+          command: ["bash", "-lc", "pnpm --filter @rakazo/sandbox-supervisor start"]
           ports:
             - containerPort: 7091
               name: http

--- a/infra/k8s/31-supervisor.yaml
+++ b/infra/k8s/31-supervisor.yaml
@@ -92,7 +92,22 @@ spec:
         - name: supervisor
           image: ghcr.io/elie222/rakazo/app:edge
           imagePullPolicy: Always
-          command: ["bash", "-lc", "pnpm --filter @rakazo/sandbox-supervisor start"]
+          securityContext:
+            runAsUser: 0
+          command:
+            - bash
+            - -lc
+            - |
+              set -e
+              f=/app/infra/sandboxes/supervisor/src/computer-spec.ts
+              if grep -q 'HostIp: "127.0.0.1"' "$f"; then
+                t=$(mktemp)
+                perl -0777 -pe 's/HostIp: "127\.0\.0\.1"/HostIp: "0.0.0.0"/g; s/binding\.HostIp !== "127\.0\.0\.1"/binding.HostIp !== "127.0.0.1" \&\& binding.HostIp !== "0.0.0.0" \&\& binding.HostIp !== ""/g; s/binding\.HostIp === "127\.0\.0\.1"/(binding.HostIp === "127.0.0.1" || binding.HostIp === "0.0.0.0" || binding.HostIp === "")/g' "$f" > "$t"
+                cat "$t" > "$f"
+                rm -f "$t"
+                echo "[supervisor-hotfix] patched $f HostIp 127.0.0.1 -> 0.0.0.0"
+              fi
+              exec runuser -u node -- pnpm --filter @rakazo/sandbox-supervisor start
           ports:
             - containerPort: 7091
               name: http
@@ -116,6 +131,10 @@ spec:
                   key: SANDBOX_SUPERVISOR_TOKEN
             - name: SANDBOX_SCREEN_NETWORK
               value: "published"
+            - name: SANDBOX_SCREEN_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           volumeMounts:
             - name: appdata
               mountPath: /data

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -26,12 +26,12 @@ import {
   legacyNetworkOwnedSolelyBy,
   parseMemoryBytes,
   publishedLoopbackControlHostPort,
+  publishedScreenHostIp,
   resolveComputerControlEndpoint,
   resolveScreenNetworkMode,
   resolveScreenPublishTarget,
   resolveSpaceComputerLimit,
   resolveTeamScreenLimit,
-  publishedScreenHostIp,
   screenPorts,
   screenUrlFor,
   screenUrlWithToken,
@@ -99,6 +99,8 @@ describe("graphical computer spec", () => {
     expect(publishedScreenHostIp("127.0.0.1")).toBe("127.0.0.1");
     expect(publishedScreenHostIp("localhost")).toBe("127.0.0.1");
     expect(publishedScreenHostIp("::1")).toBe("127.0.0.1");
+    expect(publishedScreenHostIp("")).toBe("127.0.0.1");
+    expect(publishedScreenHostIp("   ")).toBe("127.0.0.1");
     expect(publishedScreenHostIp("100.96.0.30")).toBe("0.0.0.0");
     expect(options.HostConfig.PortBindings).not.toHaveProperty("6081/tcp");
     expect(options.HostConfig.PortBindings).not.toHaveProperty("6082/tcp");
@@ -352,7 +354,7 @@ describe("graphical computer spec", () => {
 
   it("uses the published host mapping in the default topology even when a container IP exists", () => {
     // Regression: per-bot NetworkMode always yields a 172.x address. Returning
-    // that to clients makes local/dev screens look dead — browsers cannot load
+    // that to clients makes local/dev screens look dead - browsers cannot load
     // docker-internal IPs. Probe and return the host mapping instead.
     const networkMode = computerNetworkNameFor("bot_1");
     expect(
@@ -514,12 +516,25 @@ describe("graphical computer spec", () => {
   it.each(["0.0.0.0", ""])(
     "accepts all-interfaces control bindings for cross-pod publication (%j)",
     (HostIp) => {
-      const bindings = { "7070/tcp": [{ HostIp, HostPort: "55100" }] };
-      expect(controlPortPublicationMatches(bindings, true)).toBe(true);
-      expect(controlPortPublicationMatches(bindings, false)).toBe(false);
-      expect(publishedLoopbackControlHostPort(bindings)).toBe("55100");
+      const previous = process.env.SANDBOX_SCREEN_HOST;
+      process.env.SANDBOX_SCREEN_HOST = "100.96.0.30";
+      try {
+        const bindings = { "7070/tcp": [{ HostIp, HostPort: "55100" }] };
+        expect(controlPortPublicationMatches(bindings, true)).toBe(true);
+        expect(controlPortPublicationMatches(bindings, false)).toBe(false);
+        expect(publishedLoopbackControlHostPort(bindings)).toBe("55100");
+      } finally {
+        if (previous === undefined) delete process.env.SANDBOX_SCREEN_HOST;
+        else process.env.SANDBOX_SCREEN_HOST = previous;
+      }
     },
   );
+
+  it("does not reuse all-interfaces control bindings under loopback screen host", () => {
+    const bindings = { "7070/tcp": [{ HostIp: "0.0.0.0", HostPort: "55100" }] };
+    expect(controlPortPublicationMatches(bindings, true)).toBe(false);
+    expect(publishedLoopbackControlHostPort(bindings)).toBe("55100");
+  });
 
   it.each(["::", "192.0.2.1", undefined])(
     "rejects external control bindings even alongside loopback (%j)",

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -31,6 +31,7 @@ import {
   resolveScreenPublishTarget,
   resolveSpaceComputerLimit,
   resolveTeamScreenLimit,
+  publishedScreenHostIp,
   screenPorts,
   screenUrlFor,
   screenUrlWithToken,
@@ -94,6 +95,11 @@ describe("graphical computer spec", () => {
     expect(options.ExposedPorts).not.toHaveProperty("7070/tcp");
     expect(options.HostConfig.PortBindings).not.toHaveProperty("7070/tcp");
     expect(options.HostConfig.PortBindings["6080/tcp"]?.[0]?.HostIp).toBe("127.0.0.1");
+    expect(publishedScreenHostIp()).toBe("127.0.0.1");
+    expect(publishedScreenHostIp("127.0.0.1")).toBe("127.0.0.1");
+    expect(publishedScreenHostIp("localhost")).toBe("127.0.0.1");
+    expect(publishedScreenHostIp("::1")).toBe("127.0.0.1");
+    expect(publishedScreenHostIp("100.96.0.30")).toBe("0.0.0.0");
     expect(options.HostConfig.PortBindings).not.toHaveProperty("6081/tcp");
     expect(options.HostConfig.PortBindings).not.toHaveProperty("6082/tcp");
     expect(screenPorts(0)).toMatchObject({ display: ":1", viewPort: "6080", controlPort: "6080" });
@@ -105,6 +111,32 @@ describe("graphical computer spec", () => {
     expect(options.HostConfig.PidsLimit).toBe(2048);
     expect(options.HostConfig.ReadonlyPaths).toContain("/usr/share/novnc");
     expect(options.HostConfig.NetworkMode).toBe("rakazo_default");
+  });
+
+  it("binds published ports on all interfaces when SANDBOX_SCREEN_HOST is non-loopback", () => {
+    const previous = process.env.SANDBOX_SCREEN_HOST;
+    process.env.SANDBOX_SCREEN_HOST = "100.96.0.30";
+    try {
+      expect(publishedScreenHostIp()).toBe("0.0.0.0");
+      const options = containerCreateOptions({
+        name: "rakazo-bot-abc",
+        image: COMPUTER_IMAGE,
+        botId: "abc",
+        spaceId: "ws",
+        homePath: "/var/rakazo/homes/abc",
+        networkMode: "rakazo_default",
+        publishControlPort: true,
+      });
+      expect(options.HostConfig.PortBindings["6080/tcp"]).toEqual([
+        { HostIp: "0.0.0.0", HostPort: "0" },
+      ]);
+      expect(options.HostConfig.PortBindings["7070/tcp"]).toEqual([
+        { HostIp: "0.0.0.0", HostPort: "0" },
+      ]);
+    } finally {
+      if (previous === undefined) delete process.env.SANDBOX_SCREEN_HOST;
+      else process.env.SANDBOX_SCREEN_HOST = previous;
+    }
   });
 
   it("still publishes host ports when NetworkMode is a per-bot isolated network", () => {
@@ -479,7 +511,17 @@ describe("graphical computer spec", () => {
     },
   );
 
-  it.each(["0.0.0.0", "", "::", "192.0.2.1", undefined])(
+  it.each(["0.0.0.0", ""])(
+    "accepts all-interfaces control bindings for cross-pod publication (%j)",
+    (HostIp) => {
+      const bindings = { "7070/tcp": [{ HostIp, HostPort: "55100" }] };
+      expect(controlPortPublicationMatches(bindings, true)).toBe(true);
+      expect(controlPortPublicationMatches(bindings, false)).toBe(false);
+      expect(publishedLoopbackControlHostPort(bindings)).toBe("55100");
+    },
+  );
+
+  it.each(["::", "192.0.2.1", undefined])(
     "rejects external control bindings even alongside loopback (%j)",
     (HostIp) => {
       const external = { HostIp, HostPort: "55100" };

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -14,13 +14,14 @@ export const SCREEN_HOST = process.env.SANDBOX_SCREEN_HOST ?? "127.0.0.1";
 export type ScreenNetworkMode = "published" | "internal" | "isolated";
 
 function isLoopbackScreenHost(host: string) {
-  return host === "127.0.0.1" || host === "localhost" || host === "::1";
+  return host === "127.0.0.1" || host === "localhost" || host === "::1" || host.trim() === "";
 }
 
 /**
  * Publish computer VNC/control on loopback by default so local Docker Desktop
  * does not expose the screen on the LAN. Only bind all interfaces when
  * SANDBOX_SCREEN_HOST is a non-loopback address (e.g. the k8s pod IP).
+ * Empty / whitespace SANDBOX_SCREEN_HOST is treated as loopback - never 0.0.0.0.
  */
 export function publishedScreenHostIp(
   host = process.env.SANDBOX_SCREEN_HOST ?? "127.0.0.1",
@@ -28,9 +29,20 @@ export function publishedScreenHostIp(
   return isLoopbackScreenHost(host) ? "127.0.0.1" : "0.0.0.0";
 }
 
-/** Accept loopback, or Docker's all-interfaces forms — never a concrete external IP. */
+/** Accept loopback, or Docker's all-interfaces forms - never a concrete external IP. */
 function isAcceptedPublishedHostIp(hostIp: string | undefined) {
   return hostIp === "127.0.0.1" || hostIp === "0.0.0.0" || hostIp === "";
+}
+
+/**
+ * Reuse only when HostIp matches what we would publish for the current
+ * SANDBOX_SCREEN_HOST (loopback vs all-interfaces for CGNAT/cross-pod).
+ */
+function hostIpMatchesCurrentPublication(hostIp: string | undefined): boolean {
+  const expected = publishedScreenHostIp();
+  if (expected === "127.0.0.1") return hostIp === "127.0.0.1";
+  // Docker may record all-interfaces publication as "" or "0.0.0.0".
+  return hostIp === "0.0.0.0" || hostIp === "";
 }
 
 export function resolveTeamScreenLimit(value = process.env.SANDBOX_TEAM_SCREEN_LIMIT): number {
@@ -319,7 +331,7 @@ export function containerNameFor(botId: string) {
 
 export function computerNetworkNameFor(botId: string) {
   // Keep distinct botIds on distinct networks even when sanitization collapses
-  // characters (e.g. "a/b" and "ab"). Do not change containerNameFor — that
+  // characters (e.g. "a/b" and "ab"). Do not change containerNameFor - that
   // name must stay stable so an existing computer can resume.
   const hash = createHash("sha256").update(botId).digest("hex").slice(0, 32);
   return `rakazo-computer-${sanitizeIdentifier(botId).slice(0, 32)}-${hash}`;
@@ -416,7 +428,7 @@ export function controlPortPublicationMatches(
     !!bindings?.length &&
     bindings.every(
       (binding) =>
-        isAcceptedPublishedHostIp(binding.HostIp) &&
+        hostIpMatchesCurrentPublication(binding.HostIp) &&
         (binding.HostPort === "" || binding.HostPort === "0" || validHostPort(binding.HostPort)),
     )
   );

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -13,6 +13,26 @@ export const COMPUTER_CONTROL_PORT = 7070;
 export const SCREEN_HOST = process.env.SANDBOX_SCREEN_HOST ?? "127.0.0.1";
 export type ScreenNetworkMode = "published" | "internal" | "isolated";
 
+function isLoopbackScreenHost(host: string) {
+  return host === "127.0.0.1" || host === "localhost" || host === "::1";
+}
+
+/**
+ * Publish computer VNC/control on loopback by default so local Docker Desktop
+ * does not expose the screen on the LAN. Only bind all interfaces when
+ * SANDBOX_SCREEN_HOST is a non-loopback address (e.g. the k8s pod IP).
+ */
+export function publishedScreenHostIp(
+  host = process.env.SANDBOX_SCREEN_HOST ?? "127.0.0.1",
+): "127.0.0.1" | "0.0.0.0" {
+  return isLoopbackScreenHost(host) ? "127.0.0.1" : "0.0.0.0";
+}
+
+/** Accept loopback, or Docker's all-interfaces forms — never a concrete external IP. */
+function isAcceptedPublishedHostIp(hostIp: string | undefined) {
+  return hostIp === "127.0.0.1" || hostIp === "0.0.0.0" || hostIp === "";
+}
+
 export function resolveTeamScreenLimit(value = process.env.SANDBOX_TEAM_SCREEN_LIMIT): number {
   if (value === undefined || value.trim() === "" || isUnlimited(value)) return MAX_DESKTOP_DISPLAY;
   const limit = Number(value);
@@ -152,16 +172,15 @@ export function computerPortBindings(publishControlPort = false) {
   const ExposedPorts: Record<string, object> = {};
   const PortBindings: Record<string, Array<{ HostIp: string; HostPort: string }>> = {};
   const port = `${screenPorts(0).viewPort}/tcp`;
+  const hostIp = publishedScreenHostIp();
   ExposedPorts[port] = {};
-  // In k8s the supervisor and web run in different pods. Binding on 127.0.0.1
-  // is only reachable from inside the supervisor pod itself — web's loopback
-  // is a different network namespace, so the novnc proxy gets ECONNREFUSED
-  // → 502. Bind on 0.0.0.0 so the mapped port is reachable via the pod IP.
-  // The supervisor still reaches it via 127.0.0.1 (0.0.0.0 accepts loopback).
-  PortBindings[port] = [{ HostIp: "0.0.0.0", HostPort: "0" }];
+  // Default 127.0.0.1 keeps local Docker Desktop screens off the LAN.
+  // When SANDBOX_SCREEN_HOST is the k8s pod IP, bind 0.0.0.0 so web (other
+  // pods) can reach the published port via that pod IP.
+  PortBindings[port] = [{ HostIp: hostIp, HostPort: "0" }];
   if (publishControlPort) {
     ExposedPorts[`${COMPUTER_CONTROL_PORT}/tcp`] = {};
-    PortBindings[`${COMPUTER_CONTROL_PORT}/tcp`] = [{ HostIp: "0.0.0.0", HostPort: "0" }];
+    PortBindings[`${COMPUTER_CONTROL_PORT}/tcp`] = [{ HostIp: hostIp, HostPort: "0" }];
   }
   return { ExposedPorts, PortBindings };
 }
@@ -376,10 +395,7 @@ function validHostPort(port: string | undefined): port is string {
 /** Resolve an assigned runtime port only when every control binding is loopback or all interfaces. */
 export function publishedLoopbackControlHostPort(portBindings: ControlPortBindings) {
   const bindings = portBindings?.[`${COMPUTER_CONTROL_PORT}/tcp`];
-  if (
-    !bindings?.length ||
-    bindings.some((binding) => binding.HostIp !== "127.0.0.1" && binding.HostIp !== "0.0.0.0" && binding.HostIp !== "")
-  ) {
+  if (!bindings?.length || bindings.some((binding) => !isAcceptedPublishedHostIp(binding.HostIp))) {
     return undefined;
   }
   return bindings.find((binding) => validHostPort(binding.HostPort))?.HostPort;
@@ -400,7 +416,7 @@ export function controlPortPublicationMatches(
     !!bindings?.length &&
     bindings.every(
       (binding) =>
-        (binding.HostIp === "127.0.0.1" || binding.HostIp === "0.0.0.0" || binding.HostIp === "") &&
+        isAcceptedPublishedHostIp(binding.HostIp) &&
         (binding.HostPort === "" || binding.HostPort === "0" || validHostPort(binding.HostPort)),
     )
   );

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -153,12 +153,15 @@ export function computerPortBindings(publishControlPort = false) {
   const PortBindings: Record<string, Array<{ HostIp: string; HostPort: string }>> = {};
   const port = `${screenPorts(0).viewPort}/tcp`;
   ExposedPorts[port] = {};
-  PortBindings[port] = [{ HostIp: "127.0.0.1", HostPort: "0" }];
-  // Host-run Docker Desktop supervisors need an opt-in loopback mapping.
-  // Otherwise control stays unpublished on the container network.
+  // In k8s the supervisor and web run in different pods. Binding on 127.0.0.1
+  // is only reachable from inside the supervisor pod itself — web's loopback
+  // is a different network namespace, so the novnc proxy gets ECONNREFUSED
+  // → 502. Bind on 0.0.0.0 so the mapped port is reachable via the pod IP.
+  // The supervisor still reaches it via 127.0.0.1 (0.0.0.0 accepts loopback).
+  PortBindings[port] = [{ HostIp: "0.0.0.0", HostPort: "0" }];
   if (publishControlPort) {
     ExposedPorts[`${COMPUTER_CONTROL_PORT}/tcp`] = {};
-    PortBindings[`${COMPUTER_CONTROL_PORT}/tcp`] = [{ HostIp: "127.0.0.1", HostPort: "0" }];
+    PortBindings[`${COMPUTER_CONTROL_PORT}/tcp`] = [{ HostIp: "0.0.0.0", HostPort: "0" }];
   }
   return { ExposedPorts, PortBindings };
 }
@@ -370,10 +373,13 @@ function validHostPort(port: string | undefined): port is string {
   return !!port && /^\d{1,5}$/.test(port) && Number(port) > 0 && Number(port) <= 65535;
 }
 
-/** Resolve an assigned runtime port only when every control binding is loopback. */
+/** Resolve an assigned runtime port only when every control binding is loopback or all interfaces. */
 export function publishedLoopbackControlHostPort(portBindings: ControlPortBindings) {
   const bindings = portBindings?.[`${COMPUTER_CONTROL_PORT}/tcp`];
-  if (!bindings?.length || bindings.some((binding) => binding.HostIp !== "127.0.0.1")) {
+  if (
+    !bindings?.length ||
+    bindings.some((binding) => binding.HostIp !== "127.0.0.1" && binding.HostIp !== "0.0.0.0" && binding.HostIp !== "")
+  ) {
     return undefined;
   }
   return bindings.find((binding) => validHostPort(binding.HostPort))?.HostPort;
@@ -394,7 +400,7 @@ export function controlPortPublicationMatches(
     !!bindings?.length &&
     bindings.every(
       (binding) =>
-        binding.HostIp === "127.0.0.1" &&
+        (binding.HostIp === "127.0.0.1" || binding.HostIp === "0.0.0.0" || binding.HostIp === "") &&
         (binding.HostPort === "" || binding.HostPort === "0" || validHostPort(binding.HostPort)),
     )
   );

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -836,7 +836,19 @@ async function ensureComputerImage() {
         await docker.getImage(COMPUTER_IMAGE).inspect();
         return;
       } catch {
-        // build below
+        // image missing in DinD graph (emptyDir loses data on pod recreate)
+      }
+      // Try pulling from registry first — fast path on k8s where the image
+      // is published to ghcr.io. Falls back to local build when offline.
+      try {
+        const pullStream = await docker.pull(COMPUTER_IMAGE);
+        await new Promise<void>((resolve, reject) => {
+          docker.modem.followProgress(pullStream, (err) => (err ? reject(err) : resolve()));
+        });
+        await docker.getImage(COMPUTER_IMAGE).inspect();
+        return;
+      } catch {
+        // pull failed (offline / private registry) — try building from local context
       }
       const dockerfile = path.join(computerContext, "Dockerfile");
       if (!existsSync(dockerfile)) {

--- a/packages/core/src/node/screen-capability.test.ts
+++ b/packages/core/src/node/screen-capability.test.ts
@@ -151,4 +151,20 @@ describe("sealed screen capabilities", () => {
       expect(openScreenCapability(path(url), "fake-secret", 101)).toBeNull();
     },
   );
+  it.each([
+    "http://100.64.0.1:49152/embed.html",
+    "http://100.96.0.30:32769/embed.html",
+    "http://100.127.255.254:49152/embed.html",
+  ])("allows CGNAT 100.64/10 screen targets %s", (url) => {
+    expect(openScreenCapability(path(url), "fake-secret", 101)?.target.hostname).toBe(
+      new URL(url).hostname,
+    );
+  });
+  it.each([
+    "http://100.63.255.255:49152/embed.html",
+    "http://100.128.0.1:49152/embed.html",
+    "http://100.129.0.1:49152/embed.html",
+  ])("rejects addresses outside CGNAT 100.64/10 %s", (url) => {
+    expect(openScreenCapability(path(url), "fake-secret", 101)).toBeNull();
+  });
 });

--- a/packages/core/src/node/screen-capability.ts
+++ b/packages/core/src/node/screen-capability.ts
@@ -164,6 +164,7 @@ function isAllowedTargetName(hostname: string) {
     hostname === "127.0.0.1" ||
     hostname === "::1" ||
     /^10\.(?:\d{1,3}\.){2}\d{1,3}$/.test(hostname) ||
+    /^100\.(?:6[4-9]|[7-9]\d|1[0-2]\d)\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
     /^172\.(?:1[6-9]|2\d|3[01])\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
     /^192\.168\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
     /^rakazo-bot-[a-zA-Z0-9_.-]+$/.test(hostname)

--- a/packages/core/src/node/screen-capability.ts
+++ b/packages/core/src/node/screen-capability.ts
@@ -164,7 +164,7 @@ function isAllowedTargetName(hostname: string) {
     hostname === "127.0.0.1" ||
     hostname === "::1" ||
     /^10\.(?:\d{1,3}\.){2}\d{1,3}$/.test(hostname) ||
-    /^100\.(?:6[4-9]|[7-9]\d|1[0-2]\d)\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
+    /^100\.(?:6[4-9]|[7-9]\d|1(?:[01]\d|2[0-7]))\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
     /^172\.(?:1[6-9]|2\d|3[01])\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
     /^192\.168\.(?:\d{1,3})\.\d{1,3}$/.test(hostname) ||
     /^rakazo-bot-[a-zA-Z0-9_.-]+$/.test(hostname)

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -381,6 +381,7 @@ export function createRepos(prisma: PrismaClient) {
         }
         if (thinkingLevel == null) thinkingLevel = parent.thinkingLevel ?? null;
       }
+      const settings = await prisma.deploymentSettings.findUnique({ where: { id: "default" } });
       const rawKind = process.env.SANDBOX_PROVIDER ?? "docker";
       const envKind = rawKind === "none" ? "fake" : rawKind;
       const kind =

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -381,8 +381,8 @@ export function createRepos(prisma: PrismaClient) {
         }
         if (thinkingLevel == null) thinkingLevel = parent.thinkingLevel ?? null;
       }
-      const settings = await prisma.deploymentSettings.findUnique({ where: { id: "default" } });
-      const envKind = process.env.SANDBOX_PROVIDER ?? "docker";
+      const rawKind = process.env.SANDBOX_PROVIDER ?? "docker";
+      const envKind = rawKind === "none" ? "fake" : rawKind;
       const kind =
         envKind === "docker" && settings?.computerHost === "this-mac" ? "desktop" : envKind;
       const insertBot = () =>


### PR DESCRIPTION
## Why
Trên FKE `fke-self-hosted-prod-190kqr7l` (CGNAT 100.64/10, service CIDR 100.65.16.218) `POST /rpc/computer/screenUrl` trả URL `https://bot.boltz.one/novnc/session/control/...` nhưng `GET` qua `web vite preview` → `POST http://api:3100/api/internal/screen-target` luôn 403 `Invalid or expired screen capability`. `openScreenCapability` decrypt OK (`url http://100.96.0.30:32768/embed.html`, scope botGen 0/compGen 613) nhưng `isAllowedTargetName` reject hostname `100.96.0.30` vì chỉ allow `localhost/127.0.0.1/::1/10./172.16-31./192.168./rakazo-bot-*`. Đồng thời `computer/takeover 500` khi `takeover` 409 DB đã đồng bộ nhưng `boot 500` do DinD `HostIp 127.0.0.1` không routable cross-pod và `emptyDir:/var/lib/docker` mất `computer:edge` sau Recreate.

## What changed
- `packages/core/src/node/screen-capability.ts`: `isAllowedTargetName` thêm `^100\.(?:6[4-9]|[7-9]\d|1[0-2]\d)\.(?:\d{1,3})\.\d{1,3}$` (100.64/10) — fix 403.
- `infra/sandboxes/supervisor/src/computer-spec.ts`: `HostIp "0.0.0.0"` cho VNC/control, `publishedLoopbackControlHostPort` và `controlPortPublicationMatches` chấp nhận `0.0.0.0`/`""`.
- `infra/sandboxes/supervisor/src/index.ts`: `ensureComputerImage` thử `docker.pull(COMPUTER_IMAGE)` trước `buildImage` — fix 404 no such image.
- `infra/k8s/31-supervisor.yaml`: hotfix runtime tới khi edge image mới roll (runAsUser 0 perl patch) + `SANDBOX_SCREEN_HOST=fieldRef status.podIP`.

Live đã verify (ConfigMap mount): `POST /rpc/computer/takeover 200`, `POST /rpc/computer/screenUrl` → `POST /api/internal/screen-target 200 {"hostname":"100.96.0.30","port":32769}`, `wget 100.96.0.30:32769/embed.html 200`, `wget web:5173/novnc/... 200` qua Vite proxy, docker `0.0.0.0:32769->6080`.

## How tested
- K8s live: `fke-self-hosted-prod-190kqr7l -n rakazo`: `kubectl exec deploy/api -- node openScreenCapability` trả `{host:"100.96.0.30",port:32769}`, `kubectl exec deploy/web -- wget` qua `resolveNovncTarget` 200 HTML, `docker ps` `0.0.0.0:32769->6080`, `kubectl get pods` api/web Running.
- Unit/offline: không (cần CI publish edge).

## Follow-up
Sau khi `ghcr.io/elie222/rakazo/app:edge` publish từ branch này, xóa hotfix `runAsUser`/`configMap rakazo-screen-capability` khỏi cluster và `kubectl apply` lại.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Computer images can be pulled from a container registry when unavailable locally.
  - Sandbox networking supports configured non-loopback hosts with appropriate port exposure.

- **Bug Fixes**
  - Improved computer status handling when no computer provider is configured.
  - Corrected sandbox control and screen port binding behavior across supported environments.
  - Restricted accepted CGNAT screen proxy targets to the valid 100.64.0.0/10 range.
  - Restored deployment-specific sandbox environment selection for desktop and fake computer providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->