### PR TITLE
fix(adapters): respect selected subagent image limits

### DIFF
--- a/packages/adapters/src/pi-runtime-thinking-level.test.ts
+++ b/packages/adapters/src/pi-runtime-thinking-level.test.ts
@@ -1,7 +1,9 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fakeAgentState = vi.hoisted(() => ({
   thinkingLevels: [] as string[],
+  transforms: [] as Array<(messages: AgentMessage[]) => Promise<AgentMessage[]>>,
   models: [] as Array<{
     id: string;
     provider: string;
@@ -28,6 +30,7 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
 
     constructor(options: {
       sessionId?: string;
+      transformContext: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
       initialState: {
         thinkingLevel: string;
         tools: FakeAgentTool[];
@@ -35,6 +38,7 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
       };
     }) {
       this.tools = options.initialState.tools;
+      fakeAgentState.transforms.push(options.transformContext);
       fakeAgentState.sessionIds.push(options.sessionId);
       fakeAgentState.thinkingLevels.push(options.initialState.thinkingLevel);
       fakeAgentState.models.push(options.initialState.model);
@@ -109,8 +113,10 @@ async function runWithModel(
     provider: string;
     id: string;
     apiKey?: string;
+    maxImagesPerPrompt?: number;
     thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | null;
   }>,
+  maxImagesPerPrompt?: number,
 ) {
   const runtime = new PiAgentRuntime();
   for await (const _event of runtime.run(
@@ -122,7 +128,7 @@ async function runWithModel(
       instructions: "",
       history: [],
       tools: [],
-      model: { provider, id: modelId, thinkingLevel },
+      model: { provider, id: modelId, thinkingLevel, maxImagesPerPrompt },
       executeTool: vi.fn(async () => ({ ok: true })),
       resolveModel,
     },
@@ -142,6 +148,7 @@ async function runWithModel(
 describe("Pi agent thinking level", () => {
   beforeEach(() => {
     fakeAgentState.thinkingLevels = [];
+    fakeAgentState.transforms = [];
     fakeAgentState.models = [];
     fakeAgentState.sessionIds = [];
     fakeAgentState.subagentArgs = { name: "helper", task: "help" };
@@ -198,6 +205,53 @@ describe("Pi agent thinking level", () => {
     ]);
     expect(levels).toEqual(["off", "high"]);
   });
+
+  it.each([
+    { parentLimit: 2, childLimit: 1, expected: 1 },
+    { parentLimit: 1, childLimit: 2, expected: 2 },
+    { parentLimit: 2, childLimit: 0, expected: 0 },
+    { parentLimit: 0, childLimit: undefined, expected: 2 },
+  ])(
+    "uses the selected subagent image budget: $parentLimit -> $childLimit",
+    async ({ parentLimit, childLimit, expected }) => {
+      fakeAgentState.subagentArgs = {
+        name: "helper",
+        task: "inspect screenshots",
+        model_provider: "test",
+        model_id: "plain-model",
+      };
+      await runWithModel(
+        "plain-model",
+        "test",
+        new AbortController().signal,
+        null,
+        async () => ({ provider: "test", id: "plain-model", maxImagesPerPrompt: childLimit }),
+        parentLimit,
+      );
+      const screenshots: AgentMessage[] = [0, 1].map((index) => ({
+        role: "toolResult",
+        toolCallId: `capture-${index}`,
+        toolName: "computer_observe",
+        content: [{ type: "image", data: "fake-image", mimeType: "image/png" }],
+        details: { frameId: `frame-${index}` },
+        isError: false,
+        timestamp: index,
+      }));
+      const countImages = (messages: AgentMessage[]) =>
+        messages.reduce(
+          (count, message) =>
+            count +
+            ("content" in message && Array.isArray(message.content)
+              ? message.content.filter((part) => part.type === "image").length
+              : 0),
+          0,
+        );
+      const [parentTransform, childTransform] = fakeAgentState.transforms;
+      if (!parentTransform || !childTransform) throw new Error("missing agent transforms");
+      expect(countImages(await parentTransform(screenshots))).toBe(parentLimit);
+      expect(countImages(await childTransform(screenshots))).toBe(expected);
+    },
+  );
 
   it("rejects an incomplete per-call subagent model pair", async () => {
     fakeAgentState.subagentArgs = {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -995,7 +995,7 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
       selectedModel.models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
     getApiKey: async () => selectedModel.apiKey,
     transformContext: async (messages) =>
-      pruneComputerScreenshotContext(messages, host.request.model.maxImagesPerPrompt),
+      pruneComputerScreenshotContext(messages, requestModel.maxImagesPerPrompt),
     initialState: {
       systemPrompt: [
         `You are a Rakazo subagent named "${name}".`,


### PR DESCRIPTION
## Why

A subagent can select a different model connection with its own image limit, but its context transform still reads the parent model's limit. A stricter child can receive too many screenshots, while a more capable child can lose screenshots unnecessarily. A child with no configured limit also incorrectly inherits an explicit parent limit instead of the normal screenshot fallback.

## What changed

- Use the resolved subagent request model's `maxImagesPerPrompt` for the child context transform.
- Exercise the transforms installed by the actual runtime with parent/child limits of 2→1, 1→2, 2→0, and 0→unset. Assert that the parent retains its own budget in every case.

The screenshot pruning algorithm, model selection, and parent configuration are unchanged. This follows the per-connection image limits introduced in #761 and the existing per-call subagent model selection.

## Testing

- All four new cases fail on the original implementation and pass after the one-line fix.
- Focused runtime/computer tests: 22 passed.
- Full adapters suite: 1,671 passed, 25 skipped.
- Adapters TypeScript, targeted Biome and diff checks passed.
- No live provider or computer was provisioned; tests use the existing fake agent with the real context transform.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Screenshot context is now limited according to the model handling each subagent request, improving compatibility when parent and subagent models support different image limits.
  - Excess screenshot images are truncated consistently for both parent agents and subagents, helping prevent oversized prompts and related processing issues.

- **Tests**
  - Added coverage verifying image-limit behavior across parent and subagent execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->